### PR TITLE
Dynamic HII Form generator framework

### DIFF
--- a/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactory.h
+++ b/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactory.h
@@ -55,6 +55,10 @@ typedef struct DynamicTableFactoryInfo {
         SmbiosHandleMap[FixedPcdGet16 (
                       PcdMaxSmbiosHandleMapEntries
                       )];
+
+  /// An array for holding the list of Standard SMBIOS Table Generators.
+  HII_FORMS_GENERATOR *
+        StdHiiFormsGeneratorList[EStdHiiFormsIdMax];
 } EDKII_DYNAMIC_TABLE_FACTORY_INFO;
 
 /** Return a pointer to the ACPI table generator.
@@ -118,6 +122,27 @@ GetDtTableGenerator (
   IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST  This,
   IN  CONST DT_TABLE_GENERATOR_ID                         GeneratorId,
   OUT CONST DT_TABLE_GENERATOR                   **CONST  Generator
+  );
+
+/** Return a pointer to the HII Forms generator.
+
+  @param [in]  This         Pointer to the Dynamic Table Factory Protocol.
+  @param [in]  GeneratorId  The HII Forms generator ID for the
+                            requested generator.
+  @param [out] Generator    Pointer to the requested HII Forms
+                            generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+EFI_STATUS
+EFIAPI
+GetHiiFormsGenerator (
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST   This,
+  IN  CONST HII_FORMS_GENERATOR_ID                         GeneratorId,
+  OUT       HII_FORMS_GENERATOR                   **CONST  Generator
   );
 
 #pragma pack()

--- a/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactory.h
+++ b/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactory.h
@@ -55,6 +55,16 @@ typedef struct DynamicTableFactoryInfo {
         SmbiosHandleMap[FixedPcdGet16 (
                       PcdMaxSmbiosHandleMapEntries
                       )];
+
+  /// An array for holding the list of STD HII form generators.
+  HII_FORMS_GENERATOR *
+        StdHiiFormsGeneratorList[EStdHiiFormsIdMax];
+
+  /// An array for holding the list of custom HII form generators.
+  HII_FORMS_GENERATOR *
+        CustomHiiFormsGeneratorList[FixedPcdGet16 (
+                                  PcdMaxCustomHiiGenerators
+                                  )];
 } EDKII_DYNAMIC_TABLE_FACTORY_INFO;
 
 /** Return a pointer to the ACPI table generator.
@@ -118,6 +128,27 @@ GetDtTableGenerator (
   IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST  This,
   IN  CONST DT_TABLE_GENERATOR_ID                         GeneratorId,
   OUT CONST DT_TABLE_GENERATOR                   **CONST  Generator
+  );
+
+/** Return a pointer to the HII Forms generator.
+
+  @param [in]  This         Pointer to the Dynamic Table Factory Protocol.
+  @param [in]  GeneratorId  The HII Forms generator ID for the
+                            requested generator.
+  @param [out] Generator    Pointer to the requested HII Forms
+                            generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+EFI_STATUS
+EFIAPI
+GetHiiFormsGenerator (
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST   This,
+  IN  CONST HII_FORMS_GENERATOR_ID                         GeneratorId,
+  OUT       HII_FORMS_GENERATOR                   **CONST  Generator
   );
 
 #pragma pack()

--- a/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactoryDxe.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactoryDxe.c
@@ -17,6 +17,7 @@
 #include <ConfigurationManagerObject.h>
 #include <ConfigurationManagerHelper.h>
 #include <DeviceTreeTableGenerator.h>
+#include <HiiFormsGenerator.h>
 #include <Library/TableHelperLib.h>
 #include <Protocol/ConfigurationManagerProtocol.h>
 #include <Protocol/DynamicTableFactoryProtocol.h>
@@ -64,6 +65,9 @@ EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  DynamicTableFactoryProtocol = {
   GetDtTableGenerator,
   RegisterDtTableGenerator,
   DeregisterDtTableGenerator,
+  GetHiiFormsGenerator,
+  RegisterHiiFormsGenerator,
+  DeregisterHiiFormsGenerator,
   GetMetadataRoot,
   AddSmbiosHandle,
   FindSmbiosHandle,

--- a/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactoryDxe.inf
+++ b/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactoryDxe.inf
@@ -19,6 +19,7 @@
   DeviceTreeTableFactory/DeviceTreeTableFactory.c
   DynamicTableFactoryDxe.c
   SmbiosTableFactory/SmbiosTableFactory.c
+  HiiFormsFactory/HiiFormsFactory.c
   DynamicTableFactory.h
 
 [Packages]

--- a/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactoryDxe.inf
+++ b/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/DynamicTableFactoryDxe.inf
@@ -19,6 +19,7 @@
   DeviceTreeTableFactory/DeviceTreeTableFactory.c
   DynamicTableFactoryDxe.c
   SmbiosTableFactory/SmbiosTableFactory.c
+  HiiFormsFactory/HiiFormsFactory.c
   DynamicTableFactory.h
 
 [Packages]
@@ -39,6 +40,7 @@
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdMaxCustomACPIGenerators
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdMaxCustomSMBIOSGenerators
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdMaxCustomDTGenerators
+  gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdMaxCustomHiiGenerators
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdMaxSmbiosHandleMapEntries
 
 [Protocols]

--- a/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/HiiFormsFactory/HiiFormsFactory.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/HiiFormsFactory/HiiFormsFactory.c
@@ -1,0 +1,192 @@
+/** @file
+  HII Forms Factory
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII - Human Interface Infrastructure
+    - Std - Standard
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+
+// Module specific include files.
+#include <HiiFormsGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+
+#include "DynamicTableFactory.h"
+
+extern EDKII_DYNAMIC_TABLE_FACTORY_INFO  TableFactoryInfo;
+
+/** Return a pointer to the Hii Forms generator.
+
+  @param [in]  This         Pointer to the Dynamic Table Factory Protocol.
+  @param [in]  GeneratorId  The Hii Forms generator ID for the
+                            requested generator.
+  @param [out] Generator    Pointer to the requested Hii Forms
+                            generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+EFI_STATUS
+EFIAPI
+GetHiiFormsGenerator (
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST   This,
+  IN  CONST HII_FORMS_GENERATOR_ID                         GeneratorId,
+  OUT       HII_FORMS_GENERATOR                   **CONST  Generator
+  )
+{
+  UINT16                            FormId;
+  EDKII_DYNAMIC_TABLE_FACTORY_INFO  *FactoryInfo;
+
+  ASSERT (This != NULL);
+
+  FactoryInfo = This->TableFactoryInfo;
+
+  if (Generator == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Invalid Generator pointer\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((GeneratorId != 0) && !IS_GENERATOR_TYPE_HII (GeneratorId)) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Generator Type is not Hii\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Generator = NULL;
+  FormId     = GET_TABLE_ID (GeneratorId);
+  if (IS_GENERATOR_NAMESPACE_STD (GeneratorId)) {
+    if (FormId >= EStdHiiFormsIdMax) {
+      ASSERT (FormId < EStdHiiFormsIdMax);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (FactoryInfo->StdHiiFormsGeneratorList[FormId] != NULL) {
+      *Generator = FactoryInfo->StdHiiFormsGeneratorList[FormId];
+    } else {
+      return EFI_NOT_FOUND;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Register Hii Forms factory generator.
+
+  The Hii Forms factory maintains a list of the Standard Hii Forms
+  generators.
+
+  @param [in]  Generator        Pointer to the Hii Forms generator.
+
+  @retval EFI_SUCCESS           The Generator was registered
+                                successfully.
+  @retval EFI_INVALID_PARAMETER The Generator ID is invalid or
+                                the Generator pointer is NULL.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID is
+                                already registered.
+**/
+EFI_STATUS
+EFIAPI
+RegisterHiiFormsGenerator (
+  IN  HII_FORMS_GENERATOR                *CONST  Generator
+  )
+{
+  UINT16  FormId;
+
+  if (Generator == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Hii Forms register - Invalid Generator\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IS_GENERATOR_TYPE_HII (Generator->GeneratorID)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii Forms register - Generator" \
+      " Type is not Hii\n"
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((DEBUG_INFO, "Registering %s\n", Generator->Description));
+
+  FormId = GET_TABLE_ID (Generator->GeneratorID);
+  if (IS_GENERATOR_NAMESPACE_STD (Generator->GeneratorID)) {
+    if (FormId >= EStdHiiFormsIdMax) {
+      ASSERT (FormId < EStdHiiFormsIdMax);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (TableFactoryInfo.StdHiiFormsGeneratorList[FormId] == NULL) {
+      TableFactoryInfo.StdHiiFormsGeneratorList[FormId] = Generator;
+    } else {
+      return EFI_ALREADY_STARTED;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Deregister Hii Forms generator.
+
+  This function is called by the Hii Forms generator to deregister itself
+  from the Hii Forms factory.
+
+  @param [in]  Generator        Pointer to the Hii Forms generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER The generator is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+EFI_STATUS
+EFIAPI
+DeregisterHiiFormsGenerator (
+  IN  HII_FORMS_GENERATOR                *CONST  Generator
+  )
+{
+  UINT16  FormId;
+
+  if (Generator == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Hii Forms deregister - Invalid Generator\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IS_GENERATOR_TYPE_HII (Generator->GeneratorID)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii Forms deregister - Generator" \
+      " Type is not Hii\n"
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FormId = GET_TABLE_ID (Generator->GeneratorID);
+  if (IS_GENERATOR_NAMESPACE_STD (Generator->GeneratorID)) {
+    if (FormId >= EStdHiiFormsIdMax) {
+      ASSERT (FormId < EStdHiiFormsIdMax);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (TableFactoryInfo.StdHiiFormsGeneratorList[FormId] != NULL) {
+      if (Generator != TableFactoryInfo.StdHiiFormsGeneratorList[FormId]) {
+        return EFI_INVALID_PARAMETER;
+      }
+
+      TableFactoryInfo.StdHiiFormsGeneratorList[FormId] = NULL;
+    } else {
+      return EFI_NOT_FOUND;
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "Deregistering %s\n", Generator->Description));
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/HiiFormsFactory/HiiFormsFactory.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableFactoryDxe/HiiFormsFactory/HiiFormsFactory.c
@@ -1,0 +1,232 @@
+/** @file
+  HII Forms Factory
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII - Human Interface Infrastructure
+    - Std - Standard
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+
+// Module specific include files.
+#include <HiiFormsGenerator.h>
+#include <ConfigurationManagerObject.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+
+#include "DynamicTableFactory.h"
+
+extern EDKII_DYNAMIC_TABLE_FACTORY_INFO  TableFactoryInfo;
+
+/** Return a pointer to the Hii Forms generator.
+
+  @param [in]  This         Pointer to the Dynamic Table Factory Protocol.
+  @param [in]  GeneratorId  The Hii Forms generator ID for the
+                            requested generator.
+  @param [out] Generator    Pointer to the requested Hii Forms
+                            generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+EFI_STATUS
+EFIAPI
+GetHiiFormsGenerator (
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST   This,
+  IN  CONST HII_FORMS_GENERATOR_ID                         GeneratorId,
+  OUT       HII_FORMS_GENERATOR                   **CONST  Generator
+  )
+{
+  UINT16                            FormId;
+  EDKII_DYNAMIC_TABLE_FACTORY_INFO  *FactoryInfo;
+
+  if (This == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Invalid factory protocol pointer\n"));
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Generator == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Invalid Generator pointer\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((GeneratorId != 0) && !IS_GENERATOR_TYPE_HII (GeneratorId)) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Generator Type is not Hii\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FactoryInfo = This->TableFactoryInfo;
+  *Generator  = NULL;
+  FormId      = GET_TABLE_ID (GeneratorId);
+  if (IS_GENERATOR_NAMESPACE_STD (GeneratorId)) {
+    if (FormId >= EStdHiiFormsIdMax) {
+      ASSERT (FormId < EStdHiiFormsIdMax);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (FactoryInfo->StdHiiFormsGeneratorList[FormId] != NULL) {
+      *Generator = FactoryInfo->StdHiiFormsGeneratorList[FormId];
+    } else {
+      return EFI_NOT_FOUND;
+    }
+  } else {
+    if (FormId >= FixedPcdGet16 (PcdMaxCustomHiiGenerators)) {
+      ASSERT (FormId <= FixedPcdGet16 (PcdMaxCustomHiiGenerators));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (FactoryInfo->CustomHiiFormsGeneratorList[FormId] != NULL) {
+      *Generator = FactoryInfo->CustomHiiFormsGeneratorList[FormId];
+    } else {
+      return EFI_NOT_FOUND;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Register Hii Forms factory generator.
+
+  The Hii Forms factory maintains a list of the Standard Hii Forms
+  generators.
+
+  @param [in]  Generator        Pointer to the Hii Forms generator.
+
+  @retval EFI_SUCCESS           The Generator was registered
+                                successfully.
+  @retval EFI_INVALID_PARAMETER The Generator ID is invalid or
+                                the Generator pointer is NULL.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID is
+                                already registered.
+**/
+EFI_STATUS
+EFIAPI
+RegisterHiiFormsGenerator (
+  IN  HII_FORMS_GENERATOR                *CONST  Generator
+  )
+{
+  UINT16  FormId;
+
+  if (Generator == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Hii Forms register - Invalid Generator\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IS_GENERATOR_TYPE_HII (Generator->GeneratorID)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii Forms register - Generator" \
+      " Type is not Hii\n"
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((DEBUG_INFO, "Registering %s\n", Generator->Description));
+
+  FormId = GET_TABLE_ID (Generator->GeneratorID);
+  if (IS_GENERATOR_NAMESPACE_STD (Generator->GeneratorID)) {
+    if (FormId >= EStdHiiFormsIdMax) {
+      ASSERT (FormId < EStdHiiFormsIdMax);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (TableFactoryInfo.StdHiiFormsGeneratorList[FormId] == NULL) {
+      TableFactoryInfo.StdHiiFormsGeneratorList[FormId] = Generator;
+    } else {
+      return EFI_ALREADY_STARTED;
+    }
+  } else {
+    if (FormId >= FixedPcdGet16 (PcdMaxCustomHiiGenerators)) {
+      ASSERT (FormId <= FixedPcdGet16 (PcdMaxCustomHiiGenerators));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (TableFactoryInfo.CustomHiiFormsGeneratorList[FormId] == NULL) {
+      TableFactoryInfo.CustomHiiFormsGeneratorList[FormId] = Generator;
+    } else {
+      return EFI_ALREADY_STARTED;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Deregister Hii Forms generator.
+
+  This function is called by the Hii Forms generator to deregister itself
+  from the Hii Forms factory.
+
+  @param [in]  Generator        Pointer to the Hii Forms generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER The generator is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+EFI_STATUS
+EFIAPI
+DeregisterHiiFormsGenerator (
+  IN  HII_FORMS_GENERATOR                *CONST  Generator
+  )
+{
+  UINT16  FormId;
+
+  if (Generator == NULL) {
+    DEBUG ((DEBUG_ERROR, "ERROR: Hii Forms deregister - Invalid Generator\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!IS_GENERATOR_TYPE_HII (Generator->GeneratorID)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii Forms deregister - Generator" \
+      " Type is not Hii\n"
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FormId = GET_TABLE_ID (Generator->GeneratorID);
+  if (IS_GENERATOR_NAMESPACE_STD (Generator->GeneratorID)) {
+    if (FormId >= EStdHiiFormsIdMax) {
+      ASSERT (FormId < EStdHiiFormsIdMax);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (TableFactoryInfo.StdHiiFormsGeneratorList[FormId] != NULL) {
+      if (Generator != TableFactoryInfo.StdHiiFormsGeneratorList[FormId]) {
+        return EFI_INVALID_PARAMETER;
+      }
+
+      TableFactoryInfo.StdHiiFormsGeneratorList[FormId] = NULL;
+    } else {
+      return EFI_NOT_FOUND;
+    }
+  } else {
+    if (FormId >= FixedPcdGet16 (PcdMaxCustomHiiGenerators)) {
+      ASSERT (FormId <= FixedPcdGet16 (PcdMaxCustomHiiGenerators));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (TableFactoryInfo.CustomHiiFormsGeneratorList[FormId] != NULL) {
+      if (Generator != TableFactoryInfo.CustomHiiFormsGeneratorList[FormId]) {
+        return EFI_INVALID_PARAMETER;
+      }
+
+      TableFactoryInfo.CustomHiiFormsGeneratorList[FormId] = NULL;
+    } else {
+      return EFI_NOT_FOUND;
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "Deregistering %s\n", Generator->Description));
+  return EFI_SUCCESS;
+}

--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.c
@@ -26,6 +26,7 @@
 
 STATIC VOID  *mAcpiTableProtocolRegistration;
 STATIC VOID  *mSmbiosProtocolRegistration;
+static VOID  *mHiiFormsRegistration;
 
 /** Entrypoint of Dynamic Table Manager Dxe.
 
@@ -57,6 +58,7 @@ DynamicTableManagerDxeInitialize (
 {
   EFI_EVENT  AcpiEvent;
   EFI_EVENT  SmbiosEvent;
+  EFI_EVENT  HiiFormsEvent;
 
   AcpiEvent = EfiCreateProtocolNotifyEvent (
                 &gEfiAcpiTableProtocolGuid,
@@ -86,6 +88,23 @@ DynamicTableManagerDxeInitialize (
       "Failed to register SMBIOS protocol notification event.\n"
       ));
     gBS->CloseEvent (AcpiEvent);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  HiiFormsEvent = EfiCreateProtocolNotifyEvent (
+                    &gEdkiiConfigurationManagerProtocolGuid,
+                    TPL_CALLBACK,
+                    DynamicHiiFormsProcess,
+                    NULL,
+                    &mHiiFormsRegistration
+                    );
+  if (HiiFormsEvent == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "Failed to register Hii Forms protocol notification event.\n"
+      ));
+    gBS->CloseEvent (AcpiEvent);
+    gBS->CloseEvent (SmbiosEvent);
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.h
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.h
@@ -92,3 +92,21 @@ SmbiosProtocolReady (
   IN  EFI_EVENT  Event,
   IN  VOID       *Context
   );
+
+/** Dynamic Hii Forms Process function.
+
+  This event notification indicates that the Configuration Manager protocol
+  is ready. Therefore, dispatch the generation of HII Forms by getting
+  information from the Configuration Manager.
+
+  @param  [in]  Event     The Event that is signalled.
+  @param  [in]  Context   The Context information.
+
+  @retval None
+**/
+VOID
+EFIAPI
+DynamicHiiFormsProcess (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  );

--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.inf
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.inf
@@ -28,6 +28,7 @@
   SmbiosTableDispatcher.h
   AcpiTableBuilder.c
   SmbiosTableBuilder.c
+  HiiFormsBuilder.c
 
 [Sources.AARCH64]
   Arm/ArmDynamicTableManager.c
@@ -47,6 +48,8 @@
   DynamicTablesPkg/DynamicTablesPkg.dec
 
 [LibraryClasses]
+  HiiLib
+  MemoryAllocationLib
   MetadataHandlerLib
   PrintLib
   TableHelperLib

--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/HiiFormsBuilder.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/HiiFormsBuilder.c
@@ -1,0 +1,408 @@
+/** @file
+  Hii Forms Builder.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <HiiFormsGenerator.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+STATIC LIST_ENTRY  mHiiHandleList = INITIALIZE_LIST_HEAD_VARIABLE (mHiiHandleList);
+
+/** This macro expands to a function that retrieves the Hii Forms
+    list from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceHiiForms,
+  EHiiFormsObjList,
+  CM_HII_FORMS_OBJ_INFO
+  )
+
+/** A helper function to invoke a Hii Form generator
+
+  This is a helper function that invokes the Hii Form generator interface
+  for dynamically generating an HII Form.
+
+  @param [in]  FormsFactoryProtocol Pointer to the Table Factory Protocol
+                                    interface.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol Interface.
+  @param [in]  HiiFormsInfo         Pointer to the Hii Forms Info.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         Required object is not found.
+  @retval EFI_BAD_BUFFER_SIZE   Size returned by the Configuration Manager
+                                is less than the Object size for the
+                                requested object.
+**/
+static
+EFI_STATUS
+EFIAPI
+BuildHiiForm (
+  IN CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST  FormsFactoryProtocol,
+  IN CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN CONST CM_HII_FORMS_OBJ_INFO                 *CONST  HiiFormsInfo
+  )
+{
+  EFI_STATUS              Status;
+  EFI_STATUS              Status1;
+  HII_FORM_HANDLE         *FormHandle;
+  HII_FORMS_GENERATOR     *Generator;
+  HII_FORMS_GENERATOR_ID  HiiFormGeneratorId;
+
+  ASSERT (FormsFactoryProtocol != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+
+  HiiFormGeneratorId = HiiFormsInfo != NULL ? HiiFormsInfo->FormGeneratorId : 0;
+
+  DEBUG ((
+    DEBUG_INFO,
+    " HiiFormGeneratorId = 0x%x\n",
+    HiiFormGeneratorId
+    ));
+
+  Generator = NULL;
+  Status    = FormsFactoryProtocol->GetHiiFormsGenerator (
+                                      FormsFactoryProtocol,
+                                      HiiFormGeneratorId,
+                                      &Generator
+                                      );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii Forms Generator not found." \
+      " HiiFormGeneratorId = 0x%x. Status = %r\n",
+      HiiFormGeneratorId,
+      Status
+      ));
+    return Status;
+  }
+
+  if (Generator == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "INFO: Generator found : %s\n",
+    Generator->Description
+    ));
+
+  FormHandle = AllocateZeroPool (sizeof (*FormHandle));
+  if (FormHandle == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = Generator->BuildHiiForm (
+                        Generator,
+                        HiiFormsInfo,
+                        CfgMgrProtocol,
+                        HiiFormGeneratorId == 0 ? &mHiiHandleList : NULL,
+                        &FormHandle->HiiHandle
+                        );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to Build the Hii Form." \
+      " HiiFormGeneratorId = 0x%x. Status = %r\n",
+      HiiFormGeneratorId,
+      Status
+      ));
+    goto err_handler;
+  }
+
+  if (HiiFormGeneratorId != EStdHiiFormsIdRootForm) {
+    InsertTailList (&mHiiHandleList, &FormHandle->List);
+  } else {
+    FreePool (FormHandle);
+  }
+
+  return EFI_SUCCESS;
+
+err_handler:
+  // Free any resources allocated for generating the Form.
+  if (Generator->FreeHiiFormResources != NULL) {
+    Status1 = Generator->FreeHiiFormResources (
+                           Generator,
+                           HiiFormsInfo,
+                           &FormHandle->HiiHandle
+                           );
+    if (EFI_ERROR (Status1)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: Failed to Free Table Resources." \
+        "HiiFormGeneratorId = 0x%x. Status = %r\n",
+        HiiFormGeneratorId,
+        Status1
+        ));
+    }
+
+    // Return the first error status in case of failure
+    if (!EFI_ERROR (Status)) {
+      Status = Status1;
+    }
+  }
+
+  FreePool (FormHandle);
+
+  return Status;
+}
+
+/** Generate Dynamic HII Forms.
+
+  The function gathers the information necessary for generating the
+  Dynamic HII Forms by invoking the generators.
+
+  @param [in]  FormsFactoryProtocol Pointer to the Table Factory Protocol
+                                    interface.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol Interface.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_NOT_FOUND         If a generator is not found.
+  @retval EFI_ALREADY_STARTED   If a generator is already installed.
+**/
+static
+EFI_STATUS
+EFIAPI
+ProcessHiiForms (
+  IN CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST  FormsFactoryProtocol,
+  IN CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol
+  )
+{
+  EFI_STATUS              Status;
+  CM_HII_FORMS_OBJ_INFO   *HiiFormsInfo;
+  UINT32                  HiiFormsCount;
+  UINT32                  Idx;
+  HII_FORMS_GENERATOR_ID  HiiFormGeneratorId;
+
+  ASSERT (FormsFactoryProtocol != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+
+  Status = GetEHiiFormsObjList (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &HiiFormsInfo,
+             &HiiFormsCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to get Hii Forms List. Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  if (HiiFormsCount == 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: EHiiFormsObjList: Got zero HiiFormsCount\n"
+      ));
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "INFO: EHiiFormsObjList: HiiFormsCount = %d\n",
+    HiiFormsCount
+    ));
+
+  for (Idx = 0; Idx < HiiFormsCount; Idx++) {
+    HiiFormGeneratorId = HiiFormsInfo[Idx].FormGeneratorId;
+
+    DEBUG ((
+      DEBUG_INFO,
+      "INFO: HiiFormsInfo[%d].FormGeneratorId = 0x%x\n",
+      Idx,
+      HiiFormGeneratorId
+      ));
+
+    if (!IS_VALID_STD_HII_FORMS_GENERATOR_ID (HiiFormGeneratorId)) {
+      DEBUG ((
+        DEBUG_WARN,
+        "WARNING: Invalid Hii Forms Generator ID = 0x%x, Skipping...\n",
+        HiiFormGeneratorId
+        ));
+      continue;
+    }
+
+    Status = BuildHiiForm (
+               FormsFactoryProtocol,
+               CfgMgrProtocol,
+               &HiiFormsInfo[Idx]
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: Failed to build Hii Form."
+        " Status = %r\n",
+        Status
+        ));
+      return Status;
+    }
+  }
+
+  // Add the Top Level Root Form at last
+  Status = BuildHiiForm (
+             FormsFactoryProtocol,
+             CfgMgrProtocol,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to build the Root Hii Form."
+      " Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  return Status;
+}
+
+/** Free up the HII Handles from the list
+
+  Iterate through the list of HII Handles that have been
+  added, and free up the memory associated with these
+  handles.
+
+**/
+static
+VOID
+FreeHiiHandleList (
+  VOID
+  )
+{
+  HII_FORM_HANDLE  *Entry;
+  HII_FORM_HANDLE  *NextEntry;
+
+  Entry = (HII_FORM_HANDLE *)GetFirstNode (&mHiiHandleList);
+  while (!IsNull (&mHiiHandleList, &Entry->List)) {
+    NextEntry = (HII_FORM_HANDLE *)GetNextNode (&mHiiHandleList, &Entry->List);
+
+    if (Entry->HiiHandle != NULL) {
+      HiiRemovePackages (Entry->HiiHandle);
+    }
+
+    RemoveEntryList (&Entry->List);
+    FreePool (Entry);
+
+    Entry = NextEntry;
+  }
+}
+
+/** Dynamic Hii Forms Process function.
+
+  This event notification indicates that the Configuration Manager protocol
+  is ready. Therefore, dispatch the generation of HII Forms by getting
+  information from the Configuration Manager.
+
+  @param  [in]  Event     The Event that is signalled.
+  @param  [in]  Context   The Context information.
+
+**/
+VOID
+EFIAPI
+DynamicHiiFormsProcess (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS                             Status;
+  EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CfgMgrProtocol;
+  CM_STD_OBJ_CONFIGURATION_MANAGER_INFO  *CfgMfrInfo;
+  EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *FormsFactoryProtocol;
+
+  // Locate the Dynamic Table Factory
+  Status = gBS->LocateProtocol (
+                  &gEdkiiDynamicTableFactoryProtocolGuid,
+                  NULL,
+                  (VOID **)&FormsFactoryProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to find Dynamic Table Factory protocol." \
+      " Status = %r\n",
+      Status
+      ));
+    return;
+  }
+
+  // Locate the Configuration Manager for the Platform
+  Status = gBS->LocateProtocol (
+                  &gEdkiiConfigurationManagerProtocolGuid,
+                  NULL,
+                  (VOID **)&CfgMgrProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to find Configuration Manager protocol. Status = %r\n",
+      Status
+      ));
+    return;
+  }
+
+  Status = GetCgfMgrInfo (CfgMgrProtocol, &CfgMfrInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to get Configuration Manager info. Status = %r\n",
+      Status
+      ));
+    return;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "INFO: Configuration Manager Version = 0x%x, OemID = %c%c%c%c%c%c\n",
+    CfgMfrInfo->Revision,
+    CfgMfrInfo->OemId[0],
+    CfgMfrInfo->OemId[1],
+    CfgMfrInfo->OemId[2],
+    CfgMfrInfo->OemId[3],
+    CfgMfrInfo->OemId[4],
+    CfgMfrInfo->OemId[5]
+    ));
+
+  Status = ProcessHiiForms (FormsFactoryProtocol, CfgMgrProtocol);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Dynamic Hii Forms processing failure. Status = %r\n",
+      Status
+      ));
+    ASSERT_EFI_ERROR (Status);
+    goto exit;
+  }
+
+  Status = gBS->CloseEvent (Event);
+  ASSERT_EFI_ERROR (Status);
+
+  return;
+
+exit:
+  FreeHiiHandleList ();
+}

--- a/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/HiiFormsBuilder.c
+++ b/DynamicTablesPkg/Drivers/DynamicTableManagerDxe/HiiFormsBuilder.c
@@ -1,0 +1,408 @@
+/** @file
+  Hii Forms Builder.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <HiiFormsGenerator.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+STATIC LIST_ENTRY  mHiiHandleList = INITIALIZE_LIST_HEAD_VARIABLE (mHiiHandleList);
+
+/** This macro expands to a function that retrieves the Hii Forms
+    list from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceHiiForms,
+  EHiiFormsObjList,
+  CM_HII_FORMS_OBJ_INFO
+  )
+
+/** A helper function to invoke a Hii Form generator
+
+  This is a helper function that invokes the Hii Form generator interface
+  for dynamically generating an HII Form.
+
+  @param [in]  FormsFactoryProtocol Pointer to the Table Factory Protocol
+                                    interface.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol Interface.
+  @param [in]  HiiFormsInfo         Pointer to the Hii Forms Info.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         Required object is not found.
+  @retval EFI_BAD_BUFFER_SIZE   Size returned by the Configuration Manager
+                                is less than the Object size for the
+                                requested object.
+**/
+static
+EFI_STATUS
+EFIAPI
+BuildHiiForm (
+  IN CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST  FormsFactoryProtocol,
+  IN CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN CONST CM_HII_FORMS_OBJ_INFO                 *CONST  HiiFormsInfo
+  )
+{
+  EFI_STATUS              Status;
+  EFI_STATUS              Status1;
+  HII_FORM_HANDLE         *FormHandle;
+  HII_FORMS_GENERATOR     *Generator;
+  HII_FORMS_GENERATOR_ID  HiiFormGeneratorId;
+
+  ASSERT (FormsFactoryProtocol != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+
+  HiiFormGeneratorId = HiiFormsInfo != NULL ? HiiFormsInfo->FormGeneratorId : 0;
+
+  DEBUG ((
+    DEBUG_INFO,
+    " HiiFormGeneratorId = 0x%x\n",
+    HiiFormGeneratorId
+    ));
+
+  Generator = NULL;
+  Status    = FormsFactoryProtocol->GetHiiFormsGenerator (
+                                      FormsFactoryProtocol,
+                                      HiiFormGeneratorId,
+                                      &Generator
+                                      );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii Forms Generator not found." \
+      " HiiFormGeneratorId = 0x%x. Status = %r\n",
+      HiiFormGeneratorId,
+      Status
+      ));
+    return Status;
+  }
+
+  if (Generator == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "INFO: Generator found : %s\n",
+    Generator->Description
+    ));
+
+  FormHandle = AllocateZeroPool (sizeof (*FormHandle));
+  if (FormHandle == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = Generator->BuildHiiForm (
+                        Generator,
+                        HiiFormsInfo,
+                        CfgMgrProtocol,
+                        HiiFormGeneratorId == 0 ? &mHiiHandleList : NULL,
+                        &FormHandle->HiiHandle
+                        );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to Build the Hii Form." \
+      " HiiFormGeneratorId = 0x%x. Status = %r\n",
+      HiiFormGeneratorId,
+      Status
+      ));
+    goto err_handler;
+  }
+
+  if (HiiFormGeneratorId != EStdHiiFormsIdRootForm) {
+    InsertTailList (&mHiiHandleList, &FormHandle->List);
+  } else {
+    FreePool (FormHandle);
+  }
+
+  return EFI_SUCCESS;
+
+err_handler:
+  // Free any resources allocated for generating the Form.
+  if (Generator->FreeHiiFormResources != NULL) {
+    Status1 = Generator->FreeHiiFormResources (
+                           Generator,
+                           HiiFormsInfo,
+                           &FormHandle->HiiHandle
+                           );
+    if (EFI_ERROR (Status1)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: Failed to Free Table Resources." \
+        "HiiFormGeneratorId = 0x%x. Status = %r\n",
+        HiiFormGeneratorId,
+        Status1
+        ));
+    }
+
+    // Return the first error status in case of failure
+    if (!EFI_ERROR (Status)) {
+      Status = Status1;
+    }
+  }
+
+  FreePool (FormHandle);
+
+  return Status;
+}
+
+/** Generate Dynamic HII Forms.
+
+  The function gathers the information necessary for generating the
+  Dynamic HII Forms by invoking the generators.
+
+  @param [in]  FormsFactoryProtocol Pointer to the Table Factory Protocol
+                                    interface.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol Interface.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_NOT_FOUND         If a generator is not found.
+  @retval EFI_ALREADY_STARTED   If a generator is already installed.
+**/
+static
+EFI_STATUS
+EFIAPI
+ProcessHiiForms (
+  IN CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST  FormsFactoryProtocol,
+  IN CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol
+  )
+{
+  EFI_STATUS              Status;
+  CM_HII_FORMS_OBJ_INFO   *HiiFormsInfo;
+  UINT32                  HiiFormsCount;
+  UINT32                  Idx;
+  HII_FORMS_GENERATOR_ID  HiiFormGeneratorId;
+
+  ASSERT (FormsFactoryProtocol != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+
+  Status = GetEHiiFormsObjList (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &HiiFormsInfo,
+             &HiiFormsCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to get Hii Forms List. Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  if (HiiFormsCount == 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: EHiiFormsObjList: Got zero HiiFormsCount\n"
+      ));
+    return EFI_NOT_FOUND;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "INFO: EHiiFormsObjList: HiiFormsCount = %d\n",
+    HiiFormsCount
+    ));
+
+  for (Idx = 0; Idx < HiiFormsCount; Idx++) {
+    HiiFormGeneratorId = HiiFormsInfo[Idx].FormGeneratorId;
+
+    DEBUG ((
+      DEBUG_INFO,
+      "INFO: HiiFormsInfo[%d].FormGeneratorId = 0x%x\n",
+      Idx,
+      HiiFormGeneratorId
+      ));
+
+    if (!IS_VALID_HII_FORMS_GENERATOR_ID (HiiFormGeneratorId)) {
+      DEBUG ((
+        DEBUG_WARN,
+        "WARNING: Invalid Hii Forms Generator ID = 0x%x, Skipping...\n",
+        HiiFormGeneratorId
+        ));
+      continue;
+    }
+
+    Status = BuildHiiForm (
+               FormsFactoryProtocol,
+               CfgMgrProtocol,
+               &HiiFormsInfo[Idx]
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "ERROR: Failed to build Hii Form."
+        " Status = %r\n",
+        Status
+        ));
+      return Status;
+    }
+  }
+
+  // Add the Top Level Root Form at last
+  Status = BuildHiiForm (
+             FormsFactoryProtocol,
+             CfgMgrProtocol,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to build the Root Hii Form."
+      " Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  return Status;
+}
+
+/** Free up the HII Handles from the list
+
+  Iterate through the list of HII Handles that have been
+  added, and free up the memory associated with these
+  handles.
+
+**/
+static
+VOID
+FreeHiiHandleList (
+  VOID
+  )
+{
+  HII_FORM_HANDLE  *Entry;
+  HII_FORM_HANDLE  *NextEntry;
+
+  Entry = (HII_FORM_HANDLE *)GetFirstNode (&mHiiHandleList);
+  while (!IsNull (&mHiiHandleList, &Entry->List)) {
+    NextEntry = (HII_FORM_HANDLE *)GetNextNode (&mHiiHandleList, &Entry->List);
+
+    if (Entry->HiiHandle != NULL) {
+      HiiRemovePackages (Entry->HiiHandle);
+    }
+
+    RemoveEntryList (&Entry->List);
+    FreePool (Entry);
+
+    Entry = NextEntry;
+  }
+}
+
+/** Dynamic Hii Forms Process function.
+
+  This event notification indicates that the Configuration Manager protocol
+  is ready. Therefore, dispatch the generation of HII Forms by getting
+  information from the Configuration Manager.
+
+  @param  [in]  Event     The Event that is signalled.
+  @param  [in]  Context   The Context information.
+
+**/
+VOID
+EFIAPI
+DynamicHiiFormsProcess (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS                             Status;
+  EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CfgMgrProtocol;
+  CM_STD_OBJ_CONFIGURATION_MANAGER_INFO  *CfgMfrInfo;
+  EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *FormsFactoryProtocol;
+
+  // Locate the Dynamic Table Factory
+  Status = gBS->LocateProtocol (
+                  &gEdkiiDynamicTableFactoryProtocolGuid,
+                  NULL,
+                  (VOID **)&FormsFactoryProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to find Dynamic Table Factory protocol." \
+      " Status = %r\n",
+      Status
+      ));
+    return;
+  }
+
+  // Locate the Configuration Manager for the Platform
+  Status = gBS->LocateProtocol (
+                  &gEdkiiConfigurationManagerProtocolGuid,
+                  NULL,
+                  (VOID **)&CfgMgrProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to find Configuration Manager protocol. Status = %r\n",
+      Status
+      ));
+    return;
+  }
+
+  Status = GetCgfMgrInfo (CfgMgrProtocol, &CfgMfrInfo);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Failed to get Configuration Manager info. Status = %r\n",
+      Status
+      ));
+    return;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "INFO: Configuration Manager Version = 0x%x, OemID = %c%c%c%c%c%c\n",
+    CfgMfrInfo->Revision,
+    CfgMfrInfo->OemId[0],
+    CfgMfrInfo->OemId[1],
+    CfgMfrInfo->OemId[2],
+    CfgMfrInfo->OemId[3],
+    CfgMfrInfo->OemId[4],
+    CfgMfrInfo->OemId[5]
+    ));
+
+  Status = ProcessHiiForms (FormsFactoryProtocol, CfgMgrProtocol);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Dynamic Hii Forms processing failure. Status = %r\n",
+      Status
+      ));
+    ASSERT_EFI_ERROR (Status);
+    goto exit;
+  }
+
+  Status = gBS->CloseEvent (Event);
+  ASSERT_EFI_ERROR (Status);
+
+  return;
+
+exit:
+  FreeHiiHandleList ();
+}

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -27,6 +27,8 @@
   MetadataObjLib|DynamicTablesPkg/Library/Common/MetadataObjLib/MetadataObjLib.inf
   MetadataHandlerLib|DynamicTablesPkg/Library/Common/MetadataHandlerLib/MetadataHandlerLib.inf
   Tpm2DeviceTableLib|DynamicTablesPkg/Library/Common/Tpm2DeviceTableLib/Tpm2DeviceTableLib.inf
+  HiiFormsLib|DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormsLib.inf
+  HiiStringsLib|DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringsLib.inf
 
 [LibraryClasses.AARCH64]
   ArmSmcccSocIdLib|ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -86,6 +86,9 @@
   #
   DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.inf
 
+  #  HII Form Generators
+  DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+
 [Components.X64]
   #
   # Generators (X64 specific)
@@ -123,6 +126,9 @@
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
       #  X64 specific
       NULL|DynamicTablesPkg/Library/Acpi/X64/AcpiSsdtHpetLib/AcpiSsdtHpetLib.inf
+
+      #  HII Form Generators
+      NULL|DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
   }
 
 [Components.AARCH64]
@@ -195,6 +201,9 @@
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType37Lib/SmbiosType37Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType40Lib/SmbiosType40Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Lib.inf
+
+      #  HII Form Generators
+      NULL|DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
   }
 
 [Components.RISCV64]

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -28,6 +28,7 @@
   MetadataHandlerLib|DynamicTablesPkg/Library/Common/MetadataHandlerLib/MetadataHandlerLib.inf
   Tpm2DeviceTableLib|DynamicTablesPkg/Library/Common/Tpm2DeviceTableLib/Tpm2DeviceTableLib.inf
   HiiFormsLib|DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormsLib.inf
+  HiiStringsLib|DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringsLib.inf
 
 [LibraryClasses.AARCH64]
   ArmSmcccSocIdLib|ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -88,6 +88,7 @@
 
   #  HII Form Generators
   DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+  DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.inf
 
 [Components.X64]
   #
@@ -129,6 +130,7 @@
 
       #  HII Form Generators
       NULL|DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+      NULL|DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.inf
   }
 
 [Components.AARCH64]
@@ -204,6 +206,7 @@
 
       #  HII Form Generators
       NULL|DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+      NULL|DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.inf
   }
 
 [Components.RISCV64]

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -88,6 +88,9 @@
   #
   DynamicTablesPkg/Drivers/DynamicTableManagerDxe/DynamicTableManagerDxe.inf
 
+  #  HII Form Generators
+  DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+
 [Components.X64]
   #
   # Generators (X64 specific)
@@ -126,6 +129,9 @@
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
       #  X64 specific
       NULL|DynamicTablesPkg/Library/Acpi/X64/AcpiSsdtHpetLib/AcpiSsdtHpetLib.inf
+
+      #  HII Form Generators
+      NULL|DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
   }
 
 [Components.AARCH64]
@@ -202,6 +208,9 @@
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType40Lib/SmbiosType40Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType42Lib/SmbiosType42Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Lib.inf
+
+      #  HII Form Generators
+      NULL|DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
   }
 
 [Components.RISCV64]

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -90,6 +90,7 @@
 
   #  HII Form Generators
   DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+  DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.inf
 
 [Components.X64]
   #
@@ -132,6 +133,7 @@
 
       #  HII Form Generators
       NULL|DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+      NULL|DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.inf
   }
 
 [Components.AARCH64]
@@ -211,6 +213,7 @@
 
       #  HII Form Generators
       NULL|DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+      NULL|DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.inf
   }
 
 [Components.RISCV64]

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -27,6 +27,7 @@
   MetadataObjLib|DynamicTablesPkg/Library/Common/MetadataObjLib/MetadataObjLib.inf
   MetadataHandlerLib|DynamicTablesPkg/Library/Common/MetadataHandlerLib/MetadataHandlerLib.inf
   Tpm2DeviceTableLib|DynamicTablesPkg/Library/Common/Tpm2DeviceTableLib/Tpm2DeviceTableLib.inf
+  HiiFormsLib|DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormsLib.inf
 
 [LibraryClasses.AARCH64]
   ArmSmcccSocIdLib|ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf

--- a/DynamicTablesPkg/DynamicTablesPkg.dec
+++ b/DynamicTablesPkg/DynamicTablesPkg.dec
@@ -31,6 +31,12 @@
   ##  @libraryclass  Defines a set of APIs to handle dynamically created CmObj.
   DynamicPlatRepoLib|Include/Library/DynamicPlatRepoLib.h
 
+  ## @libraryclass Defines a set of APIs to generate HII form packages.
+  HiiFormsLib|Include/Library/HiiFormsLib.h
+
+  ## @libraryclass Defines a set of APIs to generate HII string packages.
+  HiiStringsLib|Include/Library/HiiStringsLib.h
+
   ##  @libraryclass  Defines a set of APIs to a hardware information parser.
   HwInfoParserLib|Include/Library/HwInfoParserLib.h
 

--- a/DynamicTablesPkg/DynamicTablesPkg.dec
+++ b/DynamicTablesPkg/DynamicTablesPkg.dec
@@ -106,5 +106,8 @@
   # Maximum number of Additional Information Value bytes used by SMBIOS Type 40.
   gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdMaxAdditionalInformationValue|128|UINT8|0xC0000005
 
+  # Maximum number of Custom HII Generators
+  gEdkiiDynamicTablesPkgTokenSpaceGuid.PcdMaxCustomHiiGenerators|16|UINT16|0xC0000006
+
 [Guids]
   gEdkiiDynamicTablesPkgTokenSpaceGuid = { 0xab226e66, 0x31d8, 0x4613, { 0x87, 0x9d, 0xd2, 0xfa, 0xb6, 0x10, 0x26, 0x3c } }

--- a/DynamicTablesPkg/DynamicTablesPkg.dec
+++ b/DynamicTablesPkg/DynamicTablesPkg.dec
@@ -31,6 +31,9 @@
   ##  @libraryclass  Defines a set of APIs to handle dynamically created CmObj.
   DynamicPlatRepoLib|Include/Library/DynamicPlatRepoLib.h
 
+  ## @libraryclass Defines a set of APIs to generate HII form packages.
+  HiiFormsLib|Include/Library/HiiFormsLib.h
+
   ##  @libraryclass  Defines a set of APIs to a hardware information parser.
   HwInfoParserLib|Include/Library/HwInfoParserLib.h
 

--- a/DynamicTablesPkg/DynamicTablesPkg.dec
+++ b/DynamicTablesPkg/DynamicTablesPkg.dec
@@ -34,6 +34,9 @@
   ## @libraryclass Defines a set of APIs to generate HII form packages.
   HiiFormsLib|Include/Library/HiiFormsLib.h
 
+  ## @libraryclass Defines a set of APIs to generate HII string packages.
+  HiiStringsLib|Include/Library/HiiStringsLib.h
+
   ##  @libraryclass  Defines a set of APIs to a hardware information parser.
   HwInfoParserLib|Include/Library/HwInfoParserLib.h
 

--- a/DynamicTablesPkg/DynamicTablesPkg.dsc
+++ b/DynamicTablesPkg/DynamicTablesPkg.dsc
@@ -28,12 +28,14 @@
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+  HiiLib|MdeModulePkg/Library/UefiHiiLib/UefiHiiLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+  UefiHiiServicesLib|MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.inf
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
 

--- a/DynamicTablesPkg/DynamicTablesPkg.dsc
+++ b/DynamicTablesPkg/DynamicTablesPkg.dsc
@@ -52,6 +52,8 @@
   DynamicTablesPkg/Library/Common/MetadataObjLib/MetadataObjLib.inf
   DynamicTablesPkg/Library/Common/MetadataHandlerLib/MetadataHandlerLib.inf
   DynamicTablesPkg/Library/Common/Tpm2DeviceTableLib/Tpm2DeviceTableLib.inf
+  DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormsLib.inf
+  DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringsLib.inf
 
 [Components.AARCH64]
   DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf

--- a/DynamicTablesPkg/DynamicTablesPkg.dsc
+++ b/DynamicTablesPkg/DynamicTablesPkg.dsc
@@ -53,6 +53,7 @@
   DynamicTablesPkg/Library/Common/MetadataObjLib/MetadataObjLib.inf
   DynamicTablesPkg/Library/Common/MetadataHandlerLib/MetadataHandlerLib.inf
   DynamicTablesPkg/Library/Common/Tpm2DeviceTableLib/Tpm2DeviceTableLib.inf
+  DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormsLib.inf
 
 [Components.AARCH64]
   DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf

--- a/DynamicTablesPkg/DynamicTablesPkg.dsc
+++ b/DynamicTablesPkg/DynamicTablesPkg.dsc
@@ -54,6 +54,7 @@
   DynamicTablesPkg/Library/Common/MetadataHandlerLib/MetadataHandlerLib.inf
   DynamicTablesPkg/Library/Common/Tpm2DeviceTableLib/Tpm2DeviceTableLib.inf
   DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormsLib.inf
+  DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringsLib.inf
 
 [Components.AARCH64]
   DynamicTablesPkg/Library/FdtHwInfoParserLib/FdtHwInfoParserLib.inf

--- a/DynamicTablesPkg/DynamicTablesPkg.dsc
+++ b/DynamicTablesPkg/DynamicTablesPkg.dsc
@@ -28,6 +28,7 @@
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+  HiiLib|MdeModulePkg/Library/UefiHiiLib/UefiHiiLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
@@ -35,6 +36,7 @@
   SortLib|MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+  UefiHiiServicesLib|MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.inf
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
 

--- a/DynamicTablesPkg/Include/ConfigurationManagerObject.h
+++ b/DynamicTablesPkg/Include/ConfigurationManagerObject.h
@@ -7,6 +7,7 @@
 
   @par Glossary:
     - Cm or CM   - Configuration Manager
+    - Hii or HII - Human Interface Infrastructure
     - Obj or OBJ - Object
     - X64 or x64 - X64 Architecture
 **/
@@ -15,6 +16,7 @@
 
 #include <ArchCommonNameSpaceObjects.h>
 #include <ArmNameSpaceObjects.h>
+#include <HiiFormsNameSpaceObjects.h>
 #include <RiscVNameSpaceObjects.h>
 #include <StandardNameSpaceObjects.h>
 #include <X64NameSpaceObjects.h>
@@ -37,6 +39,7 @@ Bits: [31:28] - Name Space ID
                 0010 - ARM
                 0011 - X64
                 0100 - RISC-V
+                1110 - Hii Forms
                 1111 - Custom/OEM
                 All other values are reserved.
 
@@ -90,7 +93,8 @@ typedef enum ObjectNameSpaceID {
   EObjNameSpaceArm,               ///< ARM Objects Namespace
   EObjNameSpaceX64,               ///< X64 Objects Namespace
   EObjNameSpaceRiscV,             ///< RISC-V Objects Namespace
-  EObjNameSpaceOem = 0xF,         ///< OEM Objects Namespace
+  EObjNameSpaceHiiForms = 0xE,    ///< Hii Forms Objects Namespace
+  EObjNameSpaceOem      = 0xF,    ///< OEM Objects Namespace
   EObjNameSpaceMax,
 } EOBJECT_NAMESPACE_ID;
 
@@ -204,3 +208,13 @@ typedef struct CmObjDescriptor {
 **/
 #define CREATE_CM_X64_OBJECT_ID(ObjectId) \
           (CREATE_CM_OBJECT_ID (EObjNameSpaceX64, ObjectId))
+
+/** This macro returns a Configuration Manager Object ID
+    in the Standard Object Namespace.
+
+  @param [in] ObjectId    The Object ID.
+
+  @retval Returns a Standard Configuration Manager Object ID.
+**/
+#define CREATE_CM_HII_FORMS_OBJECT_ID(ObjectId) \
+          (CREATE_CM_OBJECT_ID (EObjNameSpaceHiiForms, ObjectId))

--- a/DynamicTablesPkg/Include/ConfigurationManagerObject.h
+++ b/DynamicTablesPkg/Include/ConfigurationManagerObject.h
@@ -8,6 +8,7 @@
 
   @par Glossary:
     - Cm or CM   - Configuration Manager
+    - Hii or HII - Human Interface Infrastructure
     - Obj or OBJ - Object
     - X64 or x64 - X64 Architecture
 **/
@@ -16,6 +17,7 @@
 
 #include <ArchCommonNameSpaceObjects.h>
 #include <ArmNameSpaceObjects.h>
+#include <HiiFormsNameSpaceObjects.h>
 #include <LoongArch64NameSpaceObjects.h>
 #include <RiscVNameSpaceObjects.h>
 #include <StandardNameSpaceObjects.h>
@@ -40,6 +42,7 @@ Bits: [31:28] - Name Space ID
                 0011 - X64
                 0100 - RISC-V
                 0101 - LoongArch64
+                1110 - Hii Forms
                 1111 - Custom/OEM
                 All other values are reserved.
 
@@ -94,7 +97,8 @@ typedef enum ObjectNameSpaceID {
   EObjNameSpaceX64,               ///< X64 Objects Namespace
   EObjNameSpaceRiscV,             ///< RISC-V Objects Namespace
   EObjNameSpaceLoongArch64,       ///< LoongArch64 Objects Namespace
-  EObjNameSpaceOem = 0xF,         ///< OEM Objects Namespace
+  EObjNameSpaceHiiForms = 0xE,    ///< Hii Forms Objects Namespace
+  EObjNameSpaceOem      = 0xF,    ///< OEM Objects Namespace
   EObjNameSpaceMax,
 } EOBJECT_NAMESPACE_ID;
 
@@ -218,3 +222,13 @@ typedef struct CmObjDescriptor {
 **/
 #define CREATE_CM_X64_OBJECT_ID(ObjectId) \
           (CREATE_CM_OBJECT_ID (EObjNameSpaceX64, ObjectId))
+
+/** This macro returns a Configuration Manager Object ID
+    in the Standard Object Namespace.
+
+  @param [in] ObjectId    The Object ID.
+
+  @retval Returns a Standard Configuration Manager Object ID.
+**/
+#define CREATE_CM_HII_FORMS_OBJECT_ID(ObjectId) \
+          (CREATE_CM_OBJECT_ID (EObjNameSpaceHiiForms, ObjectId))

--- a/DynamicTablesPkg/Include/HiiFormsGenerator.h
+++ b/DynamicTablesPkg/Include/HiiFormsGenerator.h
@@ -1,0 +1,186 @@
+/** @file
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Obj or OBJ - Object
+    - Std or STD - Standard
+    - HII        - Human Interface Infrastructure
+**/
+
+#pragma once
+
+#include <TableGenerator.h>
+
+/** The HII_FORMS_GENERATOR_ID type describes the HII Form generator ID.
+*/
+typedef TABLE_GENERATOR_ID HII_FORMS_GENERATOR_ID;
+
+/** The ESTD_HII_FORMS_ID enum describes the Hii Form IDs reserved for
+    the standard generators.
+*/
+typedef enum HiiFormsId {
+  EStdHiiFormsIdRootForm = 0x0000,             ///< Reserved for the Root form generator.
+  EStdHiiFormsIdCpuArm,                        ///< Cpu Generator for Arm Platforms.
+  EStdHiiFormsIdMax
+} ESTD_HII_FORMS_ID;
+
+/** This structure is used for holding the HII handles of
+    forms that have been added.
+*/
+typedef struct {
+  LIST_ENTRY        List;
+
+  EFI_HII_HANDLE    HiiHandle;
+} HII_FORM_HANDLE;
+
+/** This macro checks if the Generator ID is for a HII Forms Generator.
+
+  @param [in] HiiFormGeneratorId  The Form generator ID.
+
+  @return TRUE if the table generator ID is for a HII Form
+            Generator.
+**/
+#define IS_GENERATOR_TYPE_HII(HiiFormGeneratorId) \
+          (GET_TABLE_TYPE(HiiFormGeneratorId) == ETableGeneratorTypeHii)
+
+/** This macro creates a standard HII Form Generator ID.
+
+  @param [in] TableId  The table generator ID.
+
+  @return a standard HII Form generator ID.
+**/
+#define CREATE_HII_FORMS_GEN_ID(FormsId) \
+          CREATE_TABLE_GEN_ID (                 \
+            ETableGeneratorTypeHii,             \
+            ETableGeneratorNameSpaceStd,        \
+            FormsId                             \
+            )
+
+/** This macro checks if the Forms Generator ID is for a standard HII
+    Forms Generator.
+
+  @param [in] HiiFormsGeneratorId  The Hii Forms generator ID.
+
+  @return  TRUE if the Forms generator ID is for a standard HII
+            Forms Generator.
+**/
+#define IS_VALID_STD_HII_FORMS_GENERATOR_ID(HiiFormsGeneratorId)            \
+          (                                                                 \
+          IS_GENERATOR_NAMESPACE_STD(HiiFormsGeneratorId) &&                \
+          IS_GENERATOR_TYPE_HII(HiiFormsGeneratorId)   &&                   \
+          ((GET_TABLE_ID(HiiFormsGeneratorId) > EStdHiiFormsIdRootForm) &&   \
+           (GET_TABLE_ID(HiiFormsGeneratorId) < EStdHiiFormsIdMax))              \
+          )
+
+/** Forward declarations.
+*/
+typedef struct ConfigurationManagerProtocol EDKII_CONFIGURATION_MANAGER_PROTOCOL;
+typedef struct CmHiiFormsObjInfo            CM_HII_FORMS_OBJ_INFO;
+typedef struct HiiFormsGenerator            HII_FORMS_GENERATOR;
+typedef struct DynamicTableFactoryProtocol  EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL;
+typedef UINTN                               CM_OBJECT_TOKEN;
+
+/** This function pointer describes the interface to HII Form build
+    function provided by the HII Forms generator and called by the
+    Table Manager to build a HII Form.
+
+  @param [in]  Generator       Pointer to the HII Form generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII Form information.
+  @param [in]  CfgMgrProtocol  Pointer to the Configuration Manager
+                               Protocol interface.
+  @param [in]  HiiHandleList   Optional list of Hii Handles
+  @param [out] HiiHandle       Pointer to the generated Form's Hii
+                               Handle.
+
+  @return EFI_SUCCESS  If the table is generated successfully or other
+                        failure codes as returned by the generator.
+**/
+typedef EFI_STATUS (EFIAPI *HII_FORMS_GENERATOR_BUILD_FORM)(
+  IN        HII_FORMS_GENERATOR                           *Generator,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                 *CONST  HiiFormsInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CONST LIST_ENTRY                                    *HiiHandleList OPTIONAL,
+  OUT       EFI_HII_HANDLE                                *HiiHandle
+  );
+
+/** This function pointer describes the interface to used by the
+    Table Manager to give the generator an opportunity to free
+    any resources allocated for building the HII Form.
+
+  @param [in]  Generator       Pointer to the HII Forms generator.
+  @param [in]  HiiHandle       Pointer to the generated Form's HII
+                               Handle.
+
+  @return EFI_SUCCESS  If freed successfully or other failure codes
+                        as returned by the generator.
+**/
+typedef EFI_STATUS (EFIAPI *HII_FORMS_GENERATOR_FREE_RES)(
+  IN        HII_FORMS_GENERATOR                           *Generator,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                 *CONST  HiiFormsInfo,
+  IN        EFI_HII_HANDLE                                *HiiHandle
+  );
+
+/** The HII_FORMS_GENERATOR structure provides an interface that the
+    Table Manager can use to invoke the functions to build HII Forms.
+*/
+typedef struct HiiFormsGenerator {
+  /// The HII Forms generator ID.
+  HII_FORMS_GENERATOR_ID            GeneratorID;
+
+  /// String describing the HII Form
+  /// generator.
+  CONST CHAR16                      *Description;
+
+  /// Any private data associated with the
+  /// generator.
+  VOID                              *Priv;
+
+  /// HII Form build function pointer.
+  HII_FORMS_GENERATOR_BUILD_FORM    BuildHiiForm;
+
+  /// The function to free any resources allocated
+  /// for building the HII Form.
+  HII_FORMS_GENERATOR_FREE_RES      FreeHiiFormResources;
+} HII_FORMS_GENERATOR;
+
+/** Register HII Forms factory generator.
+
+  The HII Forms factory maintains a list of the Standard and OEM
+  HII Forms generators.
+
+  @param [in]  Generator       Pointer to the HII Forms generator.
+
+  @retval  EFI_SUCCESS          The Generator was registered
+                                successfully.
+  @retval EFI_INVALID_PARAMETER The Generator ID is invalid or
+                                the Generator pointer is NULL.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID is
+                                already registered.
+**/
+EFI_STATUS
+EFIAPI
+RegisterHiiFormsGenerator (
+  IN  HII_FORMS_GENERATOR                   *CONST  Generator
+  );
+
+/** Deregister HII Forms generator.
+
+  This function is called by the HII Forms generator to deregister itself
+  from the HII Forms factory.
+
+  @param [in]  Generator       Pointer to the HII Forms generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER The generator is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+EFI_STATUS
+EFIAPI
+DeregisterHiiFormsGenerator (
+  IN  HII_FORMS_GENERATOR                   *CONST  Generator
+  );

--- a/DynamicTablesPkg/Include/HiiFormsGenerator.h
+++ b/DynamicTablesPkg/Include/HiiFormsGenerator.h
@@ -1,0 +1,194 @@
+/** @file
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Obj or OBJ - Object
+    - Std or STD - Standard
+    - HII        - Human Interface Infrastructure
+**/
+
+#pragma once
+
+#include <TableGenerator.h>
+
+/** The HII_FORMS_GENERATOR_ID type describes the HII Form generator ID.
+*/
+typedef TABLE_GENERATOR_ID HII_FORMS_GENERATOR_ID;
+
+/** The ESTD_HII_FORMS_ID enum describes the Hii Form IDs reserved for
+    the standard generators.
+*/
+typedef enum HiiFormsId {
+  EStdHiiFormsIdRootForm = 0x0000,             ///< Reserved for the Root form generator.
+  EStdHiiFormsIdCpuArm,                        ///< Cpu Generator for Arm Platforms.
+  EStdHiiFormsIdMax
+} ESTD_HII_FORMS_ID;
+
+/** This structure is used for holding the HII handles of
+    forms that have been added.
+*/
+typedef struct {
+  LIST_ENTRY        List;
+
+  EFI_HII_HANDLE    HiiHandle;
+} HII_FORM_HANDLE;
+
+/** This macro checks if the Generator ID is for a HII Forms Generator.
+
+  @param [in] HiiFormGeneratorId  The Form generator ID.
+
+  @return TRUE if the table generator ID is for a HII Form
+            Generator.
+**/
+#define IS_GENERATOR_TYPE_HII(HiiFormGeneratorId) \
+          (GET_TABLE_TYPE(HiiFormGeneratorId) == ETableGeneratorTypeHii)
+
+/** This macro creates an OEM HII Form Generator ID.
+
+  @param [in] FormsId  The HII form generator ID.
+
+  @return OEM HII Form generator ID.
+**/
+#define CREATE_OEM_HII_FORMS_GEN_ID(FormsId) \
+          CREATE_TABLE_GEN_ID (                 \
+            ETableGeneratorTypeHii,             \
+            ETableGeneratorNameSpaceOem,        \
+            FormsId                             \
+            )
+
+/** This macro creates a standard HII Form Generator ID.
+
+  @param [in] FormsId  The HII form generator ID.
+
+  @return a standard HII Form generator ID.
+**/
+#define CREATE_HII_FORMS_GEN_ID(FormsId) \
+          CREATE_TABLE_GEN_ID (                 \
+            ETableGeneratorTypeHii,             \
+            ETableGeneratorNameSpaceStd,        \
+            FormsId                             \
+            )
+
+/** This macro checks if the Forms Generator ID is for a HII
+    Forms Generator.
+
+  @param [in] HiiFormsGeneratorId  The Hii Forms generator ID.
+
+  @return  TRUE if the Forms generator ID is for a HII Forms
+           Generator.
+**/
+#define IS_VALID_HII_FORMS_GENERATOR_ID(HiiFormsGeneratorId)            \
+        IS_GENERATOR_TYPE_HII(HiiFormsGeneratorId)
+
+/** Forward declarations.
+*/
+typedef struct ConfigurationManagerProtocol EDKII_CONFIGURATION_MANAGER_PROTOCOL;
+typedef struct CmHiiFormsObjInfo            CM_HII_FORMS_OBJ_INFO;
+typedef struct HiiFormsGenerator            HII_FORMS_GENERATOR;
+typedef struct DynamicTableFactoryProtocol  EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL;
+typedef UINTN                               CM_OBJECT_TOKEN;
+
+/** This function pointer describes the interface to HII Form build
+    function provided by the HII Forms generator and called by the
+    Table Manager to build a HII Form.
+
+  @param [in]  Generator       Pointer to the HII Form generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII Form information.
+  @param [in]  CfgMgrProtocol  Pointer to the Configuration Manager
+                               Protocol interface.
+  @param [in]  HiiHandleList   Optional list of Hii Handles
+  @param [out] HiiHandle       Pointer to the generated Form's Hii
+                               Handle.
+
+  @return EFI_SUCCESS  If the table is generated successfully or other
+                        failure codes as returned by the generator.
+**/
+typedef EFI_STATUS (EFIAPI *HII_FORMS_GENERATOR_BUILD_FORM)(
+  IN        HII_FORMS_GENERATOR                           *Generator,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                 *CONST  HiiFormsInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN  CONST LIST_ENTRY                                    *HiiHandleList OPTIONAL,
+  OUT       EFI_HII_HANDLE                                *HiiHandle
+  );
+
+/** This function pointer describes the interface to used by the
+    Table Manager to give the generator an opportunity to free
+    any resources allocated for building the HII Form.
+
+  @param [in]  Generator       Pointer to the HII Forms generator.
+  @param [in]  HiiHandle       Pointer to the generated Form's HII
+                               Handle.
+
+  @return EFI_SUCCESS  If freed successfully or other failure codes
+                        as returned by the generator.
+**/
+typedef EFI_STATUS (EFIAPI *HII_FORMS_GENERATOR_FREE_RES)(
+  IN        HII_FORMS_GENERATOR                           *Generator,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                 *CONST  HiiFormsInfo,
+  IN        EFI_HII_HANDLE                                *HiiHandle
+  );
+
+/** The HII_FORMS_GENERATOR structure provides an interface that the
+    Table Manager can use to invoke the functions to build HII Forms.
+*/
+typedef struct HiiFormsGenerator {
+  /// The HII Forms generator ID.
+  HII_FORMS_GENERATOR_ID            GeneratorID;
+
+  /// String describing the HII Form
+  /// generator.
+  CONST CHAR16                      *Description;
+
+  /// Any private data associated with the
+  /// generator.
+  VOID                              *Priv;
+
+  /// HII Form build function pointer.
+  HII_FORMS_GENERATOR_BUILD_FORM    BuildHiiForm;
+
+  /// The function to free any resources allocated
+  /// for building the HII Form.
+  HII_FORMS_GENERATOR_FREE_RES      FreeHiiFormResources;
+} HII_FORMS_GENERATOR;
+
+/** Register HII Forms factory generator.
+
+  The HII Forms factory maintains a list of the Standard and OEM
+  HII Forms generators.
+
+  @param [in]  Generator       Pointer to the HII Forms generator.
+
+  @retval  EFI_SUCCESS          The Generator was registered
+                                successfully.
+  @retval EFI_INVALID_PARAMETER The Generator ID is invalid or
+                                the Generator pointer is NULL.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID is
+                                already registered.
+**/
+EFI_STATUS
+EFIAPI
+RegisterHiiFormsGenerator (
+  IN  HII_FORMS_GENERATOR                   *CONST  Generator
+  );
+
+/** Deregister HII Forms generator.
+
+  This function is called by the HII Forms generator to deregister itself
+  from the HII Forms factory.
+
+  @param [in]  Generator       Pointer to the HII Forms generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER The generator is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+EFI_STATUS
+EFIAPI
+DeregisterHiiFormsGenerator (
+  IN  HII_FORMS_GENERATOR                   *CONST  Generator
+  );

--- a/DynamicTablesPkg/Include/HiiFormsNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/HiiFormsNameSpaceObjects.h
@@ -1,0 +1,34 @@
+/** @file
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Hii or HII - Human Interface Infrastructure
+    - Obj or OBJ - Object
+    - Std or STD - Standard
+**/
+
+#pragma once
+
+#include <HiiFormsGenerator.h>
+
+/** The EHII_FORMS_OBJECT_ID enum describes the Object IDs
+    in the HII Forms namespace
+*/
+typedef enum HiiFormsObjectID {
+  EHiiFormsObjReserved,                                            ///<  0 - Reserved
+  EHiiFormsObjList,                                                ///< 1 - Hii Forms Info List
+  EHiiFormsObjMax
+} EHII_FORMS_OBJECT_ID;
+
+/** A structure used to describe the HII Forms generators to be invoked.
+*/
+typedef struct CmHiiFormsObjInfo {
+  /// The Hii Form Generator ID
+  HII_FORMS_GENERATOR_ID    FormGeneratorId;
+
+  CM_OBJECT_TOKEN           FormsetToken;
+} CM_HII_FORMS_OBJ_INFO;

--- a/DynamicTablesPkg/Include/HiiFormsNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/HiiFormsNameSpaceObjects.h
@@ -1,0 +1,37 @@
+/** @file
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Hii or HII - Human Interface Infrastructure
+    - Obj or OBJ - Object
+    - Std or STD - Standard
+**/
+
+#pragma once
+
+#include <HiiFormsGenerator.h>
+
+/** The EHII_FORMS_OBJECT_ID enum describes the Object IDs
+    in the HII Forms namespace
+*/
+typedef enum HiiFormsObjectID {
+  EHiiFormsObjReserved,                                            ///<  0 - Reserved
+  EHiiFormsObjList,                                                ///< 1 - Hii Forms Info List
+  EHiiFormsObjMax
+} EHII_FORMS_OBJECT_ID;
+
+/** A structure used to describe the HII Forms generators to be invoked.
+*/
+typedef struct CmHiiFormsObjInfo {
+  /// The Hii Form Generator ID
+  HII_FORMS_GENERATOR_ID    FormGeneratorId;
+
+  /// Form variant ID. Can be used to distinguish
+  /// between different form versions, and generate
+  /// forms accordingly
+  UINT32                    FormVariantId;
+} CM_HII_FORMS_OBJ_INFO;

--- a/DynamicTablesPkg/Include/Library/HiiFormsLib.h
+++ b/DynamicTablesPkg/Include/Library/HiiFormsLib.h
@@ -1,0 +1,605 @@
+/** @file
+  Functions for dynamically building Formsets.
+
+  This file contains function prototypes that
+  are needed for generating Formsets and it's
+  underlying nodes dynamically.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+    - Dyn        - Dynamic
+    - Ref        - Cross-link Reference
+**/
+
+#pragma once
+
+#include <Base.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+/// A generic, opaque handle for HII objects
+typedef VOID *DYN_HII_HANDLE;
+
+/** Get a Form from a given formset
+
+  Get a form from the given formset.
+
+  @param [in]  FormsetHandle     Handle to the formset from which the form is
+                                 to be fetched.
+  @param [in]  FormId            The form ID of the required form.
+
+  @retval  A pointer to the form object or NULL if form not found.
+
+**/
+DYN_HII_HANDLE
+EFIAPI
+DynHiiGetForm (
+  IN  DYN_HII_HANDLE  FormsetHandle,
+  IN  EFI_FORM_ID     FormId
+  );
+
+/** Get a question from a given form
+
+  Get a question from the given form.
+
+  @param [in]  FormHandle        Handle to the form from which the
+                                 question is to be fetched.
+  @param [in]  QuestionId        The question ID of the required
+                                 question.
+
+  @retval  A pointer to the question object or NULL if form not found.
+
+**/
+DYN_HII_HANDLE
+EFIAPI
+DynHiiGetQuestion (
+  IN  DYN_HII_HANDLE   FormHandle,
+  IN  EFI_QUESTION_ID  QuestionId
+  );
+
+/** Create a HII Formset.
+
+  Create a HII Formset under which other HII nodes can
+  be added subsequently.
+
+  @param [in]  FormsetGuid      Formset GUID
+  @param [in]  ClassGuid        Pointer to an array of Class GUIDs, if any.
+  @param [in]  Title            String ID to the Formset title text.
+  @param [in]  Help             String ID to the Formset help text.
+  @param [in]  ClassGuidCount   Number of Class GUIDs(can be 0 - 3).
+  @param [out] FormsetHandle    The Formset object created by the function.
+
+
+  @retval  EFI_SUCCESS            The Formset was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The FormsetGuid or Formset is NULL, or the
+                                  ClassGuidCount > 3.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiCreateFormSet (
+  IN  CONST EFI_GUID  *FormsetGuid,
+  IN  CONST EFI_GUID  *ClassGuid,
+  IN  EFI_STRING_ID   Title,
+  IN  EFI_STRING_ID   Help,
+  IN  UINT8           ClassGuidCount,
+  OUT DYN_HII_HANDLE  *FormsetHandle
+  );
+
+/** Add a form to a Formset.
+
+  Create a HII Form and add it to the given Formset.
+
+  @param [in]   FormsetHandle    Formset handle under which Form is to be added.
+  @param [in]   Title            String ID to the Form's title text.
+  @param [out]  FormId           Form Identifier.
+
+  @retval  EFI_SUCCESS            The Form was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Formset is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddForm (
+  IN   DYN_HII_HANDLE  FormsetHandle,
+  IN   EFI_STRING_ID   Title,
+  OUT  EFI_FORM_ID     *FormId
+  );
+
+/** Add a Subtitle statement to a Form.
+
+  Create a HII Subtitle statement and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  SubtitleFlags    The flags for subtitle opcode.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddSubtitle (
+  IN   DYN_HII_HANDLE  FormHandle,
+  IN   EFI_STRING_ID   Prompt,
+  IN   EFI_STRING_ID   Help,
+  IN   UINT8           SubtitleFlags
+  );
+
+/** Add a Checkbox Question to a Form.
+
+  Create a HII Checkbox Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  CheckboxFlags    The flags for checkbox opcode.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_ALREADY_STARTED    The Question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddCheckbox (
+  IN   DYN_HII_HANDLE   FormHandle,
+  IN   EFI_QUESTION_ID  QuestionId,
+  IN   EFI_VARSTORE_ID  VarstoreId,
+  IN   UINT16           VarOffset,
+  IN   EFI_STRING_ID    Prompt,
+  IN   EFI_STRING_ID    Help,
+  IN   UINT8            QuestionFlags,
+  IN   UINT8            CheckboxFlags
+  );
+
+/** Add a Numeric Question to a Form.
+
+  Create a HII Numeric Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  NumericFlags     The flags for numeric opcode.
+  @param [in]  Minimum          The numeric minimum value.
+  @param [in]  Maximum          The numeric maximum value.
+  @param [in]  Step             The numeric step for edit.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_ALREADY_STARTED    The question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddNumeric (
+  IN   DYN_HII_HANDLE   FormHandle,
+  IN   EFI_QUESTION_ID  QuestionId,
+  IN   EFI_VARSTORE_ID  VarstoreId,
+  IN   UINT16           VarOffset,
+  IN   EFI_STRING_ID    Prompt,
+  IN   EFI_STRING_ID    Help,
+  IN   UINT8            QuestionFlags,
+  IN   UINT8            NumericFlags,
+  IN   UINT64           Minimum,
+  IN   UINT64           Maximum,
+  IN   UINT64           Step
+  );
+
+/** Add a Ref Question to a Form.
+
+  Create a HII Ref Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags,
+  IN          EFI_FORM_ID      RefFormId
+  );
+
+/** Add a Ref2 Question to a Form.
+
+  Create a HII Ref2 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef2 (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags,
+  IN          EFI_FORM_ID      RefFormId,
+  IN          EFI_QUESTION_ID  RefQuestionId
+  );
+
+/** Add a Ref3 Question to a Form.
+
+  Create a HII Ref3 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [in]  RefFormsetId     Target Formset GUID.
+                                If its value is NULL, and RefDevicePath is zero,
+                                then the link is to the current form set.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef3 (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags,
+  IN          EFI_FORM_ID      RefFormId,
+  IN          EFI_QUESTION_ID  RefQuestionId,
+  IN  CONST   EFI_GUID         *RefFormsetId
+  );
+
+/** Add a Ref4 Question to a Form.
+
+  Create a HII Ref4 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [in]  RefFormsetId     Target Formset GUID.
+                                If its value is NULL, and RefDevicePath is zero,
+                                then the link is to the current form set.
+  @param [in]  RefDevicePath    The string ID that specifies the string
+                                containing the text representation of the device
+                                path to which the form set containing the form
+                                specified by FormId. If its value is zero,
+                                then the link refers to the current page.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef4 (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags,
+  IN          EFI_FORM_ID      RefFormId,
+  IN          EFI_QUESTION_ID  RefQuestionId,
+  IN  CONST   EFI_GUID         *RefFormsetId,
+  IN          EFI_STRING_ID    RefDevicePath
+  );
+
+/** Add a Ref5 Question to a Form.
+
+  Create a HII Ref5 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_UNSUPPORTED        The Ref type is unsupported.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef5 (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags
+  );
+
+/** Add a OneOf Question to a Form.
+
+  Create a HII OneOf Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  OneOfFlags       The flags for one-of opcode.
+  @param [in]  ValueType        The value type taken by the one-of opcode.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_ALREADY_STARTED    The question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddOneOf (
+  IN   DYN_HII_HANDLE   FormHandle,
+  IN   EFI_QUESTION_ID  QuestionId,
+  IN   EFI_VARSTORE_ID  VarstoreId,
+  IN   UINT16           VarOffset,
+  IN   EFI_STRING_ID    Prompt,
+  IN   EFI_STRING_ID    Help,
+  IN   UINT8            QuestionFlags,
+  IN   UINT8            OneOfFlags,
+  IN   UINT8            ValueType
+  );
+
+/** Add an Option to a Question.
+
+  Create a HII Option and add it to the given Statement. Currently, adding
+  of options only to the OneOf question type is supported.
+
+  @param [in]  QuestionHandle   Question/Statement handle under which option
+                                is to be added.
+  @param [in]  Text             The string ID for the option description.
+  @param [in]  Flags            Flags associated with the option.
+  @param [in]  Type             Type of data in the value field.
+  @param [in]  Value            Value of the Option.
+
+  @retval  EFI_SUCCESS            The Option was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The any input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddOption (
+  IN  DYN_HII_HANDLE      QuestionHandle,
+  IN  EFI_STRING_ID       Text,
+  IN  UINT8               Flags,
+  IN  UINT8               Type,
+  IN  EFI_IFR_TYPE_VALUE  Value
+  );
+
+/** Add a Default to a Question.
+
+  Create a HII Default and add it to the given Statement.
+
+  @param [in]  QuestionHandle   Question/Statement handle under which option
+                                is to be added.
+  @param [in]  DefaultId        The Default Store ID for this Default.
+  @param [in]  Type             Type of data in the value field.
+  @param [in]  Value            Value of the Default.
+
+  @retval  EFI_SUCCESS            The Default was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Statement is NULL.
+  @retval  EFI_ALREADY_STARTED    The Default for the corresponding DefaultId
+                                  has already been added for the Statement.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddDefault (
+  IN  DYN_HII_HANDLE      QuestionHandle,
+  IN  UINT16              DefaultId,
+  IN  UINT8               Type,
+  IN  EFI_IFR_TYPE_VALUE  Value
+  );
+
+/** Add a Buffer type Variable Store (Varstore) under a Formset.
+
+  Add the buffer variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+  @param [in]  Size               Size of the varstore.
+  @param [in]  Name               Ascii name of the varstore.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreBuffer (
+  IN            DYN_HII_HANDLE   FormsetHandle,
+  IN  CONST     EFI_GUID         *Guid,
+  IN            EFI_VARSTORE_ID  VarstoreId,
+  IN            UINT16           Size,
+  IN  CONST     CHAR8            *Name
+  );
+
+/** Add an EFI type Variable Store (Varstore) under a Formset.
+
+  Add the EFI variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+  @param [in]  Size               Size of the varstore.
+  @param [in]  Attributes         Flags for the varstore.
+  @param [in]  Name               Ascii name of the varstore.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreEfi (
+  IN            DYN_HII_HANDLE   FormsetHandle,
+  IN  CONST     EFI_GUID         *Guid,
+  IN            EFI_VARSTORE_ID  VarstoreId,
+  IN            UINT16           Size,
+  IN            UINT32           Attributes,
+  IN  CONST     CHAR8            *Name
+  );
+
+/** Add an name-value type Variable Store (Varstore) under a Formset.
+
+  Add the name-value variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreNameValue (
+  IN            DYN_HII_HANDLE   FormsetHandle,
+  IN  CONST     EFI_GUID         *Guid,
+  IN            EFI_VARSTORE_ID  VarstoreId
+  );
+
+/** Generate the IFR byte-stream for the Formset.
+
+  Serialize the Formset and it's child nodes to generate an IFR byte-stream
+  based Form package. This can then be added to the HII database through the
+  HiiAddPackages() call.
+
+  @param [in]  FormsetHandle      The formset hierarchy that needs to be
+                                  serialized.
+  @param [out] IfrHandle          Handle of the IFR buffer structure.
+  @param [out] IfrBuf             Pointer to the IFR data buffer.
+
+  @retval  EFI_SUCCESS            The Default was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiGenerateFormPackage (
+  IN  CONST DYN_HII_HANDLE  FormsetHandle,
+  OUT       DYN_HII_HANDLE  *IfrHandle,
+  OUT       UINT8           **IfrBuf
+  );
+
+/** Free up all the memory used by a Formset hierarchy.
+
+  Free up all the memory that had been allocated for the Formset and it's
+  child nodes, including Varstores, Forms, individual Statements etc.
+
+  @param [in]  FormsetHandle    Handle to the formset hierarchy that needs to be
+                                freed up.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeFormSet (
+  IN DYN_HII_HANDLE  FormsetHandle
+  );
+
+/** Free up all the memory used by a Form package.
+
+  Free up all the memory that had been allocated for the Form package which
+  keeps the serialized IFR byte-stream for the formset.
+
+  @param [in]  IfrHandle           Pointer to DYN_HII_IFR_BUFFER.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeFormPackage (
+  IN  DYN_HII_HANDLE  IfrHandle
+  );

--- a/DynamicTablesPkg/Include/Library/HiiFormsLib.h
+++ b/DynamicTablesPkg/Include/Library/HiiFormsLib.h
@@ -1,0 +1,631 @@
+/** @file
+  Functions for dynamically building Formsets.
+
+  This file contains function prototypes that
+  are needed for generating Formsets and it's
+  underlying nodes dynamically.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+    - Dyn        - Dynamic
+    - Ref        - Cross-link Reference
+
+  @par Reference(s):
+  - UEFI specification 2.11, section 33.3.8 Forms Package
+
+**/
+
+#pragma once
+
+#include <Base.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+/// A generic, opaque handle for HII formset objects
+typedef VOID *DYN_HII_FORMSET_HANDLE;
+
+/// A generic handle for HII statement objects
+typedef VOID *DYN_HII_STATEMENT_HANDLE;
+
+/// A generic handle for HII form objects
+typedef VOID *DYN_HII_FORM_HANDLE;
+
+/** Get a Form from a given formset
+
+  Get a form from the given formset through it's form-id.
+
+  @param [in]  FormsetHandle     Handle to the formset from which the form is
+                                 to be fetched.
+  @param [in]  FormId            The form ID of the required form.
+
+  @retval  A pointer to the form object or NULL if form not found.
+
+**/
+DYN_HII_FORM_HANDLE
+EFIAPI
+DynHiiGetForm (
+  IN  DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN  EFI_FORM_ID             FormId
+  );
+
+/** Get a question from a given form
+
+  Get a question from the given form through it's question-id.
+
+  @param [in]  FormHandle        Handle to the form from which the
+                                 question is to be fetched.
+  @param [in]  QuestionId        The question ID of the required
+                                 question.
+
+  @retval  A pointer to the question object or NULL if form not found.
+
+**/
+DYN_HII_STATEMENT_HANDLE
+EFIAPI
+DynHiiGetQuestion (
+  IN  DYN_HII_FORM_HANDLE  FormHandle,
+  IN  EFI_QUESTION_ID      QuestionId
+  );
+
+/** Create a HII Formset.
+
+  Create a HII Formset under which other HII nodes can
+  be added subsequently.
+
+  @param [in]  FormsetGuid      Formset GUID
+  @param [in]  ClassGuid        Pointer to an array of Class GUIDs, if any.
+  @param [in]  Title            String ID to the Formset title text.
+  @param [in]  Help             String ID to the Formset help text.
+  @param [in]  ClassGuidCount   Number of Class GUIDs(can be 0 - 3).
+  @param [out] FormsetHandle    The Formset object created by the function.
+
+
+  @retval  EFI_SUCCESS            The Formset was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The FormsetGuid or Formset is NULL, or the
+                                  ClassGuidCount > 3.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiCreateFormSet (
+  IN  CONST EFI_GUID          *FormsetGuid,
+  IN  CONST EFI_GUID          *ClassGuid,
+  IN  EFI_STRING_ID           Title,
+  IN  EFI_STRING_ID           Help,
+  IN  UINT8                   ClassGuidCount,
+  OUT DYN_HII_FORMSET_HANDLE  *FormsetHandle
+  );
+
+/** Add a form to a Formset.
+
+  Create a HII Form and add it to the given Formset.
+
+  @param [in]   FormsetHandle    Formset handle under which Form is to be added.
+  @param [in]   Title            String ID to the Form's title text.
+  @param [out]  FormId           Form Identifier.
+
+  @retval  EFI_SUCCESS            The Form was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Formset is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddForm (
+  IN   DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN   EFI_STRING_ID           Title,
+  OUT  EFI_FORM_ID             *FormId
+  );
+
+/** Add a Subtitle statement to a Form.
+
+  Create a HII Subtitle statement and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  SubtitleFlags    The flags for subtitle opcode.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddSubtitle (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     SubtitleFlags,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add a Checkbox Question to a Form.
+
+  Create a HII Checkbox Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  CheckboxFlags    The flags for checkbox opcode.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_ALREADY_STARTED    The Question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddCheckbox (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_VARSTORE_ID           VarstoreId,
+  IN   UINT16                    VarOffset,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   UINT8                     CheckboxFlags,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add a Numeric Question to a Form.
+
+  Create a HII Numeric Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  NumericFlags     The flags for numeric opcode.
+  @param [in]  Minimum          The numeric minimum value.
+  @param [in]  Maximum          The numeric maximum value.
+  @param [in]  Step             The numeric step for edit.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_ALREADY_STARTED    The question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddNumeric (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_VARSTORE_ID           VarstoreId,
+  IN   UINT16                    VarOffset,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   UINT8                     NumericFlags,
+  IN   UINT64                    Minimum,
+  IN   UINT64                    Maximum,
+  IN   UINT64                    Step,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add a Ref Question to a Form.
+
+  Create a HII Ref Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_UNSUPPORTED        The Ref type is unsupported.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   EFI_FORM_ID               RefFormId,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add a Ref2 Question to a Form.
+
+  Create a HII Ref2 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef2 (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   EFI_FORM_ID               RefFormId,
+  IN   EFI_QUESTION_ID           RefQuestionId,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add a Ref3 Question to a Form.
+
+  Create a HII Ref3 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [in]  RefFormsetId     Target Formset GUID.
+                                If its value is NULL, and RefDevicePath is zero,
+                                then the link is to the current form set.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef3 (
+  IN          DYN_HII_FORM_HANDLE       FormHandle,
+  IN          EFI_QUESTION_ID           QuestionId,
+  IN          EFI_STRING_ID             Prompt,
+  IN          EFI_STRING_ID             Help,
+  IN          UINT8                     QuestionFlags,
+  IN          EFI_FORM_ID               RefFormId,
+  IN          EFI_QUESTION_ID           RefQuestionId,
+  IN  CONST   EFI_GUID                  *RefFormsetId,
+  OUT         DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add a Ref4 Question to a Form.
+
+  Create a HII Ref4 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [in]  RefFormsetId     Target Formset GUID.
+                                If its value is NULL, and RefDevicePath is zero,
+                                then the link is to the current form set.
+  @param [in]  RefDevicePath    The string ID that specifies the string
+                                containing the text representation of the device
+                                path to which the form set containing the form
+                                specified by FormId. If its value is zero,
+                                then the link refers to the current page.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef4 (
+  IN          DYN_HII_FORM_HANDLE       FormHandle,
+  IN          EFI_QUESTION_ID           QuestionId,
+  IN          EFI_STRING_ID             Prompt,
+  IN          EFI_STRING_ID             Help,
+  IN          UINT8                     QuestionFlags,
+  IN          EFI_FORM_ID               RefFormId,
+  IN          EFI_QUESTION_ID           RefQuestionId,
+  IN  CONST   EFI_GUID                  *RefFormsetId,
+  IN          EFI_STRING_ID             RefDevicePath,
+  OUT         DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add a Ref5 Question to a Form.
+
+  Create a HII Ref5 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_UNSUPPORTED        The Ref type is unsupported.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef5 (
+  IN          DYN_HII_FORM_HANDLE       FormHandle,
+  IN          EFI_QUESTION_ID           QuestionId,
+  IN          EFI_STRING_ID             Prompt,
+  IN          EFI_STRING_ID             Help,
+  IN          UINT8                     QuestionFlags,
+  OUT         DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add a OneOf Question to a Form.
+
+  Create a HII OneOf Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  OneOfFlags       The flags for one-of opcode.
+  @param [in]  ValueType        The value type taken by the one-of opcode.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_ALREADY_STARTED    The question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddOneOf (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_VARSTORE_ID           VarstoreId,
+  IN   UINT16                    VarOffset,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   UINT8                     OneOfFlags,
+  IN   UINT8                     ValueType,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  );
+
+/** Add an Option to a Question.
+
+  Create a HII Option and add it to the given Statement. Currently, adding
+  of options only to the OneOf question type is supported.
+
+  @param [in]  QuestionHandle   Question/Statement handle under which option
+                                is to be added.
+  @param [in]  Text             The string ID for the option description.
+  @param [in]  Flags            Flags associated with the option.
+  @param [in]  Type             Type of data in the value field.
+  @param [in]  Value            Value of the Option.
+
+  @retval  EFI_SUCCESS            The Option was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The any input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddOption (
+  IN  DYN_HII_STATEMENT_HANDLE  QuestionHandle,
+  IN  EFI_STRING_ID             Text,
+  IN  UINT8                     Flags,
+  IN  UINT8                     Type,
+  IN  EFI_IFR_TYPE_VALUE        Value
+  );
+
+/** Add a Default to a Question.
+
+  Create a HII Default and add it to the given Statement.
+
+  @param [in]  QuestionHandle   Question/Statement handle under which option
+                                is to be added.
+  @param [in]  DefaultId        The Default Store ID for this Default.
+  @param [in]  Type             Type of data in the value field.
+  @param [in]  Value            Value of the Default.
+
+  @retval  EFI_SUCCESS            The Default was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Statement is NULL.
+  @retval  EFI_ALREADY_STARTED    The Default for the corresponding DefaultId
+                                  has already been added for the Statement.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddDefault (
+  IN  DYN_HII_STATEMENT_HANDLE  QuestionHandle,
+  IN  UINT16                    DefaultId,
+  IN  UINT8                     Type,
+  IN  EFI_IFR_TYPE_VALUE        Value
+  );
+
+/** Add a Buffer type Variable Store (Varstore) under a Formset.
+
+  Add the buffer variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+  @param [in]  Size               Size of the varstore.
+  @param [in]  Name               Ascii name of the varstore.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreBuffer (
+  IN            DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN  CONST     EFI_GUID                *Guid,
+  IN            EFI_VARSTORE_ID         VarstoreId,
+  IN            UINT16                  Size,
+  IN  CONST     CHAR8                   *Name
+  );
+
+/** Add an EFI type Variable Store (Varstore) under a Formset.
+
+  Add the EFI variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+  @param [in]  Size               Size of the varstore.
+  @param [in]  Attributes         Flags for the varstore.
+  @param [in]  Name               Ascii name of the varstore.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreEfi (
+  IN            DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN  CONST     EFI_GUID                *Guid,
+  IN            EFI_VARSTORE_ID         VarstoreId,
+  IN            UINT16                  Size,
+  IN            UINT32                  Attributes,
+  IN  CONST     CHAR8                   *Name
+  );
+
+/** Add an name-value type Variable Store (Varstore) under a Formset.
+
+  Add the name-value variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreNameValue (
+  IN            DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN  CONST     EFI_GUID                *Guid,
+  IN            EFI_VARSTORE_ID         VarstoreId
+  );
+
+/** Generate the IFR byte-stream for the Formset.
+
+  Serialize the Formset and it's child nodes to generate an IFR byte-stream
+  based Form package. This can then be added to the HII database through the
+  HiiAddPackages() call.
+
+  The serialized IFR buffer is passed back to the caller in IfrBuf. It is
+  the caller's responsibility to free up the IFR buffer through a call to
+  FreePool().
+
+  @param [in]  FormsetHandle      The formset hierarchy that needs to be
+                                  serialized.
+  @param [out] IfrBuf             Pointer to the IFR data buffer.
+
+  @retval  EFI_SUCCESS            The Default was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiGenerateFormPackage (
+  IN  CONST DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  OUT       UINT8                   **IfrBuf
+  );
+
+/** Free up all the memory used by a Formset hierarchy.
+
+  Free up all the memory that had been allocated for the Formset and it's
+  child nodes, including Varstores, Forms, individual Statements etc.
+
+  @param [in]  FormsetHandle    Handle to the formset hierarchy that needs to be
+                                freed up.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeFormSet (
+  IN DYN_HII_FORMSET_HANDLE  FormsetHandle
+  );

--- a/DynamicTablesPkg/Include/Library/HiiStringsLib.h
+++ b/DynamicTablesPkg/Include/Library/HiiStringsLib.h
@@ -1,0 +1,121 @@
+/** @file
+  Functions for dynamically building a HII string package.
+
+  This file contains function prototypes that are needed
+  for generating String package dynamically.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+**/
+
+#pragma once
+
+#include <Base.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+/// A generic, opaque handle for HII string objects
+typedef VOID *DYN_HII_STR_HANDLE;
+
+/** Add a string to the string list.
+
+  Add the string passed to the function to a list of strings that would be
+  added to form the string package.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+  @param [in]   Language          Language for which string is to be added.
+  @param [in]   String            The string that is to be added.
+  @param [out]  StringId          String Identifier assigned for this string.
+
+  @retval  EFI_SUCCESS            The string was added to the list successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrList or String is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddString (
+  IN  CONST DYN_HII_STR_HANDLE  StrPkgHandle,
+  IN  CONST CHAR8               *Language,
+  IN  CONST EFI_STRING          String,
+  OUT       EFI_STRING_ID       *StringId
+  );
+
+/** Generate string package.
+
+  Generate the string package from the input parameter. The string package is
+  subsequently added to the HII database through the HiiAddPackages() call.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+  @param [out]  StrPkgData        The generated array of string package(s).
+
+  @retval  EFI_SUCCESS            The string was added to the list successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrPkgInfo or LanguageCode is NULL.
+  @retval  EFI_ALREADY_STARTED    If StrPkgBuf is not NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiGenerateStringPackage (
+  IN   DYN_HII_STR_HANDLE  StrPkgHandle,
+  OUT  UINT8               **StrPkgData
+  );
+
+/** Free all the strings in a string list.
+
+  Iterate through the string list, and free up memory allocated for the
+  string and the DYN_HII_STR_INFO structure that contains information about
+  that string.
+
+  @param [in]  StringList       The list of strings to be freed.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeStrings (
+  IN LIST_ENTRY  *StringList
+  );
+
+/** Free up the string package buffer.
+
+  Free up the string package buffer along with any other allocations that
+  were done for the string package information structure.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeStringPackage (
+  IN   DYN_HII_STR_HANDLE  StrPkgHandle
+  );
+
+/** Initialize the string package structure.
+
+  Initialize the DYN_HII_STR_PKG structure by allocating memory for
+  certain members of the structure and then initializing them with data
+  that were passed to the function.
+
+  @param [in]  StrPkgArr        Existing string package array which might
+                                consist of multiple language string arrays
+  @param [out] StrPkgHandle     Pointer to the DYN_HII_STR_HANDLE to hold
+                                the string package structure.
+
+  @retval  EFI_SUCCESS            The structure was initialized successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrPkgInfo or LanguageCode is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiInitStringPkg (
+  IN  CONST   UINT8               *StrPkgArr,
+  OUT         DYN_HII_STR_HANDLE  *StrPkgHandle
+  );

--- a/DynamicTablesPkg/Include/Library/HiiStringsLib.h
+++ b/DynamicTablesPkg/Include/Library/HiiStringsLib.h
@@ -1,0 +1,133 @@
+/** @file
+  Functions for dynamically building a HII string package.
+
+  This file contains function prototypes that are needed
+  for generating String package dynamically.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+
+  @par Reference(s):
+  - UEFI specification 2.11, section 33.3.6 String Package
+
+**/
+
+#pragma once
+
+#include <Base.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+/// A generic, opaque handle for HII string objects
+typedef VOID *DYN_HII_STR_HANDLE;
+
+/** Structure used for adding a string to a string
+    package.
+*/
+typedef struct {
+  /// The language code for which the
+  /// string is to be added
+  CHAR8         *LanguageCode;
+
+  /// The actual string to be added to
+  /// the string package
+  EFI_STRING    String;
+} DYN_HII_STR_ENTRY;
+
+/** Add a string to the string list.
+
+  Add the string(s) passed to the function to a list of strings that would
+  be added to form the string package. Each index of StrTable is a pair of
+  language-code and the corresponding string. If there are multiple
+  languages that are supported, strings for those languages can be added.
+  Alternatively, it is also possible to not add a string for a supported
+  language, in which case the string is left blank.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+  @param [in]   StrTable          An array of entries of languagecode and
+                                  string pair to be added.
+  @param [in]   StrCount          Number of entries of StrTable.
+  @param [out]  StringId          String Identifier assigned for this set
+                                  of strings.
+
+  @retval  EFI_SUCCESS            The string was added to the list successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrList or String is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddString (
+  IN  CONST DYN_HII_STR_HANDLE  StrPkgHandle,
+  IN  CONST DYN_HII_STR_ENTRY   *StrTable,
+  IN        UINT32              StrCount,
+  OUT       EFI_STRING_ID       *StringId
+  );
+
+/** Generate string package.
+
+  Generate the string package from the input parameter. The string package is
+  subsequently added to the HII database through the HiiAddPackages() call.
+
+  The serialized string package buffer is passed back to the caller in
+  StrPkgData. It is the caller's responsibility to free up the string package
+  buffer through a call to FreePool().
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+  @param [out]  StrPkgData        The generated array of string package(s).
+
+  @retval  EFI_SUCCESS            The string was added to the list successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrPkgInfo or LanguageCode is NULL.
+  @retval  EFI_ALREADY_STARTED    If StrPkgBuf is not NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiGenerateStringPackage (
+  IN   DYN_HII_STR_HANDLE  StrPkgHandle,
+  OUT  UINT8               **StrPkgData
+  );
+
+/** Free up the string package buffer.
+
+  Free up the string package buffer along with any other allocations that
+  were done for the string package information structure.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeStringPackage (
+  IN   DYN_HII_STR_HANDLE  StrPkgHandle
+  );
+
+/** Initialize the string package structure.
+
+  Initialize the DYN_HII_STR_PKG structure by allocating memory for
+  certain members of the structure and then initializing them with data
+  that were passed to the function.
+
+  @param [in]  StrPkgArr        Existing string package array which might
+                                consist of multiple language string arrays
+  @param [out] StrPkgHandle     Pointer to the DYN_HII_STR_HANDLE to hold
+                                the string package structure.
+
+  @retval  EFI_SUCCESS            The structure was initialized successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrPkgInfo or LanguageCode is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiInitStringPkg (
+  IN  CONST   UINT8               *StrPkgArr,
+  OUT         DYN_HII_STR_HANDLE  *StrPkgHandle
+  );

--- a/DynamicTablesPkg/Include/Protocol/DynamicTableFactoryProtocol.h
+++ b/DynamicTablesPkg/Include/Protocol/DynamicTableFactoryProtocol.h
@@ -15,6 +15,7 @@
 #include <AcpiTableGenerator.h>
 #include <SmbiosTableGenerator.h>
 #include <DeviceTreeTableGenerator.h>
+#include <HiiFormsGenerator.h>
 #include <Library/MetadataObjLib.h>
 
 /** This macro defines the Dynamic Table Factory Protocol GUID.
@@ -200,6 +201,59 @@ EFI_STATUS
   IN  CONST DT_TABLE_GENERATOR                *CONST Generator
   );
 
+/** Return a pointer to the Hii Forms generator.
+
+  @param [in]  This       Pointer to the Dynamic Table Factory Protocol.
+  @param [in]  TableId    The HII Forms generator ID for the
+                          requested generator.
+  @param [out] Generator  Pointer to the requested Hii Forms
+                          generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_DYNAMIC_TABLE_FACTORY_GET_HII_FORMS_GENERATOR)(
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST This,
+  IN  CONST HII_FORMS_GENERATOR_ID                      GeneratorId,
+  OUT       HII_FORMS_GENERATOR                 **CONST Generator
+  );
+
+/** Registers a Hii Forms generator.
+
+  @param [in]  Generator        Pointer to the Hii Forms generator.
+
+  @retval EFI_SUCCESS           The Generator was registered
+                                successfully.
+  @retval EFI_INVALID_PARAMETER The Generator ID is invalid or
+                                the Generator pointer is NULL.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID is
+                                already registered.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_DYNAMIC_TABLE_FACTORY_REGISTER_HII_FORMS_GENERATOR)(
+  IN  HII_FORMS_GENERATOR                *CONST Generator
+  );
+
+/** Deregister a Hii Forms generator.
+
+  @param [in]  Generator       Pointer to the Hii Forms generator.
+
+  @retval EFI_SUCCESS           Success.
+  @retval EFI_INVALID_PARAMETER The generator is invalid.
+  @retval EFI_NOT_FOUND         The requested generator is not found
+                                in the list of registered generators.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_DYNAMIC_TABLE_FACTORY_DEREGISTER_HII_FORMS_GENERATOR)(
+  IN   HII_FORMS_GENERATOR                *CONST Generator
+  );
+
 /** Get the Root handle of the MetadataObjLib.
 
   During the firmware table generation, some Metadata information might be
@@ -252,6 +306,17 @@ typedef struct DynamicTableFactoryProtocol {
   /// Deregister a DT generator
   EDKII_DYNAMIC_TABLE_FACTORY_DEREGISTER_DT_TABLE_GENERATOR
                                                             DeregisterDtTableGenerator;
+
+  /// The interface used to request a Hii Forms Generator.
+  EDKII_DYNAMIC_TABLE_FACTORY_GET_HII_FORMS_GENERATOR       GetHiiFormsGenerator;
+
+  /// Register a Hii Forms Generator
+  EDKII_DYNAMIC_TABLE_FACTORY_REGISTER_HII_FORMS_GENERATOR
+                                                            RegisterHiiFormsGenerator;
+
+  /// Deregister a Hii Forms Generator
+  EDKII_DYNAMIC_TABLE_FACTORY_DEREGISTER_HII_FORMS_GENERATOR
+                                                            DeregisterHiiFormsGenerator;
 
   /// Finalization step
   EDKII_DYNAMIC_TABLE_FACTORY_GET_METADATA_ROOT

--- a/DynamicTablesPkg/Include/TableGenerator.h
+++ b/DynamicTablesPkg/Include/TableGenerator.h
@@ -8,6 +8,7 @@
     - ACPI   - Advanced Configuration and Power Interface
     - SMBIOS - System Management BIOS
     - DT     - Device Tree
+    - HII    - Human Interface Infrastructure
 **/
 
 #pragma once
@@ -37,7 +38,8 @@ _______________________________________________________________________________
        0 - ACPI Table
        1 - SMBIOS Table
        2 - DT (Device Tree) Table
-       3 - Reserved (INVALID)
+       3 - HII Forms
+       4 - Reserved (INVALID)
 
   Bit [27:16] - Reserved, Must Be Zero
 
@@ -123,6 +125,7 @@ _______________________________________________________________________________
   45-127 - Reserved
      128 - Table Type126
      129 - Table Type127
+
 **/
 typedef UINT32 TABLE_GENERATOR_ID;
 
@@ -132,6 +135,7 @@ typedef enum TableGeneratorType {
   ETableGeneratorTypeAcpi = 0,  ///< ACPI Table Generator Type.
   ETableGeneratorTypeSmbios,    ///< SMBIOS Table Generator Type.
   ETableGeneratorTypeDt,        ///< Device Tree Table Generator Type.
+  ETableGeneratorTypeHii,       ///< HII Forms Generator Type.
   ETableGeneratorTypeReserved
 } ETABLE_GENERATOR_TYPE;
 

--- a/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormGenerator.c
+++ b/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormGenerator.c
@@ -1,0 +1,1620 @@
+/** @file
+  Dynamic Hii Form Generation API functions
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Guid/MdeModuleHii.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "InternalHiiFormsLib.h"
+
+/** Check if the default has already been added.
+
+  Check if the default has already been added for the provided
+  DefaultId which corresponds to a default store.
+
+  @param [in]  DefaultList      List to check for the Default.
+  @param [in]  DefaultId        Default ID to look for in the list.
+
+  @retval TRUE if the default exists, FALSE otherwise
+
+**/
+static
+BOOLEAN
+IsDefaultPresent (
+  IN  LIST_ENTRY  *DefaultList,
+  IN  UINT16      DefaultId
+  )
+{
+  LIST_ENTRY       *Link;
+  DYN_HII_DEFAULT  *Default;
+
+  Link = GetFirstNode (DefaultList);
+  while (!IsNull (DefaultList, Link)) {
+    Default = BASE_CR (Link, DYN_HII_DEFAULT, Hdr.Link);
+    if (Default->DefaultId == DefaultId) {
+      return TRUE;
+    }
+
+    Link = GetNextNode (DefaultList, Link);
+  }
+
+  return FALSE;
+}
+
+/** Check if the question has already been added.
+
+  Check if the question has already been added to the provided
+  StatementList.
+
+  @param [in]  StatementList    List to check for the question.
+  @param [in]  QuestionId       Question ID to look for in the list.
+
+  @retval TRUE if the question exists, FALSE otherwise
+
+**/
+static
+BOOLEAN
+IsQuestionPresent (
+  IN  LIST_ENTRY       *StatementList,
+  IN  EFI_QUESTION_ID  QuestionId
+  )
+{
+  LIST_ENTRY               *Link;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+  DYN_HII_STATEMENT        *Statement;
+
+  Link = GetFirstNode (StatementList);
+  while (!IsNull (StatementList, Link)) {
+    Statement   = BASE_CR (Link, DYN_HII_STATEMENT, Hdr.Link);
+    QuestionHdr = &Statement->Data.QuestionHdr;
+    if (QuestionHdr->QuestionId == QuestionId) {
+      return TRUE;
+    }
+
+    Link = GetNextNode (StatementList, Link);
+  }
+
+  return FALSE;
+}
+
+/** Check if this is a question or a statement
+
+  Check if the statement passed is a question, as not all
+  statements are questions.
+
+  @param [in]  StatementType    Type of the statement
+
+  @retval TRUE if question, FALSE otherwise
+
+**/
+static
+BOOLEAN
+IsTypeQuestion (
+  IN  DYN_HII_STATEMENT_TYPE  StatementType
+  )
+{
+  switch (StatementType) {
+    case DynHiiStSubtitle:
+    case DynHiiStText:
+      return FALSE;
+
+    default:
+      return TRUE;
+  }
+}
+
+/** Free all the added Defaults.
+
+  Iterate through the Default list, and free all allocated memory.
+
+  @param [in]  DefaultList    List of defaults that need to be freed up.
+
+**/
+static
+VOID
+DynHiiFreeDefaultList (
+  IN LIST_ENTRY  *DefaultList
+  )
+{
+  LIST_ENTRY       *Link;
+  LIST_ENTRY       *Next;
+  DYN_HII_DEFAULT  *Default;
+
+  if (DefaultList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (DefaultList);
+  while (!IsNull (DefaultList, Link)) {
+    Next = GetNextNode (DefaultList, Link);
+
+    Default = BASE_CR (Link, DYN_HII_DEFAULT, Hdr.Link);
+    RemoveEntryList (Link);
+    FreePool (Default);
+    Link = Next;
+  }
+}
+
+/** Free all the added Options.
+
+  Iterate through the Option list, and free all allocated memory.
+
+  @param [in]  OptionList    List of options that need to be freed up.
+
+**/
+static
+VOID
+DynHiiFreeOptionList (
+  IN LIST_ENTRY  *OptionList
+  )
+{
+  LIST_ENTRY             *Link;
+  LIST_ENTRY             *Next;
+  DYN_HII_ONE_OF_OPTION  *Option;
+
+  if (OptionList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (OptionList);
+  while (!IsNull (OptionList, Link)) {
+    Next = GetNextNode (OptionList, Link);
+
+    Option = BASE_CR (Link, DYN_HII_ONE_OF_OPTION, Hdr.Link);
+    RemoveEntryList (Link);
+    FreePool (Option);
+    Link = Next;
+  }
+}
+
+/** Free all the added Statements/Questions.
+
+  Iterate through the statement list, and free all allocated memory.
+
+  @param [in]  StatementList      List of statements that need to be freed up.
+
+**/
+static
+VOID
+DynHiiFreeStatementList (
+  IN LIST_ENTRY  *StatementList
+  )
+{
+  LIST_ENTRY         *Link;
+  LIST_ENTRY         *Next;
+  DYN_HII_STATEMENT  *Statement;
+
+  if (StatementList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (StatementList);
+  while (!IsNull (StatementList, Link)) {
+    Next      = GetNextNode (StatementList, Link);
+    Statement = BASE_CR (Link, DYN_HII_STATEMENT, Hdr.Link);
+
+    DynHiiFreeOptionList (&Statement->OptionList);
+    DynHiiFreeDefaultList (&Statement->DefaultList);
+
+    RemoveEntryList (Link);
+    FreePool (Statement);
+    Link = Next;
+  }
+}
+
+/** Free all the added Forms.
+
+  Iterate through the form list, and free all allocated memory.
+
+  @param [in]  FormList      List of forms that need to be freed up.
+
+**/
+static
+VOID
+DynHiiFreeFormList (
+  IN LIST_ENTRY  *FormList
+  )
+{
+  LIST_ENTRY    *Link;
+  LIST_ENTRY    *Next;
+  DYN_HII_FORM  *Form;
+
+  if (FormList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (FormList);
+  while (!IsNull (FormList, Link)) {
+    Next = GetNextNode (FormList, Link);
+    Form = BASE_CR (Link, DYN_HII_FORM, Hdr.Link);
+    DynHiiFreeStatementList (&Form->StatementList);
+
+    RemoveEntryList (Link);
+    FreePool (Form);
+    Link = Next;
+  }
+}
+
+/** Free all the added Variable Stores.
+
+  Iterate through the varstore list, and free all allocated memory.
+
+  @param [in]  VarstoreList  List of variable stores that need to be
+                             freed up.
+
+**/
+static
+VOID
+DynHiiFreeVarstoreList (
+  IN LIST_ENTRY  *VarstoreList
+  )
+{
+  CHAR8             *Name;
+  LIST_ENTRY        *Link;
+  LIST_ENTRY        *Next;
+  DYN_HII_VARSTORE  *Varstore;
+
+  if (VarstoreList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (VarstoreList);
+  while (!IsNull (VarstoreList, Link)) {
+    Next     = GetNextNode (VarstoreList, Link);
+    Varstore = BASE_CR (Link, DYN_HII_VARSTORE, Hdr.Link);
+
+    if ((Varstore->VarstoreType == DynHiiVarstoreBuffer) ||
+        (Varstore->VarstoreType == DynHiiVarstoreEfi))
+    {
+      Name = Varstore->VarstoreType == DynHiiVarstoreBuffer ?
+             Varstore->Data.Buffer.Name : Varstore->Data.Efi.Name;
+      FreePool (Name);
+    }
+
+    RemoveEntryList (Link);
+    FreePool (Varstore);
+    Link = Next;
+  }
+}
+
+/** Free all the added Default Stores.
+
+  Iterate through the default store list, and free all allocated memory.
+
+  @param [in]  DefaultStoreList  List of default stores that need to be
+                                 freed up.
+
+**/
+static
+VOID
+DynHiiFreeDefaultStoreList (
+  IN LIST_ENTRY  *DefaultStoreList
+  )
+{
+  LIST_ENTRY            *Link;
+  LIST_ENTRY            *Next;
+  DYN_HII_DEFAULTSTORE  *DefaultStore;
+
+  if (DefaultStoreList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (DefaultStoreList);
+  while (!IsNull (DefaultStoreList, Link)) {
+    Next         = GetNextNode (DefaultStoreList, Link);
+    DefaultStore = BASE_CR (Link, DYN_HII_DEFAULTSTORE, Hdr.Link);
+    RemoveEntryList (Link);
+    FreePool (DefaultStore);
+    Link = Next;
+  }
+}
+
+/** Add a Statement/Question to a Form.
+
+  Create a HII Statement/Question and add it to the given Form.
+
+  @param [in]  Form             Form under which Statement is to be added.
+  @param [in]  StatementType     Type of statement to be added.
+  @param [in]  StatementData     Data of the corresponding Statement to be added.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_ALREADY_STARTED    The Statement has already been added to the
+                                  form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+DynHiiAddStatement (
+  IN  DYN_HII_FORM            *Form,
+  IN  DYN_HII_STATEMENT_TYPE  StatementType,
+  IN  DYN_HII_STATEMENT_DATA  *StatementData
+  )
+{
+  DYN_HII_STATEMENT       *NewStmt;
+  EFI_QUESTION_ID         QuestionId;
+  DYN_HII_STATEMENT_DATA  *NewStatementData;
+
+  if (Form == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (StatementData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  QuestionId = StatementData->QuestionHdr.QuestionId;
+  if (IsTypeQuestion (StatementType) &&
+      IsQuestionPresent (&Form->StatementList, QuestionId))
+  {
+    return EFI_ALREADY_STARTED;
+  }
+
+  NewStmt = AllocateZeroPool (sizeof (*NewStmt));
+  if (NewStmt == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewStmt->Hdr.Type  = DynHiiNodeStatement;
+  NewStmt->Hdr.Scope = TRUE;
+  InitializeListHead (&NewStmt->Hdr.Link);
+
+  NewStmt->StatementType    = StatementType;
+  NewStmt->Data.QuestionHdr = StatementData->QuestionHdr;
+
+  InitializeListHead (&NewStmt->OptionList);
+  InitializeListHead (&NewStmt->DefaultList);
+
+  NewStatementData = &NewStmt->Data;
+  // Type-specific defaults.
+  switch (StatementType) {
+    case DynHiiStCheckbox:
+      NewStatementData->Statement.Checkbox = StatementData->Statement.Checkbox;
+      break;
+
+    case DynHiiStNumeric:
+      NewStatementData->Statement.Numeric = StatementData->Statement.Numeric;
+      break;
+
+    case DynHiiStRef:
+      NewStmt->Hdr.Scope              = FALSE;
+      NewStatementData->Statement.Ref = StatementData->Statement.Ref;
+      break;
+
+    case DynHiiStOneOf:
+      NewStatementData->Statement.OneOf = StatementData->Statement.OneOf;
+      break;
+
+    case DynHiiStSubtitle:
+      NewStmt->Hdr.Scope                   = FALSE;
+      NewStatementData->Statement.Subtitle = StatementData->Statement.Subtitle;
+      break;
+
+    default:
+      goto err_out;
+      break;
+  }
+
+  InsertTailList (&Form->StatementList, &NewStmt->Hdr.Link);
+
+  return EFI_SUCCESS;
+
+err_out:
+  FreePool (NewStmt);
+
+  return EFI_UNSUPPORTED;
+}
+
+/** Add the Varstore Name.
+
+  Add the name of the variable store.
+
+  @param [in]   Name               Ascii name of the varstore.
+  @param [out]  VarstoreName       Pointer to the varstore name data structure.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Name is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreName (
+  IN   CONST   CHAR8  *Name,
+  OUT          CHAR8  **VarstoreName
+  )
+{
+  UINTN       StrBytes;
+  EFI_STATUS  Status;
+
+  StrBytes = AsciiStrSize (Name);
+  if (StrBytes == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *VarstoreName = AllocateZeroPool (StrBytes);
+  if (*VarstoreName == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = AsciiStrCpyS (*VarstoreName, StrBytes, Name);
+  if (EFI_ERROR (Status)) {
+    FreePool (*VarstoreName);
+  }
+
+  return Status;
+}
+
+/** Get a Form from a given formset
+
+  Get a form from the given formset.
+
+  @param [in]  FormsetHandle     Handle to the formset from which the form is
+                                 to be fetched.
+  @param [in]  FormId            The form ID of the required form.
+
+  @retval  A pointer to the form object or NULL if form not found.
+
+**/
+DYN_HII_HANDLE
+EFIAPI
+DynHiiGetForm (
+  IN  DYN_HII_HANDLE  FormsetHandle,
+  IN  EFI_FORM_ID     FormId
+  )
+{
+  LIST_ENTRY       *Link;
+  DYN_HII_FORM     *Form;
+  DYN_HII_FORMSET  *Formset;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return NULL;
+  }
+
+  Link = GetFirstNode (&Formset->FormList);
+  while (!IsNull (&Formset->FormList, Link)) {
+    Form = BASE_CR (Link, DYN_HII_FORM, Hdr.Link);
+    if (Form->FormId == FormId) {
+      return Form;
+    }
+
+    Link = GetNextNode (&Formset->FormList, Link);
+  }
+
+  return NULL;
+}
+
+/** Get a question from a given form
+
+  Get a question from the given form.
+
+  @param [in]  FormHandle        Handle to the form from which the
+                                 question is to be fetched.
+  @param [in]  QuestionId        The question ID of the required
+                                 question.
+
+  @retval  A pointer to the question object or NULL if form not found.
+
+**/
+DYN_HII_HANDLE
+EFIAPI
+DynHiiGetQuestion (
+  IN  DYN_HII_HANDLE   FormHandle,
+  IN  EFI_QUESTION_ID  QuestionId
+  )
+{
+  LIST_ENTRY               *Link;
+  DYN_HII_FORM             *Form;
+  DYN_HII_STATEMENT        *Statement;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return NULL;
+  }
+
+  Link = GetFirstNode (&Form->StatementList);
+  while (!IsNull (&Form->StatementList, Link)) {
+    Statement   = BASE_CR (Link, DYN_HII_STATEMENT, Hdr.Link);
+    QuestionHdr = &Statement->Data.QuestionHdr;
+    if (QuestionHdr->QuestionId == QuestionId) {
+      return Statement;
+    }
+
+    Link = GetNextNode (&Form->StatementList, Link);
+  }
+
+  return NULL;
+}
+
+/** Create a HII Formset.
+
+  Create a HII Formset under which other HII nodes can
+  be added subsequently.
+
+  @param [in]  FormsetGuid      Formset GUID
+  @param [in]  ClassGuid        Pointer to an array of Class GUIDs, if any.
+  @param [in]  Title            String ID to the Formset title text.
+  @param [in]  Help             String ID to the Formset help text.
+  @param [in]  ClassGuidCount   Number of Class GUIDs(can be 0 - 3).
+  @param [out] FormsetHandle    The Formset object created by the function.
+
+
+  @retval  EFI_SUCCESS            The Formset was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The FormsetGuid or Formset is NULL, or the
+                                  ClassGuidCount > 3.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiCreateFormSet (
+  IN  CONST EFI_GUID  *FormsetGuid,
+  IN  CONST EFI_GUID  *ClassGuid,
+  IN  EFI_STRING_ID   Title,
+  IN  EFI_STRING_ID   Help,
+  IN  UINT8           ClassGuidCount,
+  OUT DYN_HII_HANDLE  *FormsetHandle
+  )
+{
+  UINT8            Idx;
+  DYN_HII_FORMSET  *NewFormset;
+
+  if ((FormsetHandle == NULL) || (FormsetGuid == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ClassGuidCount > MAX_FORMSET_CLASS_GUID) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NewFormset = AllocateZeroPool (sizeof (*NewFormset));
+  if (NewFormset == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewFormset->Hdr.Type  = DynHiiNodeFormset;
+  NewFormset->Hdr.Scope = TRUE;
+  InitializeListHead (&NewFormset->Hdr.Link);
+
+  CopyGuid (&NewFormset->FormsetGuid, FormsetGuid);
+  NewFormset->Title          = Title;
+  NewFormset->Help           = Help;
+  NewFormset->FormIdCounter  = 0;
+  NewFormset->ClassGuidCount = ClassGuidCount;
+
+  for (Idx = 0; Idx < ClassGuidCount; Idx++) {
+    CopyGuid (&NewFormset->ClassGuid[Idx], &ClassGuid[Idx]);
+  }
+
+  InitializeListHead (&NewFormset->FormList);
+  InitializeListHead (&NewFormset->VarstoreList);
+  InitializeListHead (&NewFormset->DefaultstoreList);
+
+  *FormsetHandle = NewFormset;
+
+  return EFI_SUCCESS;
+}
+
+/** Add a form to a Formset.
+
+  Create a HII Form and add it to the given Formset.
+
+  @param [in]   FormsetHandle    Formset handle under which Form is to be added.
+  @param [in]   Title            String ID to the Form's title text.
+  @param [out]  FormId           Form Identifier.
+
+  @retval  EFI_SUCCESS            The Form was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Formset is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddForm (
+  IN   DYN_HII_HANDLE  FormsetHandle,
+  IN   EFI_STRING_ID   Title,
+  OUT  EFI_FORM_ID     *FormId
+  )
+{
+  DYN_HII_FORM     *NewForm;
+  DYN_HII_FORMSET  *Formset;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NewForm = AllocateZeroPool (sizeof (*NewForm));
+  if (NewForm == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewForm->Hdr.Type  = DynHiiNodeForm;
+  NewForm->Hdr.Scope = TRUE;
+  InitializeListHead (&NewForm->Hdr.Link);
+
+  NewForm->FormId = ++Formset->FormIdCounter;
+  NewForm->Title  = Title;
+
+  InitializeListHead (&NewForm->StatementList);
+  InsertTailList (&Formset->FormList, &NewForm->Hdr.Link);
+  *FormId = NewForm->FormId;
+
+  return EFI_SUCCESS;
+}
+
+/** Add a Subtitle statement to a Form.
+
+  Create a HII Subtitle statement and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  SubtitleFlags    The flags for subtitle opcode.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddSubtitle (
+  IN   DYN_HII_HANDLE  FormHandle,
+  IN   EFI_STRING_ID   Prompt,
+  IN   EFI_STRING_ID   Help,
+  IN   UINT8           SubtitleFlags
+  )
+{
+  DYN_HII_FORM            *Form;
+  DYN_HII_STATEMENT_DATA  StatementData;
+  DYN_HII_SUBTITLE_DATA   *Subtitle;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Subtitle = &StatementData.Statement.Subtitle;
+
+  Subtitle->Prompt = Prompt;
+  Subtitle->Help   = Help;
+  Subtitle->Flags  = SubtitleFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStSubtitle,
+           &StatementData
+           );
+}
+
+/** Add a Checkbox Question to a Form.
+
+  Create a HII Checkbox Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  CheckboxFlags    The flags for checkbox opcode.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_ALREADY_STARTED    The Question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddCheckbox (
+  IN   DYN_HII_HANDLE   FormHandle,
+  IN   EFI_QUESTION_ID  QuestionId,
+  IN   EFI_VARSTORE_ID  VarstoreId,
+  IN   UINT16           VarOffset,
+  IN   EFI_STRING_ID    Prompt,
+  IN   EFI_STRING_ID    Help,
+  IN   UINT8            QuestionFlags,
+  IN   UINT8            CheckboxFlags
+  )
+{
+  DYN_HII_FORM             *Form;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt          = Prompt;
+  QuestionHdr->Header.Help            = Help;
+  QuestionHdr->QuestionId             = QuestionId;
+  QuestionHdr->VarStoreId             = VarstoreId;
+  QuestionHdr->Flags                  = QuestionFlags;
+  QuestionHdr->VarStoreInfo.VarOffset = VarOffset;
+
+  StatementData.Statement.Checkbox.Flags = CheckboxFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStCheckbox,
+           &StatementData
+           );
+}
+
+/** Add a Numeric Question to a Form.
+
+  Create a HII Numeric Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  NumericFlags     The flags for numeric opcode.
+  @param [in]  Minimum          The numeric minimum value.
+  @param [in]  Maximum          The numeric maximum value.
+  @param [in]  Step             The numeric step for edit.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_ALREADY_STARTED    The question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddNumeric (
+  IN   DYN_HII_HANDLE   FormHandle,
+  IN   EFI_QUESTION_ID  QuestionId,
+  IN   EFI_VARSTORE_ID  VarstoreId,
+  IN   UINT16           VarOffset,
+  IN   EFI_STRING_ID    Prompt,
+  IN   EFI_STRING_ID    Help,
+  IN   UINT8            QuestionFlags,
+  IN   UINT8            NumericFlags,
+  IN   UINT64           Minimum,
+  IN   UINT64           Maximum,
+  IN   UINT64           Step
+  )
+{
+  DYN_HII_FORM             *Form;
+  DYN_HII_NUMERIC_DATA     *Numeric;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt          = Prompt;
+  QuestionHdr->Header.Help            = Help;
+  QuestionHdr->QuestionId             = QuestionId;
+  QuestionHdr->VarStoreId             = VarstoreId;
+  QuestionHdr->Flags                  = QuestionFlags;
+  QuestionHdr->VarStoreInfo.VarOffset = VarOffset;
+
+  Numeric           = &StatementData.Statement.Numeric;
+  Numeric->Flags    = NumericFlags;
+  Numeric->MinValue = Minimum;
+  Numeric->MaxValue = Maximum;
+  Numeric->Step     = Step;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStNumeric,
+           &StatementData
+           );
+}
+
+/** Add a Ref Question to a Form.
+
+  Create a HII Ref Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_UNSUPPORTED        The Ref type is unsupported.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags,
+  IN          EFI_FORM_ID      RefFormId
+  )
+{
+  DYN_HII_FORM             *Form;
+  DYN_HII_REF_DATA         *Ref;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Ref = &StatementData.Statement.Ref;
+
+  Ref->RefType = DynHiiRef1;
+  Ref->FormId  = RefFormId;
+
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt = Prompt;
+  QuestionHdr->Header.Help   = Help;
+  QuestionHdr->QuestionId    = QuestionId;
+  QuestionHdr->Flags         = QuestionFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStRef,
+           &StatementData
+           );
+}
+
+/** Add a Ref2 Question to a Form.
+
+  Create a HII Ref2 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef2 (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags,
+  IN          EFI_FORM_ID      RefFormId,
+  IN          EFI_QUESTION_ID  RefQuestionId
+  )
+{
+  DYN_HII_FORM             *Form;
+  DYN_HII_REF_DATA         *Ref;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Ref = &StatementData.Statement.Ref;
+
+  Ref->RefType    = DynHiiRef2;
+  Ref->FormId     = RefFormId;
+  Ref->QuestionId = RefQuestionId;
+
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt = Prompt;
+  QuestionHdr->Header.Help   = Help;
+  QuestionHdr->QuestionId    = QuestionId;
+  QuestionHdr->Flags         = QuestionFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStRef,
+           &StatementData
+           );
+}
+
+/** Add a Ref3 Question to a Form.
+
+  Create a HII Ref3 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [in]  RefFormsetId     Target Formset GUID.
+                                If its value is NULL, and RefDevicePath is zero,
+                                then the link is to the current form set.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef3 (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags,
+  IN          EFI_FORM_ID      RefFormId,
+  IN          EFI_QUESTION_ID  RefQuestionId,
+  IN  CONST   EFI_GUID         *RefFormsetId
+  )
+{
+  DYN_HII_FORM             *Form;
+  DYN_HII_REF_DATA         *Ref;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  if (RefFormsetId == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Ref = &StatementData.Statement.Ref;
+
+  Ref->RefType    = DynHiiRef3;
+  Ref->FormId     = RefFormId;
+  Ref->QuestionId = RefQuestionId;
+  CopyMem (&Ref->FormSetGuid, RefFormsetId, sizeof (EFI_GUID));
+
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt = Prompt;
+  QuestionHdr->Header.Help   = Help;
+  QuestionHdr->QuestionId    = QuestionId;
+  QuestionHdr->Flags         = QuestionFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStRef,
+           &StatementData
+           );
+}
+
+/** Add a Ref4 Question to a Form.
+
+  Create a HII Ref4 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [in]  RefFormsetId     Target Formset GUID.
+                                If its value is NULL, and RefDevicePath is zero,
+                                then the link is to the current form set.
+  @param [in]  RefDevicePath    The string ID that specifies the string
+                                containing the text representation of the device
+                                path to which the form set containing the form
+                                specified by FormId. If its value is zero,
+                                then the link refers to the current page.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef4 (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags,
+  IN          EFI_FORM_ID      RefFormId,
+  IN          EFI_QUESTION_ID  RefQuestionId,
+  IN  CONST   EFI_GUID         *RefFormsetId,
+  IN          EFI_STRING_ID    RefDevicePath
+  )
+{
+  DYN_HII_FORM             *Form;
+  DYN_HII_REF_DATA         *Ref;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  if (RefDevicePath == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Ref = &StatementData.Statement.Ref;
+
+  Ref->RefType    = DynHiiRef4;
+  Ref->FormId     = RefFormId;
+  Ref->QuestionId = RefQuestionId;
+  Ref->DevicePath = RefDevicePath;
+  if (RefFormsetId != NULL) {
+    CopyMem (&Ref->FormSetGuid, RefFormsetId, sizeof (EFI_GUID));
+  }
+
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt = Prompt;
+  QuestionHdr->Header.Help   = Help;
+  QuestionHdr->QuestionId    = QuestionId;
+  QuestionHdr->Flags         = QuestionFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStRef,
+           &StatementData
+           );
+}
+
+/** Add a Ref5 Question to a Form.
+
+  Create a HII Ref5 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_UNSUPPORTED        The Ref type is unsupported.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef5 (
+  IN          DYN_HII_HANDLE   FormHandle,
+  IN          EFI_QUESTION_ID  QuestionId,
+  IN          EFI_STRING_ID    Prompt,
+  IN          EFI_STRING_ID    Help,
+  IN          UINT8            QuestionFlags
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/** Add a OneOf Question to a Form.
+
+  Create a HII OneOf Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  OneOfFlags       The flags for one-of opcode.
+  @param [in]  ValueType        The value type taken by the one-of opcode.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_ALREADY_STARTED    The question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddOneOf (
+  IN   DYN_HII_HANDLE   FormHandle,
+  IN   EFI_QUESTION_ID  QuestionId,
+  IN   EFI_VARSTORE_ID  VarstoreId,
+  IN   UINT16           VarOffset,
+  IN   EFI_STRING_ID    Prompt,
+  IN   EFI_STRING_ID    Help,
+  IN   UINT8            QuestionFlags,
+  IN   UINT8            OneOfFlags,
+  IN   UINT8            ValueType
+  )
+{
+  DYN_HII_FORM             *Form;
+  DYN_HII_ONE_OF_DATA      *OneOf;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Only numeric values supported with options
+  if ((ValueType != EFI_IFR_TYPE_NUM_SIZE_8) &&
+      (ValueType != EFI_IFR_TYPE_NUM_SIZE_16) &&
+      (ValueType != EFI_IFR_TYPE_NUM_SIZE_32) &&
+      (ValueType != EFI_IFR_TYPE_NUM_SIZE_64))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt          = Prompt;
+  QuestionHdr->Header.Help            = Help;
+  QuestionHdr->QuestionId             = QuestionId;
+  QuestionHdr->VarStoreId             = VarstoreId;
+  QuestionHdr->Flags                  = QuestionFlags;
+  QuestionHdr->VarStoreInfo.VarOffset = VarOffset;
+
+  OneOf            = &StatementData.Statement.OneOf;
+  OneOf->Flags     = OneOfFlags;
+  OneOf->ValueType = ValueType;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStOneOf,
+           &StatementData
+           );
+}
+
+/** Add an Option to a Question.
+
+  Create a HII Option and add it to the given Statement. Currently, adding
+  of options only to the OneOf question type is supported.
+
+  @param [in]  QuestionHandle   Question/Statement handle under which option
+                                is to be added.
+  @param [in]  Text             The string ID for the option description.
+  @param [in]  Flags            Flags associated with the option.
+  @param [in]  Type             Type of data in the value field.
+  @param [in]  Value            Value of the Option.
+
+  @retval  EFI_SUCCESS            The Option was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The any input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddOption (
+  IN  DYN_HII_HANDLE      QuestionHandle,
+  IN  EFI_STRING_ID       Text,
+  IN  UINT8               Flags,
+  IN  UINT8               Type,
+  IN  EFI_IFR_TYPE_VALUE  Value
+  )
+{
+  UINT64                 OptionValue;
+  DYN_HII_STATEMENT      *Statement;
+  DYN_HII_ONE_OF_DATA    *OneOf;
+  DYN_HII_ONE_OF_OPTION  *NewOption;
+
+  Statement = QuestionHandle;
+  if ((Statement == NULL) || (Statement->Hdr.Type != DynHiiNodeStatement)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  /// For now, it is only the OneOf question type that
+  /// will use the Option
+  if (Statement->StatementType != DynHiiStOneOf) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Flags != 0x0) &&
+      (Flags != EFI_IFR_OPTION_DEFAULT) &&
+      (Flags != EFI_IFR_OPTION_DEFAULT_MFG))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Only numeric values supported with options
+  if ((Type != EFI_IFR_TYPE_NUM_SIZE_8) &&
+      (Type != EFI_IFR_TYPE_NUM_SIZE_16) &&
+      (Type != EFI_IFR_TYPE_NUM_SIZE_32) &&
+      (Type != EFI_IFR_TYPE_NUM_SIZE_64))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  OneOf = &Statement->Data.Statement.OneOf;
+  if (OneOf->ValueType != Type) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NewOption = AllocateZeroPool (sizeof (*NewOption));
+  if (NewOption == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewOption->Hdr.Type  = DynHiiNodeOption;
+  NewOption->Hdr.Scope = FALSE;
+  InitializeListHead (&NewOption->Hdr.Link);
+
+  NewOption->Text  = Text;
+  NewOption->Flags = Flags;
+  NewOption->Type  = Type;
+  NewOption->Value = Value;
+
+  switch (Type) {
+    case EFI_IFR_TYPE_NUM_SIZE_8:
+      OptionValue = (UINT64)Value.u8;
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_16:
+      OptionValue = (UINT64)Value.u16;
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_32:
+      OptionValue = (UINT64)Value.u32;
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_64:
+      OptionValue = Value.u64;
+      break;
+  }
+
+  if ((OneOf->MinValue == 0) || (OptionValue < OneOf->MinValue)) {
+    OneOf->MinValue = OptionValue;
+  }
+
+  if ((OneOf->MaxValue == 0) || (OptionValue > OneOf->MaxValue)) {
+    OneOf->MaxValue = OptionValue;
+  }
+
+  InsertTailList (&Statement->OptionList, &NewOption->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Add a Default to a Question.
+
+  Create a HII Default and add it to the given Statement.
+
+  @param [in]  QuestionHandle   Question/Statement handle under which option
+                                is to be added.
+  @param [in]  DefaultId        The Default Store ID for this Default.
+  @param [in]  Type             Type of data in the value field.
+  @param [in]  Value            Value of the Default.
+
+  @retval  EFI_SUCCESS            The Default was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Statement is NULL.
+  @retval  EFI_ALREADY_STARTED    The Default for the corresponding DefaultId
+                                  has already been added for the Statement.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddDefault (
+  IN  DYN_HII_HANDLE      QuestionHandle,
+  IN  UINT16              DefaultId,
+  IN  UINT8               Type,
+  IN  EFI_IFR_TYPE_VALUE  Value
+  )
+{
+  DYN_HII_DEFAULT    *NewDefault;
+  DYN_HII_STATEMENT  *Statement;
+
+  Statement = QuestionHandle;
+  if ((Statement == NULL) || (Statement->Hdr.Type != DynHiiNodeStatement)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (IsDefaultPresent (&Statement->DefaultList, DefaultId)) {
+    return EFI_ALREADY_STARTED;
+  }
+
+  NewDefault = AllocateZeroPool (sizeof (*NewDefault));
+  if (NewDefault == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewDefault->Hdr.Type  = DynHiiNodeDefault;
+  NewDefault->Hdr.Scope = FALSE;
+  InitializeListHead (&NewDefault->Hdr.Link);
+
+  NewDefault->DefaultId = DefaultId;
+  NewDefault->Type      = Type;
+  NewDefault->Value     = Value;
+
+  InsertTailList (&Statement->DefaultList, &NewDefault->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Add a Buffer type Variable Store (Varstore) under a Formset.
+
+  Add the buffer variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+  @param [in]  Size               Size of the varstore.
+  @param [in]  Name               Ascii name of the varstore.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreBuffer (
+  IN            DYN_HII_HANDLE   FormsetHandle,
+  IN  CONST     EFI_GUID         *Guid,
+  IN            EFI_VARSTORE_ID  VarstoreId,
+  IN            UINT16           Size,
+  IN  CONST     CHAR8            *Name
+  )
+{
+  EFI_STATUS                    Status;
+  DYN_HII_FORMSET               *Formset;
+  DYN_HII_VARSTORE              *Varstore;
+  DYN_HII_VARSTORE_BUFFER_DATA  *Buffer;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Guid == NULL) || (Name == NULL) || (Size == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Varstore = AllocateZeroPool (sizeof (*Varstore));
+  if (Varstore == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Varstore->Hdr.Type  = DynHiiNodeVarstore;
+  Varstore->Hdr.Scope = FALSE;
+  InitializeListHead (&Varstore->Hdr.Link);
+
+  Varstore->VarstoreType = DynHiiVarstoreBuffer;
+
+  Buffer = &Varstore->Data.Buffer;
+
+  CopyGuid (&Buffer->Guid, Guid);
+  Buffer->VarstoreId = VarstoreId;
+  Buffer->Size       = Size;
+
+  Status = DynHiiAddVarstoreName (Name, &Buffer->Name);
+  if (EFI_ERROR (Status)) {
+    FreePool (Varstore);
+    return Status;
+  }
+
+  InsertTailList (&Formset->VarstoreList, &Varstore->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Add an EFI type Variable Store (Varstore) under a Formset.
+
+  Add the EFI variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+  @param [in]  Size               Size of the varstore.
+  @param [in]  Attributes         Flags for the varstore.
+  @param [in]  Name               Ascii name of the varstore.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreEfi (
+  IN            DYN_HII_HANDLE   FormsetHandle,
+  IN  CONST     EFI_GUID         *Guid,
+  IN            EFI_VARSTORE_ID  VarstoreId,
+  IN            UINT16           Size,
+  IN            UINT32           Attributes,
+  IN  CONST     CHAR8            *Name
+  )
+{
+  EFI_STATUS                 Status;
+  DYN_HII_FORMSET            *Formset;
+  DYN_HII_VARSTORE           *Varstore;
+  DYN_HII_VARSTORE_EFI_DATA  *Efi;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Guid == NULL) || (Name == NULL) || (Size == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Varstore = AllocateZeroPool (sizeof (*Varstore));
+  if (Varstore == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Varstore->VarstoreType = DynHiiVarstoreEfi;
+  Varstore->Hdr.Type     = DynHiiNodeVarstore;
+  Varstore->Hdr.Scope    = FALSE;
+  InitializeListHead (&Varstore->Hdr.Link);
+
+  Efi = &Varstore->Data.Efi;
+
+  CopyGuid (&Efi->Guid, Guid);
+  Efi->VarstoreId = VarstoreId;
+  Efi->Size       = Size;
+  Efi->Attributes = Attributes;
+
+  Status = DynHiiAddVarstoreName (Name, &Efi->Name);
+  if (EFI_ERROR (Status)) {
+    FreePool (Varstore);
+    return Status;
+  }
+
+  InsertTailList (&Formset->VarstoreList, &Varstore->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Add an name-value type Variable Store (Varstore) under a Formset.
+
+  Add the name-value variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreNameValue (
+  IN            DYN_HII_HANDLE   FormsetHandle,
+  IN  CONST     EFI_GUID         *Guid,
+  IN            EFI_VARSTORE_ID  VarstoreId
+  )
+{
+  DYN_HII_FORMSET   *Formset;
+  DYN_HII_VARSTORE  *Varstore;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Guid == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Varstore = AllocateZeroPool (sizeof (*Varstore));
+  if (Varstore == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Varstore->Hdr.Type  = DynHiiNodeVarstore;
+  Varstore->Hdr.Scope = FALSE;
+  InitializeListHead (&Varstore->Hdr.Link);
+
+  Varstore->VarstoreType = DynHiiVarstoreNameValue;
+
+  CopyGuid (&Varstore->Data.NameValue.Guid, Guid);
+  Varstore->Data.NameValue.VarstoreId = VarstoreId;
+
+  InsertTailList (&Formset->VarstoreList, &Varstore->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Free up all the memory used by a Formset hierarchy.
+
+  Free up all the memory that had been allocated for the Formset and it's
+  child nodes, including Varstores, Forms, individual Statements etc.
+
+  @param [in]  FormsetHandle    Handle to the formset hierarchy that needs to be
+                                freed up.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeFormSet (
+  IN DYN_HII_HANDLE  FormsetHandle
+  )
+{
+  DYN_HII_FORMSET  *Formset;
+
+  Formset = FormsetHandle;
+  if (Formset == NULL) {
+    return;
+  }
+
+  DynHiiFreeVarstoreList (&Formset->VarstoreList);
+  DynHiiFreeDefaultStoreList (&Formset->DefaultstoreList);
+  DynHiiFreeFormList (&Formset->FormList);
+
+  FreePool (Formset);
+}

--- a/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormGenerator.c
+++ b/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormGenerator.c
@@ -1,0 +1,1773 @@
+/** @file
+  Dynamic Hii Form Generation API functions
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - UEFI specification 2.11, section 33.3.8 Forms Package
+
+**/
+
+#include <Base.h>
+#include <Guid/MdeModuleHii.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "InternalHiiFormsLib.h"
+
+/** Check if the default has already been added.
+
+  Check if the default has already been added for the provided
+  DefaultId which corresponds to a default store.
+
+  @param [in]  DefaultList      List to check for the Default.
+  @param [in]  DefaultId        Default ID to look for in the list.
+
+  @retval TRUE if the default exists, FALSE otherwise
+
+**/
+static
+BOOLEAN
+IsDefaultPresent (
+  IN  LIST_ENTRY  *DefaultList,
+  IN  UINT16      DefaultId
+  )
+{
+  LIST_ENTRY       *Link;
+  DYN_HII_DEFAULT  *Default;
+
+  Link = GetFirstNode (DefaultList);
+  while (!IsNull (DefaultList, Link)) {
+    Default = BASE_CR (Link, DYN_HII_DEFAULT, Hdr.Link);
+    if (Default->DefaultId == DefaultId) {
+      return TRUE;
+    }
+
+    Link = GetNextNode (DefaultList, Link);
+  }
+
+  return FALSE;
+}
+
+/** Check if the question has already been added.
+
+  Check if the question has already been added to the provided
+  StatementList.
+
+  @param [in]  StatementList    List to check for the question.
+  @param [in]  QuestionId       Question ID to look for in the list.
+
+  @retval TRUE if the question exists, FALSE otherwise
+
+**/
+static
+BOOLEAN
+IsQuestionPresent (
+  IN  LIST_ENTRY       *StatementList,
+  IN  EFI_QUESTION_ID  QuestionId
+  )
+{
+  LIST_ENTRY               *Link;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+  DYN_HII_STATEMENT        *Statement;
+
+  Link = GetFirstNode (StatementList);
+  while (!IsNull (StatementList, Link)) {
+    Statement   = BASE_CR (Link, DYN_HII_STATEMENT, Hdr.Link);
+    QuestionHdr = &Statement->Data.QuestionHdr;
+    if (QuestionHdr->QuestionId == QuestionId) {
+      return TRUE;
+    }
+
+    Link = GetNextNode (StatementList, Link);
+  }
+
+  return FALSE;
+}
+
+/** Check if this is a question or a statement
+
+  Check if the statement passed is a question, as not all
+  statements are questions.
+
+  @param [in]  StatementType    Type of the statement
+
+  @retval TRUE if question, FALSE otherwise
+
+**/
+static
+BOOLEAN
+IsTypeQuestion (
+  IN  DYN_HII_STATEMENT_TYPE  StatementType
+  )
+{
+  switch (StatementType) {
+    case DynHiiStSubtitle:
+    case DynHiiStText:
+      return FALSE;
+
+    default:
+      return TRUE;
+  }
+}
+
+/** Free all the added Defaults.
+
+  Iterate through the Default list, and free all allocated memory.
+
+  @param [in]  DefaultList    List of defaults that need to be freed up.
+
+**/
+static
+VOID
+DynHiiFreeDefaultList (
+  IN LIST_ENTRY  *DefaultList
+  )
+{
+  LIST_ENTRY       *Link;
+  LIST_ENTRY       *Next;
+  DYN_HII_DEFAULT  *Default;
+
+  if (DefaultList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (DefaultList);
+  while (!IsNull (DefaultList, Link)) {
+    Next = GetNextNode (DefaultList, Link);
+
+    Default = BASE_CR (Link, DYN_HII_DEFAULT, Hdr.Link);
+    RemoveEntryList (Link);
+    FreePool (Default);
+    Link = Next;
+  }
+}
+
+/** Free all the added Options.
+
+  Iterate through the Option list, and free all allocated memory.
+
+  @param [in]  OptionList    List of options that need to be freed up.
+
+**/
+static
+VOID
+DynHiiFreeOptionList (
+  IN LIST_ENTRY  *OptionList
+  )
+{
+  LIST_ENTRY             *Link;
+  LIST_ENTRY             *Next;
+  DYN_HII_ONE_OF_OPTION  *Option;
+
+  if (OptionList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (OptionList);
+  while (!IsNull (OptionList, Link)) {
+    Next = GetNextNode (OptionList, Link);
+
+    Option = BASE_CR (Link, DYN_HII_ONE_OF_OPTION, Hdr.Link);
+    RemoveEntryList (Link);
+    FreePool (Option);
+    Link = Next;
+  }
+}
+
+/** Free all the added Statements/Questions.
+
+  Iterate through the statement list, and free all allocated memory.
+
+  @param [in]  StatementList      List of statements that need to be freed up.
+
+**/
+static
+VOID
+DynHiiFreeStatementList (
+  IN LIST_ENTRY  *StatementList
+  )
+{
+  LIST_ENTRY         *Link;
+  LIST_ENTRY         *Next;
+  DYN_HII_STATEMENT  *Statement;
+
+  if (StatementList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (StatementList);
+  while (!IsNull (StatementList, Link)) {
+    Next      = GetNextNode (StatementList, Link);
+    Statement = BASE_CR (Link, DYN_HII_STATEMENT, Hdr.Link);
+
+    DynHiiFreeOptionList (&Statement->OptionList);
+    DynHiiFreeDefaultList (&Statement->DefaultList);
+
+    RemoveEntryList (Link);
+    FreePool (Statement);
+    Link = Next;
+  }
+}
+
+/** Free all the added Forms.
+
+  Iterate through the form list, and free all allocated memory.
+
+  @param [in]  FormList      List of forms that need to be freed up.
+
+**/
+static
+VOID
+DynHiiFreeFormList (
+  IN LIST_ENTRY  *FormList
+  )
+{
+  LIST_ENTRY    *Link;
+  LIST_ENTRY    *Next;
+  DYN_HII_FORM  *Form;
+
+  if (FormList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (FormList);
+  while (!IsNull (FormList, Link)) {
+    Next = GetNextNode (FormList, Link);
+    Form = BASE_CR (Link, DYN_HII_FORM, Hdr.Link);
+    DynHiiFreeStatementList (&Form->StatementList);
+
+    RemoveEntryList (Link);
+    FreePool (Form);
+    Link = Next;
+  }
+}
+
+/** Free all the added Variable Stores.
+
+  Iterate through the varstore list, and free all allocated memory.
+
+  @param [in]  VarstoreList  List of variable stores that need to be
+                             freed up.
+
+**/
+static
+VOID
+DynHiiFreeVarstoreList (
+  IN LIST_ENTRY  *VarstoreList
+  )
+{
+  CHAR8             *Name;
+  LIST_ENTRY        *Link;
+  LIST_ENTRY        *Next;
+  DYN_HII_VARSTORE  *Varstore;
+
+  if (VarstoreList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (VarstoreList);
+  while (!IsNull (VarstoreList, Link)) {
+    Next     = GetNextNode (VarstoreList, Link);
+    Varstore = BASE_CR (Link, DYN_HII_VARSTORE, Hdr.Link);
+
+    if ((Varstore->VarstoreType == DynHiiVarstoreBuffer) ||
+        (Varstore->VarstoreType == DynHiiVarstoreEfi))
+    {
+      Name = Varstore->VarstoreType == DynHiiVarstoreBuffer ?
+             Varstore->Data.Buffer.Name : Varstore->Data.Efi.Name;
+      FreePool (Name);
+    }
+
+    RemoveEntryList (Link);
+    FreePool (Varstore);
+    Link = Next;
+  }
+}
+
+/** Free all the added Default Stores.
+
+  Iterate through the default store list, and free all allocated memory.
+
+  @param [in]  DefaultStoreList  List of default stores that need to be
+                                 freed up.
+
+**/
+static
+VOID
+DynHiiFreeDefaultStoreList (
+  IN LIST_ENTRY  *DefaultStoreList
+  )
+{
+  LIST_ENTRY            *Link;
+  LIST_ENTRY            *Next;
+  DYN_HII_DEFAULTSTORE  *DefaultStore;
+
+  if (DefaultStoreList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (DefaultStoreList);
+  while (!IsNull (DefaultStoreList, Link)) {
+    Next         = GetNextNode (DefaultStoreList, Link);
+    DefaultStore = BASE_CR (Link, DYN_HII_DEFAULTSTORE, Hdr.Link);
+    RemoveEntryList (Link);
+    FreePool (DefaultStore);
+    Link = Next;
+  }
+}
+
+/** Add a Statement/Question to a Form.
+
+  Create a HII Statement/Question and add it to the given Form.
+
+  @param [in]  Form              Form under which Statement is to be added.
+  @param [in]  StatementType     Type of statement to be added.
+  @param [in]  StatementData     Data of the corresponding Statement to be added.
+  @param [out] StatementHandle   Optional statement handle for storing the
+                                 statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_ALREADY_STARTED    The Statement has already been added to the
+                                  form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+DynHiiAddStatement (
+  IN  DYN_HII_FORM              *Form,
+  IN  DYN_HII_STATEMENT_TYPE    StatementType,
+  IN  DYN_HII_STATEMENT_DATA    *StatementData,
+  OUT DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  DYN_HII_STATEMENT       *NewStmt;
+  EFI_QUESTION_ID         QuestionId;
+  DYN_HII_STATEMENT_DATA  *NewStatementData;
+
+  if (StatementHandle != NULL) {
+    *StatementHandle = NULL;
+  }
+
+  if (Form == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (StatementData == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  QuestionId = StatementData->QuestionHdr.QuestionId;
+  if (IsTypeQuestion (StatementType) &&
+      IsQuestionPresent (&Form->StatementList, QuestionId))
+  {
+    return EFI_ALREADY_STARTED;
+  }
+
+  NewStmt = AllocateZeroPool (sizeof (*NewStmt));
+  if (NewStmt == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewStmt->Hdr.Type  = DynHiiNodeStatement;
+  NewStmt->Hdr.Scope = TRUE;
+  InitializeListHead (&NewStmt->Hdr.Link);
+
+  NewStmt->StatementType    = StatementType;
+  NewStmt->Data.QuestionHdr = StatementData->QuestionHdr;
+
+  InitializeListHead (&NewStmt->OptionList);
+  InitializeListHead (&NewStmt->DefaultList);
+
+  NewStatementData = &NewStmt->Data;
+  // Type-specific defaults.
+  switch (StatementType) {
+    case DynHiiStCheckbox:
+      NewStatementData->Statement.Checkbox = StatementData->Statement.Checkbox;
+      break;
+
+    case DynHiiStNumeric:
+      NewStatementData->Statement.Numeric = StatementData->Statement.Numeric;
+      break;
+
+    case DynHiiStRef:
+      NewStmt->Hdr.Scope              = FALSE;
+      NewStatementData->Statement.Ref = StatementData->Statement.Ref;
+      break;
+
+    case DynHiiStOneOf:
+      NewStatementData->Statement.OneOf = StatementData->Statement.OneOf;
+      break;
+
+    case DynHiiStSubtitle:
+      NewStmt->Hdr.Scope                   = FALSE;
+      NewStatementData->Statement.Subtitle = StatementData->Statement.Subtitle;
+      break;
+
+    default:
+      goto err_out;
+      break;
+  }
+
+  InsertTailList (&Form->StatementList, &NewStmt->Hdr.Link);
+
+  if (StatementHandle != NULL) {
+    *StatementHandle = NewStmt;
+  }
+
+  return EFI_SUCCESS;
+
+err_out:
+  FreePool (NewStmt);
+
+  return EFI_UNSUPPORTED;
+}
+
+/** Add the Varstore Name.
+
+  Add the name of the variable store.
+
+  @param [in]   Name               Ascii name of the varstore.
+  @param [out]  VarstoreName       Pointer to the varstore name data structure.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Name is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreName (
+  IN   CONST   CHAR8  *Name,
+  OUT          CHAR8  **VarstoreName
+  )
+{
+  UINTN       StrBytes;
+  EFI_STATUS  Status;
+
+  StrBytes = AsciiStrSize (Name);
+  if (StrBytes == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *VarstoreName = AllocateZeroPool (StrBytes);
+  if (*VarstoreName == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = AsciiStrCpyS (*VarstoreName, StrBytes, Name);
+  if (EFI_ERROR (Status)) {
+    FreePool (*VarstoreName);
+  }
+
+  return Status;
+}
+
+/** Get a Form from a given formset
+
+  Get a form from the given formset.
+
+  @param [in]  FormsetHandle     Handle to the formset from which the form is
+                                 to be fetched.
+  @param [in]  FormId            The form ID of the required form.
+
+  @retval  A pointer to the form object or NULL if form not found.
+
+**/
+DYN_HII_FORM_HANDLE
+EFIAPI
+DynHiiGetForm (
+  IN  DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN  EFI_FORM_ID             FormId
+  )
+{
+  LIST_ENTRY       *Link;
+  DYN_HII_FORM     *Form;
+  DYN_HII_FORMSET  *Formset;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return NULL;
+  }
+
+  Link = GetFirstNode (&Formset->FormList);
+  while (!IsNull (&Formset->FormList, Link)) {
+    Form = BASE_CR (Link, DYN_HII_FORM, Hdr.Link);
+    if (Form->FormId == FormId) {
+      return Form;
+    }
+
+    Link = GetNextNode (&Formset->FormList, Link);
+  }
+
+  return NULL;
+}
+
+/** Get a question from a given form
+
+  Get a question from the given form.
+
+  @param [in]  FormHandle        Handle to the form from which the
+                                 question is to be fetched.
+  @param [in]  QuestionId        The question ID of the required
+                                 question.
+
+  @retval  A pointer to the question object or NULL if form not found.
+
+**/
+DYN_HII_STATEMENT_HANDLE
+EFIAPI
+DynHiiGetQuestion (
+  IN  DYN_HII_FORM_HANDLE  FormHandle,
+  IN  EFI_QUESTION_ID      QuestionId
+  )
+{
+  LIST_ENTRY               *Link;
+  DYN_HII_FORM             *Form;
+  DYN_HII_STATEMENT        *Statement;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return NULL;
+  }
+
+  Link = GetFirstNode (&Form->StatementList);
+  while (!IsNull (&Form->StatementList, Link)) {
+    Statement   = BASE_CR (Link, DYN_HII_STATEMENT, Hdr.Link);
+    QuestionHdr = &Statement->Data.QuestionHdr;
+    if (QuestionHdr->QuestionId == QuestionId) {
+      return Statement;
+    }
+
+    Link = GetNextNode (&Form->StatementList, Link);
+  }
+
+  return NULL;
+}
+
+/** Create a HII Formset.
+
+  Create a HII Formset under which other HII nodes can
+  be added subsequently.
+
+  @param [in]  FormsetGuid      Formset GUID
+  @param [in]  ClassGuid        Pointer to an array of Class GUIDs, if any.
+  @param [in]  Title            String ID to the Formset title text.
+  @param [in]  Help             String ID to the Formset help text.
+  @param [in]  ClassGuidCount   Number of Class GUIDs(can be 0 - 3).
+  @param [out] FormsetHandle    The Formset object created by the function.
+
+
+  @retval  EFI_SUCCESS            The Formset was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The FormsetGuid or Formset is NULL, or the
+                                  ClassGuidCount > 3.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiCreateFormSet (
+  IN  CONST EFI_GUID          *FormsetGuid,
+  IN  CONST EFI_GUID          *ClassGuid,
+  IN  EFI_STRING_ID           Title,
+  IN  EFI_STRING_ID           Help,
+  IN  UINT8                   ClassGuidCount,
+  OUT DYN_HII_FORMSET_HANDLE  *FormsetHandle
+  )
+{
+  UINT8            Idx;
+  DYN_HII_FORMSET  *NewFormset;
+
+  if ((FormsetHandle == NULL) || (FormsetGuid == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ClassGuidCount > MAX_FORMSET_CLASS_GUID) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NewFormset = AllocateZeroPool (sizeof (*NewFormset));
+  if (NewFormset == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewFormset->Hdr.Type  = DynHiiNodeFormset;
+  NewFormset->Hdr.Scope = TRUE;
+  InitializeListHead (&NewFormset->Hdr.Link);
+
+  CopyGuid (&NewFormset->FormsetGuid, FormsetGuid);
+  NewFormset->Title          = Title;
+  NewFormset->Help           = Help;
+  NewFormset->FormIdCounter  = 0;
+  NewFormset->ClassGuidCount = ClassGuidCount;
+
+  for (Idx = 0; Idx < ClassGuidCount; Idx++) {
+    CopyGuid (&NewFormset->ClassGuid[Idx], &ClassGuid[Idx]);
+  }
+
+  InitializeListHead (&NewFormset->FormList);
+  InitializeListHead (&NewFormset->VarstoreList);
+  InitializeListHead (&NewFormset->DefaultstoreList);
+
+  *FormsetHandle = NewFormset;
+
+  return EFI_SUCCESS;
+}
+
+/** Add a form to a Formset.
+
+  Create a HII Form and add it to the given Formset.
+
+  @param [in]   FormsetHandle    Formset handle under which Form is to be added.
+  @param [in]   Title            String ID to the Form's title text.
+  @param [out]  FormId           Form Identifier.
+
+  @retval  EFI_SUCCESS            The Form was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Formset is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddForm (
+  IN   DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN   EFI_STRING_ID           Title,
+  OUT  EFI_FORM_ID             *FormId
+  )
+{
+  DYN_HII_FORM     *NewForm;
+  DYN_HII_FORMSET  *Formset;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NewForm = AllocateZeroPool (sizeof (*NewForm));
+  if (NewForm == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewForm->Hdr.Type  = DynHiiNodeForm;
+  NewForm->Hdr.Scope = TRUE;
+  InitializeListHead (&NewForm->Hdr.Link);
+
+  NewForm->FormId = ++Formset->FormIdCounter;
+  NewForm->Title  = Title;
+
+  InitializeListHead (&NewForm->StatementList);
+  InsertTailList (&Formset->FormList, &NewForm->Hdr.Link);
+  *FormId = NewForm->FormId;
+
+  return EFI_SUCCESS;
+}
+
+/** Add a Subtitle statement to a Form.
+
+  Create a HII Subtitle statement and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  SubtitleFlags    The flags for subtitle opcode.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddSubtitle (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     SubtitleFlags,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  UINT8                   InvalidStFlags;
+  DYN_HII_FORM            *Form;
+  DYN_HII_STATEMENT_DATA  StatementData;
+  DYN_HII_SUBTITLE_DATA   *Subtitle;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidStFlags = (UINT8) ~(EFI_IFR_FLAGS_HORIZONTAL);
+
+  if ((SubtitleFlags & InvalidStFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Subtitle = &StatementData.Statement.Subtitle;
+
+  Subtitle->Prompt = Prompt;
+  Subtitle->Help   = Help;
+  Subtitle->Flags  = SubtitleFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStSubtitle,
+           &StatementData,
+           StatementHandle
+           );
+}
+
+/** Add a Checkbox Question to a Form.
+
+  Create a HII Checkbox Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  CheckboxFlags    The flags for checkbox opcode.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_ALREADY_STARTED    The Question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddCheckbox (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_VARSTORE_ID           VarstoreId,
+  IN   UINT16                    VarOffset,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   UINT8                     CheckboxFlags,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  UINT8                    InvalidQtFlags;
+  UINT8                    InvalidCbFlags;
+  DYN_HII_FORM             *Form;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidQtFlags = (UINT8) ~(EFI_IFR_FLAG_READ_ONLY |
+                             EFI_IFR_FLAG_CALLBACK |
+                             EFI_IFR_FLAG_RESET_REQUIRED |
+                             EFI_IFR_FLAG_REST_STYLE);
+
+  if ((QuestionFlags & InvalidQtFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidCbFlags = (UINT8) ~(EFI_IFR_CHECKBOX_DEFAULT |
+                             EFI_IFR_CHECKBOX_DEFAULT_MFG);
+
+  if ((CheckboxFlags & InvalidCbFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt          = Prompt;
+  QuestionHdr->Header.Help            = Help;
+  QuestionHdr->QuestionId             = QuestionId;
+  QuestionHdr->VarStoreId             = VarstoreId;
+  QuestionHdr->Flags                  = QuestionFlags;
+  QuestionHdr->VarStoreInfo.VarOffset = VarOffset;
+
+  StatementData.Statement.Checkbox.Flags = CheckboxFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStCheckbox,
+           &StatementData,
+           StatementHandle
+           );
+}
+
+/** Add a Numeric Question to a Form.
+
+  Create a HII Numeric Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  NumericFlags     The flags for numeric opcode.
+  @param [in]  Minimum          The numeric minimum value.
+  @param [in]  Maximum          The numeric maximum value.
+  @param [in]  Step             The numeric step for edit.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_ALREADY_STARTED    The question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddNumeric (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_VARSTORE_ID           VarstoreId,
+  IN   UINT16                    VarOffset,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   UINT8                     NumericFlags,
+  IN   UINT64                    Minimum,
+  IN   UINT64                    Maximum,
+  IN   UINT64                    Step,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  UINT8                    InvalidQtFlags;
+  DYN_HII_FORM             *Form;
+  DYN_HII_NUMERIC_DATA     *Numeric;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidQtFlags = (UINT8) ~(EFI_IFR_FLAG_READ_ONLY |
+                             EFI_IFR_FLAG_CALLBACK |
+                             EFI_IFR_FLAG_RESET_REQUIRED |
+                             EFI_IFR_FLAG_REST_STYLE);
+
+  if ((QuestionFlags & InvalidQtFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((NumericFlags & ~NUMERIC_FLAGS_MASK) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((NumericFlags & EFI_IFR_DISPLAY) == EFI_IFR_DISPLAY) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt          = Prompt;
+  QuestionHdr->Header.Help            = Help;
+  QuestionHdr->QuestionId             = QuestionId;
+  QuestionHdr->VarStoreId             = VarstoreId;
+  QuestionHdr->Flags                  = QuestionFlags;
+  QuestionHdr->VarStoreInfo.VarOffset = VarOffset;
+
+  Numeric           = &StatementData.Statement.Numeric;
+  Numeric->Flags    = NumericFlags;
+  Numeric->MinValue = Minimum;
+  Numeric->MaxValue = Maximum;
+  Numeric->Step     = Step;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStNumeric,
+           &StatementData,
+           StatementHandle
+           );
+}
+
+/** Add a Ref Question to a Form.
+
+  Create a HII Ref Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_UNSUPPORTED        The Ref type is unsupported.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   EFI_FORM_ID               RefFormId,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  UINT8                    InvalidQtFlags;
+  DYN_HII_FORM             *Form;
+  DYN_HII_REF_DATA         *Ref;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidQtFlags = (UINT8) ~(EFI_IFR_FLAG_READ_ONLY |
+                             EFI_IFR_FLAG_CALLBACK |
+                             EFI_IFR_FLAG_RESET_REQUIRED);
+
+  if ((QuestionFlags & InvalidQtFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Ref = &StatementData.Statement.Ref;
+
+  Ref->RefType = DynHiiRef1;
+  Ref->FormId  = RefFormId;
+
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt = Prompt;
+  QuestionHdr->Header.Help   = Help;
+  QuestionHdr->QuestionId    = QuestionId;
+  QuestionHdr->Flags         = QuestionFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStRef,
+           &StatementData,
+           StatementHandle
+           );
+}
+
+/** Add a Ref2 Question to a Form.
+
+  Create a HII Ref2 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef2 (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   EFI_FORM_ID               RefFormId,
+  IN   EFI_QUESTION_ID           RefQuestionId,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  UINT8                    InvalidQtFlags;
+  DYN_HII_FORM             *Form;
+  DYN_HII_REF_DATA         *Ref;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidQtFlags = (UINT8) ~(EFI_IFR_FLAG_READ_ONLY |
+                             EFI_IFR_FLAG_CALLBACK |
+                             EFI_IFR_FLAG_RESET_REQUIRED);
+
+  if ((QuestionFlags & InvalidQtFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Ref = &StatementData.Statement.Ref;
+
+  Ref->RefType    = DynHiiRef2;
+  Ref->FormId     = RefFormId;
+  Ref->QuestionId = RefQuestionId;
+
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt = Prompt;
+  QuestionHdr->Header.Help   = Help;
+  QuestionHdr->QuestionId    = QuestionId;
+  QuestionHdr->Flags         = QuestionFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStRef,
+           &StatementData,
+           StatementHandle
+           );
+}
+
+/** Add a Ref3 Question to a Form.
+
+  Create a HII Ref3 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [in]  RefFormsetId     Target Formset GUID.
+                                If its value is NULL, and RefDevicePath is zero,
+                                then the link is to the current form set.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef3 (
+  IN          DYN_HII_FORM_HANDLE       FormHandle,
+  IN          EFI_QUESTION_ID           QuestionId,
+  IN          EFI_STRING_ID             Prompt,
+  IN          EFI_STRING_ID             Help,
+  IN          UINT8                     QuestionFlags,
+  IN          EFI_FORM_ID               RefFormId,
+  IN          EFI_QUESTION_ID           RefQuestionId,
+  IN  CONST   EFI_GUID                  *RefFormsetId,
+  OUT         DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  UINT8                    InvalidQtFlags;
+  DYN_HII_FORM             *Form;
+  DYN_HII_REF_DATA         *Ref;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  if (RefFormsetId == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidQtFlags = (UINT8) ~(EFI_IFR_FLAG_READ_ONLY |
+                             EFI_IFR_FLAG_CALLBACK |
+                             EFI_IFR_FLAG_RESET_REQUIRED);
+
+  if ((QuestionFlags & InvalidQtFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Ref = &StatementData.Statement.Ref;
+
+  Ref->RefType    = DynHiiRef3;
+  Ref->FormId     = RefFormId;
+  Ref->QuestionId = RefQuestionId;
+  CopyMem (&Ref->FormSetGuid, RefFormsetId, sizeof (EFI_GUID));
+
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt = Prompt;
+  QuestionHdr->Header.Help   = Help;
+  QuestionHdr->QuestionId    = QuestionId;
+  QuestionHdr->Flags         = QuestionFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStRef,
+           &StatementData,
+           StatementHandle
+           );
+}
+
+/** Add a Ref4 Question to a Form.
+
+  Create a HII Ref4 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  RefFormId        Target Form ID.
+  @param [in]  RefQuestionId    Target Question ID.
+                                If its value is zero, then the link refers to
+                                the top of the form.
+  @param [in]  RefFormsetId     Target Formset GUID.
+                                If its value is NULL, and RefDevicePath is zero,
+                                then the link is to the current form set.
+  @param [in]  RefDevicePath    The string ID that specifies the string
+                                containing the text representation of the device
+                                path to which the form set containing the form
+                                specified by FormId. If its value is zero,
+                                then the link refers to the current page.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef4 (
+  IN          DYN_HII_FORM_HANDLE       FormHandle,
+  IN          EFI_QUESTION_ID           QuestionId,
+  IN          EFI_STRING_ID             Prompt,
+  IN          EFI_STRING_ID             Help,
+  IN          UINT8                     QuestionFlags,
+  IN          EFI_FORM_ID               RefFormId,
+  IN          EFI_QUESTION_ID           RefQuestionId,
+  IN  CONST   EFI_GUID                  *RefFormsetId,
+  IN          EFI_STRING_ID             RefDevicePath,
+  OUT         DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  UINT8                    InvalidQtFlags;
+  DYN_HII_FORM             *Form;
+  DYN_HII_REF_DATA         *Ref;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  if (RefDevicePath == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidQtFlags = (UINT8) ~(EFI_IFR_FLAG_READ_ONLY |
+                             EFI_IFR_FLAG_CALLBACK |
+                             EFI_IFR_FLAG_RESET_REQUIRED);
+
+  if ((QuestionFlags & InvalidQtFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  Ref = &StatementData.Statement.Ref;
+
+  Ref->RefType    = DynHiiRef4;
+  Ref->FormId     = RefFormId;
+  Ref->QuestionId = RefQuestionId;
+  Ref->DevicePath = RefDevicePath;
+  if (RefFormsetId != NULL) {
+    CopyMem (&Ref->FormSetGuid, RefFormsetId, sizeof (EFI_GUID));
+  }
+
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt = Prompt;
+  QuestionHdr->Header.Help   = Help;
+  QuestionHdr->QuestionId    = QuestionId;
+  QuestionHdr->Flags         = QuestionFlags;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStRef,
+           &StatementData,
+           StatementHandle
+           );
+}
+
+/** Add a Ref5 Question to a Form.
+
+  Create a HII Ref5 Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_UNSUPPORTED        The Ref type is unsupported.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddRef5 (
+  IN          DYN_HII_FORM_HANDLE       FormHandle,
+  IN          EFI_QUESTION_ID           QuestionId,
+  IN          EFI_STRING_ID             Prompt,
+  IN          EFI_STRING_ID             Help,
+  IN          UINT8                     QuestionFlags,
+  OUT         DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/** Add a OneOf Question to a Form.
+
+  Create a HII OneOf Question and add it to the given Form.
+
+  @param [in]  FormHandle       Form handle under which Statement is to be
+                                added.
+  @param [in]  QuestionId       The question ID.
+  @param [in]  VarstoreId       The variable store ID.
+  @param [in]  VarOffset        Offset in Storage or String ID of the name (VarName)
+                                for the name/value pair.
+  @param [in]  Prompt           The string ID for Prompt.
+  @param [in]  Help             The string ID for Help.
+  @param [in]  QuestionFlags    The flags in Question Header.
+  @param [in]  OneOfFlags       The flags for one-of opcode.
+  @param [in]  ValueType        The value type taken by the one-of opcode.
+  @param [out] StatementHandle  Optional statement handle for storing the
+                                statement node.
+
+  @retval  EFI_SUCCESS            The Statement was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Form is NULL.
+  @retval  EFI_ALREADY_STARTED    The question has already been added to the
+                                  Form.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddOneOf (
+  IN   DYN_HII_FORM_HANDLE       FormHandle,
+  IN   EFI_QUESTION_ID           QuestionId,
+  IN   EFI_VARSTORE_ID           VarstoreId,
+  IN   UINT16                    VarOffset,
+  IN   EFI_STRING_ID             Prompt,
+  IN   EFI_STRING_ID             Help,
+  IN   UINT8                     QuestionFlags,
+  IN   UINT8                     OneOfFlags,
+  IN   UINT8                     ValueType,
+  OUT  DYN_HII_STATEMENT_HANDLE  *StatementHandle  OPTIONAL
+  )
+{
+  UINT8                    InvalidQtFlags;
+  DYN_HII_FORM             *Form;
+  DYN_HII_ONE_OF_DATA      *OneOf;
+  DYN_HII_STATEMENT_DATA   StatementData;
+  EFI_IFR_QUESTION_HEADER  *QuestionHdr;
+
+  Form = FormHandle;
+  if ((Form == NULL) || (Form->Hdr.Type != DynHiiNodeForm)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  InvalidQtFlags = (UINT8) ~(EFI_IFR_FLAG_READ_ONLY |
+                             EFI_IFR_FLAG_CALLBACK |
+                             EFI_IFR_FLAG_RESET_REQUIRED |
+                             EFI_IFR_FLAG_REST_STYLE |
+                             EFI_IFR_FLAG_OPTIONS_ONLY);
+
+  if ((QuestionFlags & InvalidQtFlags) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((OneOfFlags & ~NUMERIC_FLAGS_MASK) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Only numeric values supported with options
+  if ((ValueType != EFI_IFR_TYPE_NUM_SIZE_8) &&
+      (ValueType != EFI_IFR_TYPE_NUM_SIZE_16) &&
+      (ValueType != EFI_IFR_TYPE_NUM_SIZE_32) &&
+      (ValueType != EFI_IFR_TYPE_NUM_SIZE_64))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((OneOfFlags & EFI_IFR_NUMERIC_SIZE) != ValueType) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&StatementData, sizeof (DYN_HII_STATEMENT_DATA));
+  QuestionHdr = &StatementData.QuestionHdr;
+
+  QuestionHdr->Header.Prompt          = Prompt;
+  QuestionHdr->Header.Help            = Help;
+  QuestionHdr->QuestionId             = QuestionId;
+  QuestionHdr->VarStoreId             = VarstoreId;
+  QuestionHdr->Flags                  = QuestionFlags;
+  QuestionHdr->VarStoreInfo.VarOffset = VarOffset;
+
+  OneOf            = &StatementData.Statement.OneOf;
+  OneOf->Flags     = OneOfFlags;
+  OneOf->ValueType = ValueType;
+
+  return DynHiiAddStatement (
+           Form,
+           DynHiiStOneOf,
+           &StatementData,
+           StatementHandle
+           );
+}
+
+/** Add an Option to a Question.
+
+  Create a HII Option and add it to the given Statement. Currently, adding
+  of options only to the OneOf question type is supported.
+
+  @param [in]  QuestionHandle   Question/Statement handle under which option
+                                is to be added.
+  @param [in]  Text             The string ID for the option description.
+  @param [in]  Flags            Flags associated with the option.
+  @param [in]  Type             Type of data in the value field.
+  @param [in]  Value            Value of the Option.
+
+  @retval  EFI_SUCCESS            The Option was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The any input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddOption (
+  IN  DYN_HII_STATEMENT_HANDLE  QuestionHandle,
+  IN  EFI_STRING_ID             Text,
+  IN  UINT8                     Flags,
+  IN  UINT8                     Type,
+  IN  EFI_IFR_TYPE_VALUE        Value
+  )
+{
+  UINT64                 OptionValue;
+  DYN_HII_STATEMENT      *Statement;
+  DYN_HII_ONE_OF_DATA    *OneOf;
+  DYN_HII_ONE_OF_OPTION  *NewOption;
+
+  Statement = QuestionHandle;
+  if ((Statement == NULL) || (Statement->Hdr.Type != DynHiiNodeStatement)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  /// For now, it is only the OneOf question type that
+  /// will use the Option
+  if (Statement->StatementType != DynHiiStOneOf) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Flags != 0x0) &&
+      (Flags != EFI_IFR_OPTION_DEFAULT) &&
+      (Flags != EFI_IFR_OPTION_DEFAULT_MFG))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Only numeric values supported with options
+  if ((Type != EFI_IFR_TYPE_NUM_SIZE_8) &&
+      (Type != EFI_IFR_TYPE_NUM_SIZE_16) &&
+      (Type != EFI_IFR_TYPE_NUM_SIZE_32) &&
+      (Type != EFI_IFR_TYPE_NUM_SIZE_64))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  OneOf = &Statement->Data.Statement.OneOf;
+  if (OneOf->ValueType != Type) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NewOption = AllocateZeroPool (sizeof (*NewOption));
+  if (NewOption == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewOption->Hdr.Type  = DynHiiNodeOption;
+  NewOption->Hdr.Scope = FALSE;
+  InitializeListHead (&NewOption->Hdr.Link);
+
+  NewOption->Text  = Text;
+  NewOption->Flags = Flags;
+  NewOption->Type  = Type;
+  NewOption->Value = Value;
+
+  switch (Type) {
+    case EFI_IFR_TYPE_NUM_SIZE_8:
+      OptionValue = (UINT64)Value.u8;
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_16:
+      OptionValue = (UINT64)Value.u16;
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_32:
+      OptionValue = (UINT64)Value.u32;
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_64:
+      OptionValue = Value.u64;
+      break;
+  }
+
+  if (!OneOf->MinMaxSet) {
+    OneOf->MinValue  = OptionValue;
+    OneOf->MaxValue  = OptionValue;
+    OneOf->MinMaxSet = TRUE;
+  } else {
+    if (OptionValue < OneOf->MinValue) {
+      OneOf->MinValue = OptionValue;
+    }
+
+    if (OptionValue > OneOf->MaxValue) {
+      OneOf->MaxValue = OptionValue;
+    }
+  }
+
+  InsertTailList (&Statement->OptionList, &NewOption->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Add a Default to a Question.
+
+  Create a HII Default and add it to the given Statement.
+
+  @param [in]  QuestionHandle   Question/Statement handle under which option
+                                is to be added.
+  @param [in]  DefaultId        The Default Store ID for this Default.
+  @param [in]  Type             Type of data in the value field.
+  @param [in]  Value            Value of the Default.
+
+  @retval  EFI_SUCCESS            The Default was created successfully.
+  @retval  EFI_INVALID_PARAMETER  The Statement is NULL.
+  @retval  EFI_ALREADY_STARTED    The Default for the corresponding DefaultId
+                                  has already been added for the Statement.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddDefault (
+  IN  DYN_HII_STATEMENT_HANDLE  QuestionHandle,
+  IN  UINT16                    DefaultId,
+  IN  UINT8                     Type,
+  IN  EFI_IFR_TYPE_VALUE        Value
+  )
+{
+  DYN_HII_DEFAULT    *NewDefault;
+  DYN_HII_STATEMENT  *Statement;
+
+  Statement = QuestionHandle;
+  if ((Statement == NULL) || (Statement->Hdr.Type != DynHiiNodeStatement)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (IsDefaultPresent (&Statement->DefaultList, DefaultId)) {
+    return EFI_ALREADY_STARTED;
+  }
+
+  NewDefault = AllocateZeroPool (sizeof (*NewDefault));
+  if (NewDefault == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewDefault->Hdr.Type  = DynHiiNodeDefault;
+  NewDefault->Hdr.Scope = FALSE;
+  InitializeListHead (&NewDefault->Hdr.Link);
+
+  NewDefault->DefaultId = DefaultId;
+  NewDefault->Type      = Type;
+  NewDefault->Value     = Value;
+
+  InsertTailList (&Statement->DefaultList, &NewDefault->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Add a Buffer type Variable Store (Varstore) under a Formset.
+
+  Add the buffer variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+  @param [in]  Size               Size of the varstore.
+  @param [in]  Name               Ascii name of the varstore.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreBuffer (
+  IN            DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN  CONST     EFI_GUID                *Guid,
+  IN            EFI_VARSTORE_ID         VarstoreId,
+  IN            UINT16                  Size,
+  IN  CONST     CHAR8                   *Name
+  )
+{
+  EFI_STATUS                    Status;
+  DYN_HII_FORMSET               *Formset;
+  DYN_HII_VARSTORE              *Varstore;
+  DYN_HII_VARSTORE_BUFFER_DATA  *Buffer;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Guid == NULL) || (Name == NULL) || (Size == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Varstore = AllocateZeroPool (sizeof (*Varstore));
+  if (Varstore == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Varstore->Hdr.Type  = DynHiiNodeVarstore;
+  Varstore->Hdr.Scope = FALSE;
+  InitializeListHead (&Varstore->Hdr.Link);
+
+  Varstore->VarstoreType = DynHiiVarstoreBuffer;
+
+  Buffer = &Varstore->Data.Buffer;
+
+  CopyGuid (&Buffer->Guid, Guid);
+  Buffer->VarstoreId = VarstoreId;
+  Buffer->Size       = Size;
+
+  Status = DynHiiAddVarstoreName (Name, &Buffer->Name);
+  if (EFI_ERROR (Status)) {
+    FreePool (Varstore);
+    return Status;
+  }
+
+  InsertTailList (&Formset->VarstoreList, &Varstore->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Add an EFI type Variable Store (Varstore) under a Formset.
+
+  Add the EFI variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+  @param [in]  Size               Size of the varstore.
+  @param [in]  Attributes         Flags for the varstore.
+  @param [in]  Name               Ascii name of the varstore.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreEfi (
+  IN            DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN  CONST     EFI_GUID                *Guid,
+  IN            EFI_VARSTORE_ID         VarstoreId,
+  IN            UINT16                  Size,
+  IN            UINT32                  Attributes,
+  IN  CONST     CHAR8                   *Name
+  )
+{
+  EFI_STATUS                 Status;
+  DYN_HII_FORMSET            *Formset;
+  DYN_HII_VARSTORE           *Varstore;
+  DYN_HII_VARSTORE_EFI_DATA  *Efi;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Guid == NULL) || (Name == NULL) || (Size == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Varstore = AllocateZeroPool (sizeof (*Varstore));
+  if (Varstore == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Varstore->VarstoreType = DynHiiVarstoreEfi;
+  Varstore->Hdr.Type     = DynHiiNodeVarstore;
+  Varstore->Hdr.Scope    = FALSE;
+  InitializeListHead (&Varstore->Hdr.Link);
+
+  Efi = &Varstore->Data.Efi;
+
+  CopyGuid (&Efi->Guid, Guid);
+  Efi->VarstoreId = VarstoreId;
+  Efi->Size       = Size;
+  Efi->Attributes = Attributes;
+
+  Status = DynHiiAddVarstoreName (Name, &Efi->Name);
+  if (EFI_ERROR (Status)) {
+    FreePool (Varstore);
+    return Status;
+  }
+
+  InsertTailList (&Formset->VarstoreList, &Varstore->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Add an name-value type Variable Store (Varstore) under a Formset.
+
+  Add the name-value variable store under a formset.
+
+  @param [in]  FormsetHandle      Formset handle under which Varstore is to be
+                                  added.
+  @param [in]  Guid               Varstore GUID.
+  @param [in]  VarstoreId         Varstore ID.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_UNSUPPORTED        Adding Varstore of the given type is currently
+                                  not supported.
+  @retval  EFI_INVALID_PARAMETER  The VarstoreType, or any other input parameter
+                                  is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddVarstoreNameValue (
+  IN            DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  IN  CONST     EFI_GUID                *Guid,
+  IN            EFI_VARSTORE_ID         VarstoreId
+  )
+{
+  DYN_HII_FORMSET   *Formset;
+  DYN_HII_VARSTORE  *Varstore;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Guid == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Varstore = AllocateZeroPool (sizeof (*Varstore));
+  if (Varstore == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Varstore->Hdr.Type  = DynHiiNodeVarstore;
+  Varstore->Hdr.Scope = FALSE;
+  InitializeListHead (&Varstore->Hdr.Link);
+
+  Varstore->VarstoreType = DynHiiVarstoreNameValue;
+
+  CopyGuid (&Varstore->Data.NameValue.Guid, Guid);
+  Varstore->Data.NameValue.VarstoreId = VarstoreId;
+
+  InsertTailList (&Formset->VarstoreList, &Varstore->Hdr.Link);
+
+  return EFI_SUCCESS;
+}
+
+/** Free up all the memory used by a Formset hierarchy.
+
+  Free up all the memory that had been allocated for the Formset and it's
+  child nodes, including Varstores, Forms, individual Statements etc.
+
+  @param [in]  FormsetHandle    Handle to the formset hierarchy that needs to be
+                                freed up.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeFormSet (
+  IN DYN_HII_FORMSET_HANDLE  FormsetHandle
+  )
+{
+  DYN_HII_FORMSET  *Formset;
+
+  Formset = FormsetHandle;
+  if (Formset == NULL) {
+    return;
+  }
+
+  DynHiiFreeVarstoreList (&Formset->VarstoreList);
+  DynHiiFreeDefaultStoreList (&Formset->DefaultstoreList);
+  DynHiiFreeFormList (&Formset->FormList);
+
+  FreePool (Formset);
+}

--- a/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormSerialize.c
+++ b/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormSerialize.c
@@ -1,0 +1,1993 @@
+/** @file
+  Dynamic Hii Form Serialization API functions
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "InternalHiiFormsLib.h"
+
+/** The initial buffer size allocated for the
+    IFR byte-stream.
+*/
+#define IFR_INITIAL_BUFFER_SIZE  1024
+
+/** The max length of an HII opcode.
+*/
+#define MAX_HII_OPCODE_LENGTH  127
+
+/** Re-size the IFR byte-stream buffer.
+
+  Re-size the IFR byte-stream buffer to accommodate the TotalSize passed to
+  the function.
+
+  @param [in]  BufInfo          IFR buffer data structure pointer.
+  @param [in]  TotalSize        Minimum number of bytes that the function should
+                                allocate.
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiResizeIfrByteBuffer (
+  IN       DYN_HII_IFR_BUFFER  *BufInfo,
+  IN       UINTN               TotalSize
+  )
+{
+  UINTN  NewSize;
+  UINT8  *Buf;
+
+  NewSize = BufInfo->Size * 2;
+  NewSize = MAX (TotalSize, NewSize);
+
+  Buf = ReallocatePool (BufInfo->Size, NewSize, BufInfo->Data);
+  if (Buf == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  BufInfo->Data = Buf;
+  BufInfo->Size = (UINT32)NewSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Initialize the IFR byte-stream buffer.
+
+  Initialize the IFR byte-stream buffer with IFR_INITIAL_BUFFER_SIZE bytes.
+  Also allocate memory for DYN_HII_IFR_BUFFER structure which holds the IFR
+  buffer.
+
+  @param [out]  Buf              Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiInitIfrByteBuffer (
+  OUT DYN_HII_IFR_BUFFER  **Buf
+  )
+{
+  *Buf = AllocateZeroPool (sizeof (DYN_HII_IFR_BUFFER));
+  if (*Buf == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  (*Buf)->Data = AllocateZeroPool (IFR_INITIAL_BUFFER_SIZE);
+  if ((*Buf)->Data == NULL) {
+    FreePool (*Buf);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  (*Buf)->Size     = IFR_INITIAL_BUFFER_SIZE;
+  (*Buf)->Position = sizeof (UINT32) + sizeof (EFI_HII_PACKAGE_HEADER);
+
+  return EFI_SUCCESS;
+}
+
+/** Check if the IFR byte buffer is large enough.
+
+  Check if the IFR byte buffer is large enough to hold Size bytes. If not,
+  call the function to re-allocate the sufficient number of bytes.
+
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+  @param [in]  Size               The number of bytes that the buffer should
+                                  be able to hold.
+
+  @retval  EFI_SUCCESS            The IFR buffer is large enough, or the re-size
+                                  operation was successfull.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiIfrBufferSizeCheck (
+  IN       DYN_HII_IFR_BUFFER  *BufInfo,
+  IN       UINTN               Size
+  )
+{
+  if (BufInfo->Size - BufInfo->Position >= Size) {
+    return EFI_SUCCESS;
+  }
+
+  return DynHiiResizeIfrByteBuffer (BufInfo, BufInfo->Size + Size);
+}
+
+/** Insert the EFI_IFR_END opcode into the IFR buffer.
+
+  Insert the EFI_IFR_END opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiInsertEndOp (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8        *Buf;
+  UINTN        EndSize;
+  EFI_STATUS   Status;
+  EFI_IFR_END  End;
+
+  if (Hdr->Scope == 0) {
+    return EFI_SUCCESS;
+  }
+
+  EndSize = sizeof (EFI_IFR_END);
+  if (EndSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, EndSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  End.Header.OpCode = EFI_IFR_END_OP;
+  End.Header.Length = (UINT8)EndSize;
+  End.Header.Scope  = 0;
+
+  CopyMem (Buf, &End, sizeof (EFI_IFR_END));
+  BufInfo->Position += sizeof (EFI_IFR_END);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_VARSTORE opcode into the IFR buffer.
+
+  Insert the EFI_IFR_VARSTORE opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeVarstoreBuffer (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                         *Buf;
+  UINT32                        StrSize;
+  UINTN                         VarstoreSize;
+  EFI_STATUS                    Status;
+  EFI_IFR_VARSTORE              Varstore;
+  DYN_HII_VARSTORE              *VarstoreNode;
+  DYN_HII_VARSTORE_BUFFER_DATA  *VarstoreBuf;
+
+  VarstoreNode = (DYN_HII_VARSTORE *)Hdr;
+  VarstoreBuf  = &VarstoreNode->Data.Buffer;
+  StrSize      = (UINT32)AsciiStrSize (VarstoreBuf->Name);
+  VarstoreSize = OFFSET_OF (EFI_IFR_VARSTORE, Name) + StrSize;
+  if (VarstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, VarstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Varstore.Header.OpCode = EFI_IFR_VARSTORE_OP;
+  Varstore.Header.Length = (UINT8)VarstoreSize;
+  Varstore.Header.Scope  = 0;
+  CopyMem (&Varstore.Guid, &VarstoreBuf->Guid, sizeof (EFI_GUID));
+  Varstore.VarStoreId = VarstoreBuf->VarstoreId;
+  Varstore.Size       = VarstoreBuf->Size;
+
+  CopyMem (Buf, &Varstore, OFFSET_OF (EFI_IFR_VARSTORE, Name));
+  BufInfo->Position += OFFSET_OF (EFI_IFR_VARSTORE, Name);
+  Buf               += OFFSET_OF (EFI_IFR_VARSTORE, Name);
+
+  Status = AsciiStrCpyS ((CHAR8 *)Buf, StrSize, VarstoreBuf->Name);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  BufInfo->Position += StrSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_VARSTORE_EFI opcode into the IFR buffer.
+
+  Insert the EFI_IFR_VARSTORE_EFI opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeVarstoreEfi (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                      *Buf;
+  UINT32                     StrSize;
+  UINTN                      VarstoreSize;
+  EFI_STATUS                 Status;
+  EFI_IFR_VARSTORE_EFI       Varstore;
+  DYN_HII_VARSTORE           *VarstoreNode;
+  DYN_HII_VARSTORE_EFI_DATA  *VarstoreEfi;
+
+  VarstoreNode = (DYN_HII_VARSTORE *)Hdr;
+  VarstoreEfi  = &VarstoreNode->Data.Efi;
+  StrSize      = (UINT32)AsciiStrSize (VarstoreEfi->Name);
+  VarstoreSize = OFFSET_OF (EFI_IFR_VARSTORE_EFI, Name) + StrSize;
+  if (VarstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, VarstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Varstore.Header.OpCode = EFI_IFR_VARSTORE_EFI_OP;
+  Varstore.Header.Length = (UINT8)VarstoreSize;
+  Varstore.Header.Scope  = 0;
+  CopyMem (&Varstore.Guid, &VarstoreEfi->Guid, sizeof (EFI_GUID));
+  Varstore.VarStoreId = VarstoreEfi->VarstoreId;
+  Varstore.Attributes = VarstoreEfi->Attributes;
+  Varstore.Size       = VarstoreEfi->Size;
+
+  CopyMem (Buf, &Varstore, OFFSET_OF (EFI_IFR_VARSTORE_EFI, Name));
+  BufInfo->Position += OFFSET_OF (EFI_IFR_VARSTORE_EFI, Name);
+  Buf               += OFFSET_OF (EFI_IFR_VARSTORE_EFI, Name);
+
+  Status = AsciiStrCpyS ((CHAR8 *)Buf, StrSize, VarstoreEfi->Name);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  BufInfo->Position += StrSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_VARSTORE_NAME_VALUE opcode into the IFR buffer.
+
+  Insert the EFI_IFR_VARSTORE_NAME_VALUE opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeVarstoreNameValue (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                             *Buf;
+  UINTN                             VarstoreSize;
+  EFI_STATUS                        Status;
+  EFI_IFR_VARSTORE_NAME_VALUE       Varstore;
+  DYN_HII_VARSTORE                  *VarstoreNode;
+  DYN_HII_VARSTORE_NAME_VALUE_DATA  *VarstoreNameValue;
+
+  VarstoreNode      = (DYN_HII_VARSTORE *)Hdr;
+  VarstoreNameValue = &VarstoreNode->Data.NameValue;
+  VarstoreSize      = sizeof (EFI_IFR_VARSTORE_NAME_VALUE);
+  if (VarstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, VarstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Varstore.Header.OpCode = EFI_IFR_VARSTORE_NAME_VALUE_OP;
+  Varstore.Header.Length = (UINT8)VarstoreSize;
+  Varstore.Header.Scope  = 0;
+  CopyMem (&Varstore.Guid, &VarstoreNameValue->Guid, sizeof (EFI_GUID));
+  Varstore.VarStoreId = VarstoreNameValue->VarstoreId;
+
+  CopyMem (Buf, &Varstore, sizeof (EFI_IFR_VARSTORE_NAME_VALUE));
+  BufInfo->Position += sizeof (EFI_IFR_VARSTORE_NAME_VALUE);
+
+  return EFI_SUCCESS;
+}
+
+/** Serialize the varstore data into the IFR buffer.
+
+  Check for the type of varstore and call the appropriate function for
+  serializing the varstore data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_UNSUPPORTED        Currently unsupported varstore type.
+  @retval  EFI_INVALID_PARAMETER  Invalid varstore type.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeVarstore (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS        Status;
+  DYN_HII_VARSTORE  *VarstoreNode;
+
+  ASSERT (Hdr->Type == DynHiiNodeVarstore);
+
+  VarstoreNode = (DYN_HII_VARSTORE *)Hdr;
+  switch (VarstoreNode->VarstoreType) {
+    case DynHiiVarstoreBuffer:
+      return DynHiiSerializeVarstoreBuffer (Hdr, BufInfo);
+      break;
+
+    case DynHiiVarstoreEfi:
+      return DynHiiSerializeVarstoreEfi (Hdr, BufInfo);
+      break;
+
+    case DynHiiVarstoreNameValue:
+      return DynHiiSerializeVarstoreNameValue (Hdr, BufInfo);
+      break;
+
+    default:
+      Status = EFI_INVALID_PARAMETER;
+      break;
+  }
+
+  return Status;
+}
+
+/** Insert the EFI_IFR_FORM opcode into the IFR buffer.
+
+  Insert the EFI_IFR_FORM opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeForm (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8         *Buf;
+  UINTN         FormSize;
+  EFI_STATUS    Status;
+  EFI_IFR_FORM  Form;
+  DYN_HII_FORM  *FormNode;
+
+  ASSERT (Hdr->Type == DynHiiNodeForm);
+
+  FormNode = (DYN_HII_FORM *)Hdr;
+
+  FormSize = sizeof (EFI_IFR_FORM);
+  if (FormSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, FormSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                = BufInfo->Data + BufInfo->Position;
+  Form.Header.OpCode = EFI_IFR_FORM_OP;
+  Form.Header.Length = (UINT8)FormSize;
+  Form.Header.Scope  = 1;
+
+  Form.FormId    = FormNode->FormId;
+  Form.FormTitle = FormNode->Title;
+
+  CopyMem (Buf, &Form, sizeof (EFI_IFR_FORM));
+  BufInfo->Position += sizeof (EFI_IFR_FORM);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_FORM_SET opcode into the IFR buffer.
+
+  Insert the EFI_IFR_FORM_SET opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeFormset (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8             *Buf;
+  UINT8             Idx;
+  UINTN             FormsetSize;
+  EFI_STATUS        Status;
+  EFI_IFR_FORM_SET  Formset;
+  DYN_HII_FORMSET   *FormsetNode;
+
+  ASSERT (Hdr->Type == DynHiiNodeFormset);
+
+  FormsetNode = (DYN_HII_FORMSET *)Hdr;
+
+  ASSERT (FormsetNode->ClassGuidCount <= 3);
+
+  FormsetSize = sizeof (EFI_IFR_FORM_SET) + FormsetNode->ClassGuidCount * sizeof (EFI_GUID);
+  if (FormsetSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, FormsetSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                   = BufInfo->Data + BufInfo->Position;
+  Formset.Header.OpCode = EFI_IFR_FORM_SET_OP;
+  Formset.Header.Length = (UINT8)FormsetSize;
+  Formset.Header.Scope  = 1;
+
+  CopyMem (&Formset.Guid, &FormsetNode->FormsetGuid, sizeof (EFI_GUID));
+  Formset.FormSetTitle = FormsetNode->Title;
+  Formset.Help         = FormsetNode->Help;
+  Formset.Flags        = FormsetNode->ClassGuidCount & 0x3;
+
+  CopyMem (Buf, &Formset, sizeof (EFI_IFR_FORM_SET));
+  BufInfo->Position += sizeof (EFI_IFR_FORM_SET);
+
+  Buf = BufInfo->Data + BufInfo->Position;
+  for (Idx = 0; Idx < Formset.Flags; Idx++) {
+    CopyMem ((EFI_GUID *)Buf, &FormsetNode->ClassGuid[Idx], sizeof (EFI_GUID));
+    Buf               += sizeof (EFI_GUID);
+    BufInfo->Position += sizeof (EFI_GUID);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_CHECKBOX opcode into the IFR buffer.
+
+  Insert the EFI_IFR_CHECKBOX opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeCheckbox (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                   *Buf;
+  UINTN                   CheckboxSize;
+  EFI_STATUS              Status;
+  EFI_IFR_CHECKBOX        Checkbox;
+  DYN_HII_STATEMENT_DATA  *Data;
+  DYN_HII_STATEMENT       *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  Data          = &StatementNode->Data;
+
+  CheckboxSize = sizeof (EFI_IFR_CHECKBOX);
+  if (CheckboxSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, CheckboxSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Checkbox.Header.OpCode = EFI_IFR_CHECKBOX_OP;
+  Checkbox.Header.Length = (UINT8)CheckboxSize;
+  Checkbox.Header.Scope  = 1;
+
+  Checkbox.Question = Data->QuestionHdr;
+  Checkbox.Flags    = Data->Statement.Checkbox.Flags;
+
+  CopyMem (Buf, &Checkbox, sizeof (EFI_IFR_CHECKBOX));
+  BufInfo->Position += sizeof (EFI_IFR_CHECKBOX);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_ONE_OF opcode into the IFR buffer.
+
+  Insert the EFI_IFR_ONE_OF opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_INVALID_PARAMETER  Invalid data size.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeOneOf (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                   *Buf;
+  UINTN                   OneOfSize;
+  EFI_STATUS              Status;
+  EFI_IFR_ONE_OF          OneOf;
+  DYN_HII_ONE_OF_DATA     *OneOfData;
+  DYN_HII_STATEMENT_DATA  *Data;
+  DYN_HII_STATEMENT       *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  Data          = &StatementNode->Data;
+  OneOfData     = &Data->Statement.OneOf;
+
+  OneOfSize = sizeof (EFI_IFR_ONE_OF);
+  if (OneOfSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, OneOfSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                 = BufInfo->Data + BufInfo->Position;
+  OneOf.Header.OpCode = EFI_IFR_ONE_OF_OP;
+  OneOf.Header.Length = (UINT8)OneOfSize;
+  OneOf.Header.Scope  = 1;
+
+  OneOf.Question = Data->QuestionHdr;
+  OneOf.Flags    = OneOfData->Flags;
+
+  switch (OneOf.Flags & EFI_IFR_NUMERIC_SIZE) {
+    case EFI_IFR_NUMERIC_SIZE_1:
+      OneOf.data.u8.MinValue = (UINT8)OneOfData->MinValue;
+      OneOf.data.u8.MaxValue = (UINT8)OneOfData->MaxValue;
+      OneOf.data.u8.Step     = (UINT8)OneOfData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_2:
+      OneOf.data.u16.MinValue = (UINT16)OneOfData->MinValue;
+      OneOf.data.u16.MaxValue = (UINT16)OneOfData->MaxValue;
+      OneOf.data.u16.Step     = (UINT16)OneOfData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_4:
+      OneOf.data.u32.MinValue = (UINT32)OneOfData->MinValue;
+      OneOf.data.u32.MaxValue = (UINT32)OneOfData->MaxValue;
+      OneOf.data.u32.Step     = (UINT32)OneOfData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_8:
+      OneOf.data.u64.MinValue = (UINT64)OneOfData->MinValue;
+      OneOf.data.u64.MaxValue = (UINT64)OneOfData->MaxValue;
+      OneOf.data.u64.Step     = (UINT64)OneOfData->Step;
+      break;
+
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  CopyMem (Buf, &OneOf, sizeof (EFI_IFR_ONE_OF));
+  BufInfo->Position += sizeof (EFI_IFR_ONE_OF);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_NUMERIC opcode into the IFR buffer.
+
+  Insert the EFI_IFR_NUMERIC opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_INVALID_PARAMETER  Invalid data size.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeNumeric (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                   *Buf;
+  UINTN                   NumericSize;
+  EFI_STATUS              Status;
+  EFI_IFR_NUMERIC         Numeric;
+  DYN_HII_NUMERIC_DATA    *NumericData;
+  DYN_HII_STATEMENT_DATA  *Data;
+  DYN_HII_STATEMENT       *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  Data          = &StatementNode->Data;
+  NumericData   = &Data->Statement.Numeric;
+
+  NumericSize = sizeof (EFI_IFR_NUMERIC);
+  if (NumericSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, NumericSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                   = BufInfo->Data + BufInfo->Position;
+  Numeric.Header.OpCode = EFI_IFR_NUMERIC_OP;
+  Numeric.Header.Length = (UINT8)NumericSize;
+  Numeric.Header.Scope  = 1;
+
+  Numeric.Question = Data->QuestionHdr;
+  Numeric.Flags    = NumericData->Flags;
+
+  switch (Numeric.Flags & EFI_IFR_NUMERIC_SIZE) {
+    case EFI_IFR_NUMERIC_SIZE_1:
+      Numeric.data.u8.MinValue = (UINT8)NumericData->MinValue;
+      Numeric.data.u8.MaxValue = (UINT8)NumericData->MaxValue;
+      Numeric.data.u8.Step     = (UINT8)NumericData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_2:
+      Numeric.data.u16.MinValue = (UINT16)NumericData->MinValue;
+      Numeric.data.u16.MaxValue = (UINT16)NumericData->MaxValue;
+      Numeric.data.u16.Step     = (UINT16)NumericData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_4:
+      Numeric.data.u32.MinValue = (UINT32)NumericData->MinValue;
+      Numeric.data.u32.MaxValue = (UINT32)NumericData->MaxValue;
+      Numeric.data.u32.Step     = (UINT32)NumericData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_8:
+      Numeric.data.u64.MinValue = (UINT64)NumericData->MinValue;
+      Numeric.data.u64.MaxValue = (UINT64)NumericData->MaxValue;
+      Numeric.data.u64.Step     = (UINT64)NumericData->Step;
+      break;
+
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  CopyMem (Buf, &Numeric, sizeof (EFI_IFR_NUMERIC));
+  BufInfo->Position += sizeof (EFI_IFR_NUMERIC);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_REF opcode into the IFR buffer.
+
+  Insert the EFI_IFR_REF opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef1 (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8              *Buf;
+  UINTN              RefSize;
+  EFI_STATUS         Status;
+  EFI_IFR_REF        Ref;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  RefSize = sizeof (EFI_IFR_REF);
+  if (RefSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, RefSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf               = BufInfo->Data + BufInfo->Position;
+  Ref.Header.OpCode = EFI_IFR_REF_OP;
+  Ref.Header.Length = (UINT8)RefSize;
+  Ref.Header.Scope  = 0;
+
+  Ref.Question = StatementNode->Data.QuestionHdr;
+  Ref.FormId   = RefData->FormId;
+
+  CopyMem (Buf, &Ref, sizeof (EFI_IFR_REF));
+  BufInfo->Position += sizeof (EFI_IFR_REF);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_REF2 opcode into the IFR buffer.
+
+  Insert the EFI_IFR_REF2 opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef2 (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8              *Buf;
+  UINTN              RefSize;
+  EFI_STATUS         Status;
+  EFI_IFR_REF2       Ref;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  RefSize = sizeof (EFI_IFR_REF2);
+  if (RefSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, RefSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf               = BufInfo->Data + BufInfo->Position;
+  Ref.Header.OpCode = EFI_IFR_REF_OP;
+  Ref.Header.Length = (UINT8)RefSize;
+  Ref.Header.Scope  = 0;
+
+  Ref.Question   = StatementNode->Data.QuestionHdr;
+  Ref.FormId     = RefData->FormId;
+  Ref.QuestionId = RefData->QuestionId;
+
+  CopyMem (Buf, &Ref, sizeof (EFI_IFR_REF2));
+  BufInfo->Position += sizeof (EFI_IFR_REF2);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_REF3 opcode into the IFR buffer.
+
+  Insert the EFI_IFR_REF3 opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef3 (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8              *Buf;
+  UINTN              RefSize;
+  EFI_STATUS         Status;
+  EFI_IFR_REF3       Ref;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  RefSize = sizeof (EFI_IFR_REF3);
+  if (RefSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, RefSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf               = BufInfo->Data + BufInfo->Position;
+  Ref.Header.OpCode = EFI_IFR_REF_OP;
+  Ref.Header.Length = (UINT8)RefSize;
+  Ref.Header.Scope  = 0;
+
+  Ref.Question   = StatementNode->Data.QuestionHdr;
+  Ref.FormId     = RefData->FormId;
+  Ref.QuestionId = RefData->QuestionId;
+  CopyMem (&Ref.FormSetId, &RefData->FormSetGuid, sizeof (EFI_GUID));
+
+  CopyMem (Buf, &Ref, sizeof (EFI_IFR_REF3));
+  BufInfo->Position += sizeof (EFI_IFR_REF3);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_REF4 opcode into the IFR buffer.
+
+  Insert the EFI_IFR_REF4 opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef4 (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8              *Buf;
+  UINTN              RefSize;
+  EFI_STATUS         Status;
+  EFI_IFR_REF4       Ref;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  RefSize = sizeof (EFI_IFR_REF4);
+  if (RefSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, RefSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf               = BufInfo->Data + BufInfo->Position;
+  Ref.Header.OpCode = EFI_IFR_REF_OP;
+  Ref.Header.Length = (UINT8)RefSize;
+  Ref.Header.Scope  = 0;
+
+  Ref.Question   = StatementNode->Data.QuestionHdr;
+  Ref.FormId     = RefData->FormId;
+  Ref.QuestionId = RefData->QuestionId;
+  Ref.DevicePath = RefData->DevicePath;
+  CopyMem (&Ref.FormSetId, &RefData->FormSetGuid, sizeof (EFI_GUID));
+
+  CopyMem (Buf, &Ref, sizeof (EFI_IFR_REF4));
+  BufInfo->Position += sizeof (EFI_IFR_REF4);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_SUBTITLE opcode into the IFR buffer.
+
+  Insert the EFI_IFR_SUBTITLE opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeSubtitle (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                  *Buf;
+  UINTN                  SubtitleSize;
+  EFI_STATUS             Status;
+  EFI_IFR_SUBTITLE       Subtitle;
+  DYN_HII_SUBTITLE_DATA  *SubtitleData;
+  DYN_HII_STATEMENT      *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  SubtitleData  = &StatementNode->Data.Statement.Subtitle;
+
+  SubtitleSize = sizeof (EFI_IFR_SUBTITLE);
+  if (SubtitleSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, SubtitleSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Subtitle.Header.OpCode = EFI_IFR_SUBTITLE_OP;
+  Subtitle.Header.Length = (UINT8)SubtitleSize;
+  Subtitle.Header.Scope  = 0;
+
+  Subtitle.Statement.Prompt = SubtitleData->Prompt;
+  Subtitle.Statement.Help   = SubtitleData->Help;
+  Subtitle.Flags            = SubtitleData->Flags;
+
+  CopyMem (Buf, &Subtitle, sizeof (EFI_IFR_SUBTITLE));
+  BufInfo->Position += sizeof (EFI_IFR_SUBTITLE);
+
+  return EFI_SUCCESS;
+}
+
+/** Serialize the cross-reference statement data into the IFR buffer.
+
+  Check for the type of cross-reference statement and call the
+  appropriate function for serializing the ref data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_UNSUPPORTED        Currently unsupported Ref type.
+  @retval  EFI_INVALID_PARAMETER  Invalid Ref type.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS         Status;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  switch (RefData->RefType) {
+    case DynHiiRef1:
+      return DynHiiSerializeRef1 (Hdr, BufInfo);
+      break;
+
+    case DynHiiRef2:
+      Status = DynHiiSerializeRef2 (Hdr, BufInfo);
+      break;
+
+    case DynHiiRef3:
+      Status = DynHiiSerializeRef3 (Hdr, BufInfo);
+      break;
+
+    case DynHiiRef4:
+      return DynHiiSerializeRef4 (Hdr, BufInfo);
+      break;
+
+    case DynHiiRef5:
+      Status = EFI_UNSUPPORTED;
+      break;
+
+    default:
+      Status = EFI_INVALID_PARAMETER;
+      break;
+  }
+
+  return Status;
+}
+
+/** Serialize the statement/question data into the IFR buffer.
+
+  Check for the type of statement/question and call the appropriate
+  function for serializing the data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_INVALID_PARAMETER  Invalid statement type.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeStatement (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS         Status;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  ASSERT (Hdr->Type == DynHiiNodeStatement);
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+
+  switch (StatementNode->StatementType) {
+    case DynHiiStCheckbox:
+      ASSERT (Hdr->Scope == TRUE);
+      Status = DynHiiSerializeCheckbox (Hdr, BufInfo);
+      break;
+
+    case DynHiiStNumeric:
+      ASSERT (Hdr->Scope == TRUE);
+      Status = DynHiiSerializeNumeric (Hdr, BufInfo);
+      break;
+
+    case DynHiiStRef:
+      ASSERT (Hdr->Scope == FALSE);
+      Status = DynHiiSerializeRef (Hdr, BufInfo);
+      break;
+
+    case DynHiiStOneOf:
+      ASSERT (Hdr->Scope == TRUE);
+      Status = DynHiiSerializeOneOf (Hdr, BufInfo);
+      break;
+
+    case DynHiiStSubtitle:
+      ASSERT (Hdr->Scope == FALSE);
+      Status = DynHiiSerializeSubtitle (Hdr, BufInfo);
+      break;
+
+    default:
+      Status = EFI_INVALID_PARAMETER;
+      break;
+  }
+
+  return Status;
+}
+
+/** Insert the EFI_IFR_ONE_OF_OPTION opcode into the IFR buffer.
+
+  Insert the EFI_IFR_ONE_OF_OPTION opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeOption (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                  *Buf;
+  UINTN                  OptionSize;
+  EFI_STATUS             Status;
+  EFI_IFR_ONE_OF_OPTION  Option;
+  DYN_HII_ONE_OF_OPTION  *OptionNode;
+
+  OptionNode = (DYN_HII_ONE_OF_OPTION *)Hdr;
+
+  OptionSize = sizeof (EFI_IFR_ONE_OF_OPTION);
+  if (OptionSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, OptionSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  Option.Header.OpCode = EFI_IFR_ONE_OF_OPTION_OP;
+  Option.Header.Length = (UINT8)OptionSize;
+  Option.Header.Scope  = 0;
+
+  Option.Option = OptionNode->Text;
+  Option.Flags  = OptionNode->Flags;
+  Option.Type   = OptionNode->Type;
+  Option.Value  = OptionNode->Value;
+
+  CopyMem (Buf, &Option, sizeof (EFI_IFR_ONE_OF_OPTION));
+  BufInfo->Position += sizeof (EFI_IFR_ONE_OF_OPTION);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_DEFAULT opcode into the IFR buffer.
+
+  Insert the EFI_IFR_DEFAULT opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeDefault (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8            *Buf;
+  UINTN            DefaultSize;
+  EFI_STATUS       Status;
+  EFI_IFR_DEFAULT  Default;
+  DYN_HII_DEFAULT  *DefaultNode;
+
+  DefaultNode = (DYN_HII_DEFAULT *)Hdr;
+
+  DefaultSize = sizeof (EFI_IFR_DEFAULT);
+  if (DefaultSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, DefaultSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  Default.Header.OpCode = EFI_IFR_DEFAULT_OP;
+  Default.Header.Length = (UINT8)DefaultSize;
+  Default.Header.Scope  = 0;
+
+  Default.DefaultId = DefaultNode->DefaultId;
+  Default.Type      = DefaultNode->Type;
+  Default.Value     = DefaultNode->Value;
+
+  CopyMem (Buf, &Default, sizeof (EFI_IFR_DEFAULT));
+  BufInfo->Position += sizeof (EFI_IFR_DEFAULT);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_DEFAULTSTORE opcode into the IFR buffer.
+
+  In absence of an explicit addition of a defaultstore, insert the implicit
+  EFI_IFR_DEFAULTSTORE opcode data into the IFR buffer.
+
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiAddImplicitDefaultstores (
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                 Idx;
+  UINT8                 *Buf;
+  UINT32                DefaultstoreSize;
+  EFI_STATUS            Status;
+  EFI_IFR_DEFAULTSTORE  Defaultstore;
+
+  DefaultstoreSize = 2 * sizeof (EFI_IFR_DEFAULTSTORE);
+  Status           = DynHiiIfrBufferSizeCheck (BufInfo, DefaultstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  DefaultstoreSize = sizeof (EFI_IFR_DEFAULTSTORE);
+  if (DefaultstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  Defaultstore.Header.OpCode = EFI_IFR_DEFAULTSTORE_OP;
+  Defaultstore.Header.Length = (UINT8)DefaultstoreSize;
+  Defaultstore.Header.Scope  = 0;
+
+  Defaultstore.DefaultName = 0x0;
+  for (Idx = 0; Idx < 2; Idx++) {
+    Defaultstore.DefaultId = Idx;
+
+    CopyMem (Buf, &Defaultstore, sizeof (EFI_IFR_DEFAULTSTORE));
+    Buf               += sizeof (EFI_IFR_DEFAULTSTORE);
+    BufInfo->Position += sizeof (EFI_IFR_DEFAULTSTORE);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_DEFAULTSTORE opcode into the IFR buffer.
+
+  Insert the EFI_IFR_DEFAULTSTORE opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeDefaultstore (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                 *Buf;
+  UINTN                 DefaultstoreSize;
+  EFI_STATUS            Status;
+  EFI_IFR_DEFAULTSTORE  Defaultstore;
+  DYN_HII_DEFAULTSTORE  *DefaultstoreNode;
+
+  DefaultstoreNode = (DYN_HII_DEFAULTSTORE *)Hdr;
+
+  DefaultstoreSize = sizeof (EFI_IFR_DEFAULTSTORE);
+  if (DefaultstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, DefaultstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  Defaultstore.Header.OpCode = EFI_IFR_DEFAULTSTORE_OP;
+  Defaultstore.Header.Length = (UINT8)DefaultstoreSize;
+  Defaultstore.Header.Scope  = 0;
+
+  Defaultstore.DefaultName = DefaultstoreNode->DefaultName;
+  Defaultstore.DefaultId   = DefaultstoreNode->DefaultId;
+
+  CopyMem (Buf, &Defaultstore, sizeof (EFI_IFR_DEFAULTSTORE));
+  BufInfo->Position += sizeof (EFI_IFR_DEFAULTSTORE);
+
+  return EFI_SUCCESS;
+}
+
+/** Serialize the given HII node.
+
+  Check for the type of the node, and call the appropriate function for
+  inserting the opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_UNSUPPORTED        The node is currently unsupported.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+DynHiiSerializeNode (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  switch (Hdr->Type) {
+    case DynHiiNodeFormset:
+      Status = DynHiiSerializeFormset (Hdr, BufInfo);
+      break;
+
+    case DynHiiNodeVarstore:
+      Status = DynHiiSerializeVarstore (Hdr, BufInfo);
+      break;
+
+    case DynHiiNodeForm:
+      Status = DynHiiSerializeForm (Hdr, BufInfo);
+      break;
+
+    case DynHiiNodeStatement:
+      Status = DynHiiSerializeStatement (Hdr, BufInfo);
+      break;
+
+    case DynHiiNodeOption:
+      Status = DynHiiSerializeOption (Hdr, BufInfo);
+      break;
+
+    case DynHiiNodeDefault:
+      Status = DynHiiSerializeDefault (Hdr, BufInfo);
+      break;
+
+    case DynHiiNodeDefaultStore:
+      Status = DynHiiSerializeDefaultstore (Hdr, BufInfo);
+      break;
+
+    default:
+      Status = EFI_UNSUPPORTED;
+      break;
+  }
+
+  return Status;
+}
+
+/** Iterate the default list.
+
+  Iterate through the default list, and for each node found, call the function
+  to serialize the node data into the IFR buffer.
+
+  @param [in]  DefaultList        List of default nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the serialization function.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateDefaultList (
+  IN  CONST LIST_ENTRY          *DefaultList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  LIST_ENTRY       *Link;
+  EFI_STATUS       Status;
+  DYN_HII_DEFAULT  *Default;
+
+  Link = GetFirstNode (DefaultList);
+  while (!IsNull (DefaultList, Link)) {
+    Default = BASE_CR (Link, DYN_HII_DEFAULT, Hdr.Link);
+
+    Status = DynHiiSerializeNode (&Default->Hdr, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (DefaultList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Iterate the option list.
+
+  Iterate through the option list, and for each node found, call the function
+  to serialize the node data into the IFR buffer.
+
+  @param [in]  OptionList         List of option nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the serialization function.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateOptionList (
+  IN  CONST LIST_ENTRY          *OptionList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  LIST_ENTRY             *Link;
+  EFI_STATUS             Status;
+  DYN_HII_ONE_OF_OPTION  *Option;
+
+  Link = GetFirstNode (OptionList);
+  while (!IsNull (OptionList, Link)) {
+    Option = BASE_CR (Link, DYN_HII_ONE_OF_OPTION, Hdr.Link);
+
+    Status = DynHiiSerializeNode (&Option->Hdr, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (OptionList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Process the statement/question node.
+
+  Serialize the statement/question node data by calling the corresponding
+  function. Check for any question defaults, and process them if present.
+  Finally, add the end opcode for the statement if the statement is scoped.
+
+  @param [in]  Statement          Statement/Question to be processed.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the processing was successfull or any error code
+                        returned by the serialization functions.
+
+**/
+static
+EFI_STATUS
+DynHiiProcessStatement (
+  IN  CONST DYN_HII_STATEMENT   *Statement,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DynHiiSerializeNode (&Statement->Hdr, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (!IsListEmpty (&Statement->OptionList)) {
+    Status = DynHiiIterateOptionList (&Statement->OptionList, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  if (!IsListEmpty (&Statement->DefaultList)) {
+    Status = DynHiiIterateDefaultList (&Statement->DefaultList, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  return DynHiiInsertEndOp (&Statement->Hdr, BufInfo);
+}
+
+/** Iterate the statement list.
+
+  Iterate through the statement list, and for each node found, call the
+  function to serialize the process the node data.
+
+  @param [in]  StatementList      List of statement nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the processing was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateStatementList (
+  IN  CONST LIST_ENTRY          *StatementList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS         Status;
+  LIST_ENTRY         *Link;
+  DYN_HII_STATEMENT  *Statement;
+
+  Link = GetFirstNode (StatementList);
+  while (!IsNull (StatementList, Link)) {
+    Statement = BASE_CR (Link, DYN_HII_STATEMENT, Hdr.Link);
+
+    Status = DynHiiProcessStatement (Statement, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (StatementList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Process the form node.
+
+  Serialize the form node data by calling the corresponding function. Process
+  the Statements under the form. Finally, add the end opcode for the form.
+
+  @param [in]  Form               Pointer to the Form node.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the processing was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiProcessForm (
+  IN  CONST DYN_HII_FORM        *Form,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DynHiiSerializeNode (&Form->Hdr, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = DynHiiIterateStatementList (&Form->StatementList, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return DynHiiInsertEndOp (&Form->Hdr, BufInfo);
+}
+
+/** Iterate the varstore list.
+
+  Iterate through the varstore list, and for each node found, call the function
+  to serialize the node data into the IFR buffer.
+
+  @param [in]  VarstoreList       List of default nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the serialization function.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateVarstoreList (
+  IN  CONST LIST_ENTRY          *VarstoreList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS        Status;
+  LIST_ENTRY        *Link;
+  DYN_HII_VARSTORE  *Varstore;
+
+  Link = GetFirstNode (VarstoreList);
+  while (!IsNull (VarstoreList, Link)) {
+    Varstore = BASE_CR (Link, DYN_HII_VARSTORE, Hdr.Link);
+
+    Status = DynHiiSerializeNode (&Varstore->Hdr, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (VarstoreList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Iterate the form list.
+
+  Iterate through the form list, and for each node found, call the function
+  to process the form.
+
+  @param [in]  FormList           List of form nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateFormList (
+  IN  CONST LIST_ENTRY          *FormList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS    Status;
+  LIST_ENTRY    *Link;
+  DYN_HII_FORM  *Form;
+
+  Link = GetFirstNode (FormList);
+  while (!IsNull (FormList, Link)) {
+    Form = BASE_CR (Link, DYN_HII_FORM, Hdr.Link);
+
+    Status = DynHiiProcessForm (Form, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (FormList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Iterate the default store list.
+
+  Iterate through the default store list, and for each node found, call the
+  function to serialize the node into the IFR buffer.
+
+  @param [in]  DefaultstoreList   List of default store nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateDefaultstoreList (
+  IN  CONST LIST_ENTRY          *DefaultstoreList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS            Status;
+  LIST_ENTRY            *Link;
+  DYN_HII_DEFAULTSTORE  *Defaultstore;
+
+  Link = GetFirstNode (DefaultstoreList);
+  while (!IsNull (DefaultstoreList, Link)) {
+    Defaultstore = BASE_CR (Link, DYN_HII_DEFAULTSTORE, Hdr.Link);
+
+    Status = DynHiiSerializeNode (&Defaultstore->Hdr, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (DefaultstoreList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Process the formset node.
+
+  Serialize the formset node data by calling the corresponding function. Process
+  the child nodes of the formset, like varstores, forms. Finally, insert the
+  end opcode into the IFR buffer.
+
+  @param [in]  Formset            Pointer to the formset node.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the processing was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiProcessFormset (
+  IN  CONST DYN_HII_FORMSET     *Formset,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DynHiiSerializeNode (&Formset->Hdr, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (!IsListEmpty (&Formset->DefaultstoreList)) {
+    Status = DynHiiIterateDefaultstoreList (
+               &Formset->DefaultstoreList,
+               BufInfo
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  } else {
+    Status = DynHiiAddImplicitDefaultstores (BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  Status = DynHiiIterateVarstoreList (&Formset->VarstoreList, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = DynHiiIterateFormList (&Formset->FormList, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return DynHiiInsertEndOp (&Formset->Hdr, BufInfo);
+}
+
+/** Initialize the Form Package header.
+
+  Initialize the EFI_HII_PACKAGE_HEADER for the forms package.
+
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+  @param [in]  Length             Length of the Forms package, including the
+                                  preceding four bytes for array length.
+
+**/
+static
+VOID
+DynHiiInitFormPkgHdr (
+  IN  DYN_HII_IFR_BUFFER  *BufInfo,
+  IN  UINT32              Length
+  )
+{
+  UINT8                   *PkgHdr;
+  UINT32                  *Buf;
+  EFI_HII_PACKAGE_HEADER  Hdr;
+
+  Buf  = (UINT32 *)BufInfo->Data;
+  *Buf = Length;
+
+  PkgHdr     = BufInfo->Data + sizeof (UINT32);
+  Hdr.Length = Length - sizeof (UINT32);
+  Hdr.Type   = EFI_HII_PACKAGE_FORMS;
+
+  CopyMem (PkgHdr, &Hdr, sizeof (EFI_HII_PACKAGE_HEADER));
+}
+
+/** Dump the contents of the IFR buffer.
+
+  Useful for debugging.
+
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+**/
+static
+VOID
+DumpIfrBuffer (
+  IN      DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8   *Buf;
+  UINT32  Idx;
+  UINT32  Idx1;
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "INFO: %a: IfrBuf->Data => %p, "
+    "IfrBuf->Size => 0x%x, IfrBuf->Position => 0x%x\n",
+    __func__,
+    BufInfo->Data,
+    BufInfo->Size,
+    BufInfo->Position
+    ));
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "***** Generated IFR Byte Stream *****\n"
+    ));
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "IfrByteStream[] = {\n"
+    ));
+
+  Buf = BufInfo->Data;
+  for (Idx = 0; Idx < 4; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n\n"));
+
+  for (Idx = 0; Idx < 4; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n\n"));
+
+  for (Idx = 0; Idx < BufInfo->Size - 8;) {
+    for (Idx1 = 0; Idx < (BufInfo->Size - 8) && Idx1 < 16; Idx1++, Idx++) {
+      DEBUG ((
+        DEBUG_VERBOSE,
+        "0x%02x, ",
+        *Buf++
+        ));
+    }
+
+    DEBUG ((DEBUG_VERBOSE, "\n"));
+  }
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "};\n\n"
+    ));
+}
+
+/** Generate the IFR byte-stream for the Formset.
+
+  Serialize the Formset and it's child nodes to generate an IFR byte-stream
+  based Form package. This can then be added to the HII database through the
+  HiiAddPackages() call.
+
+  @param [in]  FormsetHandle      The formset hierarchy that needs to be
+                                  serialized.
+  @param [out] IfrHandle          Handle of the IFR buffer structure.
+  @param [out] IfrBuf             Pointer to the IFR data buffer.
+
+  @retval  EFI_SUCCESS            The Default was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiGenerateFormPackage (
+  IN  CONST DYN_HII_HANDLE  FormsetHandle,
+  OUT       DYN_HII_HANDLE  *IfrHandle,
+  OUT       UINT8           **IfrBuf
+  )
+{
+  UINT8               *Buf;
+  EFI_STATUS          Status;
+  DYN_HII_FORMSET     *Formset;
+  DYN_HII_IFR_BUFFER  *BufInfo;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset) ||
+      (IfrBuf == NULL) || (IfrHandle == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = DynHiiInitIfrByteBuffer (&BufInfo);
+  if (Status == EFI_OUT_OF_RESOURCES) {
+    return Status;
+  }
+
+  Status = DynHiiProcessFormset (Formset, BufInfo);
+  if (EFI_ERROR (Status)) {
+    goto err_handle;
+  } else {
+    Buf = ReallocatePool (
+            BufInfo->Size,
+            BufInfo->Position,
+            BufInfo->Data
+            );
+    if (Buf == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto err_handle;
+    }
+
+    BufInfo->Data = Buf;
+    BufInfo->Size = BufInfo->Position;
+    DynHiiInitFormPkgHdr (BufInfo, BufInfo->Size);
+    *IfrBuf    = BufInfo->Data;
+    *IfrHandle = BufInfo;
+  }
+
+  DumpIfrBuffer (BufInfo);
+
+  return EFI_SUCCESS;
+
+err_handle:
+  if (BufInfo->Data != NULL) {
+    FreePool (BufInfo->Data);
+  }
+
+  FreePool (BufInfo);
+
+  return Status;
+}
+
+/** Free up all the memory used by a Form package.
+
+  Free up all the memory that had been allocated for the Form package which
+  keeps the serialized IFR byte-stream for the formset.
+
+  @param [in]  IfrHandle           Pointer to DYN_HII_IFR_BUFFER.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeFormPackage (
+  IN  DYN_HII_HANDLE  IfrHandle
+  )
+{
+  DYN_HII_IFR_BUFFER  *IfrBuf;
+
+  if (IfrHandle == NULL) {
+    return;
+  }
+
+  IfrBuf = IfrHandle;
+
+  FreePool (IfrBuf->Data);
+  FreePool (IfrBuf);
+}

--- a/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormSerialize.c
+++ b/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormSerialize.c
@@ -1,0 +1,2089 @@
+/** @file
+  Dynamic Hii Form Serialization API functions
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - UEFI specification 2.11, section 33.3.8 Forms Package
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "InternalHiiFormsLib.h"
+
+#define MAX_FORM_PACKAGE_SIZE  (SIZE_16MB + sizeof (UINT32))
+
+/** The initial buffer size allocated for the
+    IFR byte-stream.
+*/
+#define IFR_INITIAL_BUFFER_SIZE  1024
+
+/** The max length of an HII opcode.
+*/
+#define MAX_HII_OPCODE_LENGTH  127
+
+/** Re-size the IFR byte-stream buffer.
+
+  Re-size the IFR byte-stream buffer to accommodate the TotalSize passed to
+  the function.
+
+  @param [in]  BufInfo          IFR buffer data structure pointer.
+  @param [in]  TotalSize        Minimum number of bytes that the function should
+                                allocate.
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_BAD_BUFFER_SIZE    Requested size overflows.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiResizeIfrByteBuffer (
+  IN       DYN_HII_IFR_BUFFER  *BufInfo,
+  IN       UINT32              TotalSize
+  )
+{
+  UINT8   *Buf;
+  UINT64  NewSize;
+
+  /// Try to double the size of the buffer, but
+  /// do not exceed max allowed form package size
+
+  NewSize = MIN ((UINT64)BufInfo->Size * 2, MAX_FORM_PACKAGE_SIZE);
+
+  /// Now take the max of the requested size and
+  /// the size computed above.
+  NewSize = MAX (TotalSize, NewSize);
+
+  Buf = ReallocatePool (BufInfo->Size, NewSize, BufInfo->Data);
+  if (Buf == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  BufInfo->Data = Buf;
+  BufInfo->Size = (UINT32)NewSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Check if the IFR byte buffer is large enough.
+
+  Check if the IFR byte buffer is large enough to hold Size bytes. If not,
+  call the function to re-allocate the sufficient number of bytes.
+
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+  @param [in]  Size               The number of bytes that the buffer should
+                                  be able to hold.
+
+  @retval  EFI_SUCCESS            The IFR buffer is large enough, or the re-size
+                                  operation was successfull.
+  @retval  EFI_BAD_BUFFER_SIZE    Requested size overflows.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiIfrBufferSizeCheck (
+  IN       DYN_HII_IFR_BUFFER  *BufInfo,
+  IN       UINT32              Size
+  )
+{
+  UINT64  NewSize;
+
+  if (BufInfo->Size - BufInfo->Position >= Size) {
+    return EFI_SUCCESS;
+  }
+
+  NewSize = BufInfo->Size + Size;
+  if (NewSize >= MAX_FORM_PACKAGE_SIZE) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  return DynHiiResizeIfrByteBuffer (BufInfo, (UINT32)NewSize);
+}
+
+/** Initialize the IFR byte-stream buffer.
+
+  Initialize the IFR byte-stream buffer with IFR_INITIAL_BUFFER_SIZE bytes.
+  Also allocate memory for DYN_HII_IFR_BUFFER structure which holds the IFR
+  buffer.
+
+  @param [out]  Buf               Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The varstore was created successfully.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiInitIfrByteBuffer (
+  OUT DYN_HII_IFR_BUFFER  *Buf
+  )
+{
+  Buf->Data = AllocateZeroPool (IFR_INITIAL_BUFFER_SIZE);
+  if (Buf->Data == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Buf->Size     = IFR_INITIAL_BUFFER_SIZE;
+  Buf->Position = sizeof (UINT32) + sizeof (EFI_HII_PACKAGE_HEADER);
+
+  return EFI_SUCCESS;
+}
+
+/** Invoke the function to serialize the given node.
+
+  Based on the parameters passed to the function, invoke the serializing
+  function that has been registered.
+
+  @param [in]  Table            Table of serializing functions.
+  @param [in]  TableCount       Total count of functions in the table.
+  @param [in]  Type             Index in the table array that is to be invoked.
+  @param [in]  Hdr              Pointer to the node header to be serialized.
+  @param [in]  BufInfo          Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The serialization function was called successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_UNSUPPORTED        The node type to be serialized does not currently
+                                  have a serialization function added.
+
+**/
+static
+EFI_STATUS
+DynHiiDispatchSerializeHandler (
+  IN  CONST DYN_HII_SERIALIZE_FN  *Table,
+  IN        UINTN                 TableCount,
+  IN        UINTN                 Type,
+  IN  CONST DYN_HII_NODE_HDR      *Hdr,
+  IN        DYN_HII_IFR_BUFFER    *BufInfo
+  )
+{
+  DYN_HII_SERIALIZE_FN  Handler;
+
+  if ((Table == NULL) || (Hdr == NULL) || (BufInfo == NULL) ||
+      (Type == 0) || (Type >= TableCount))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Handler = Table[Type];
+  if (Handler == NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  return Handler (Hdr, BufInfo);
+}
+
+/** Insert the EFI_IFR_END opcode into the IFR buffer.
+
+  Insert the EFI_IFR_END opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiInsertEndOp (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8        *Buf;
+  UINT32       EndSize;
+  EFI_STATUS   Status;
+  EFI_IFR_END  End;
+
+  if (Hdr->Scope == 0) {
+    return EFI_SUCCESS;
+  }
+
+  EndSize = sizeof (EFI_IFR_END);
+  if (EndSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, EndSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  End.Header.OpCode = EFI_IFR_END_OP;
+  End.Header.Length = (UINT8)EndSize;
+  End.Header.Scope  = 0;
+
+  CopyMem (Buf, &End, sizeof (EFI_IFR_END));
+  BufInfo->Position += sizeof (EFI_IFR_END);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_VARSTORE opcode into the IFR buffer.
+
+  Insert the EFI_IFR_VARSTORE opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeVarstoreBuffer (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                         *Buf;
+  UINT32                        StrSize;
+  UINT32                        VarstoreSize;
+  EFI_STATUS                    Status;
+  EFI_IFR_VARSTORE              Varstore;
+  DYN_HII_VARSTORE              *VarstoreNode;
+  DYN_HII_VARSTORE_BUFFER_DATA  *VarstoreBuf;
+
+  VarstoreNode = (DYN_HII_VARSTORE *)Hdr;
+  VarstoreBuf  = &VarstoreNode->Data.Buffer;
+  StrSize      = (UINT32)AsciiStrSize (VarstoreBuf->Name);
+  VarstoreSize = OFFSET_OF (EFI_IFR_VARSTORE, Name) + StrSize;
+  if (VarstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, VarstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Varstore.Header.OpCode = EFI_IFR_VARSTORE_OP;
+  Varstore.Header.Length = (UINT8)VarstoreSize;
+  Varstore.Header.Scope  = 0;
+  CopyMem (&Varstore.Guid, &VarstoreBuf->Guid, sizeof (EFI_GUID));
+  Varstore.VarStoreId = VarstoreBuf->VarstoreId;
+  Varstore.Size       = VarstoreBuf->Size;
+
+  CopyMem (Buf, &Varstore, OFFSET_OF (EFI_IFR_VARSTORE, Name));
+  BufInfo->Position += OFFSET_OF (EFI_IFR_VARSTORE, Name);
+  Buf               += OFFSET_OF (EFI_IFR_VARSTORE, Name);
+
+  Status = AsciiStrCpyS ((CHAR8 *)Buf, StrSize, VarstoreBuf->Name);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  BufInfo->Position += StrSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_VARSTORE_EFI opcode into the IFR buffer.
+
+  Insert the EFI_IFR_VARSTORE_EFI opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeVarstoreEfi (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                      *Buf;
+  UINT32                     StrSize;
+  UINT32                     VarstoreSize;
+  EFI_STATUS                 Status;
+  EFI_IFR_VARSTORE_EFI       Varstore;
+  DYN_HII_VARSTORE           *VarstoreNode;
+  DYN_HII_VARSTORE_EFI_DATA  *VarstoreEfi;
+
+  VarstoreNode = (DYN_HII_VARSTORE *)Hdr;
+  VarstoreEfi  = &VarstoreNode->Data.Efi;
+  StrSize      = (UINT32)AsciiStrSize (VarstoreEfi->Name);
+  VarstoreSize = OFFSET_OF (EFI_IFR_VARSTORE_EFI, Name) + StrSize;
+  if (VarstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, VarstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Varstore.Header.OpCode = EFI_IFR_VARSTORE_EFI_OP;
+  Varstore.Header.Length = (UINT8)VarstoreSize;
+  Varstore.Header.Scope  = 0;
+  CopyMem (&Varstore.Guid, &VarstoreEfi->Guid, sizeof (EFI_GUID));
+  Varstore.VarStoreId = VarstoreEfi->VarstoreId;
+  Varstore.Attributes = VarstoreEfi->Attributes;
+  Varstore.Size       = VarstoreEfi->Size;
+
+  CopyMem (Buf, &Varstore, OFFSET_OF (EFI_IFR_VARSTORE_EFI, Name));
+  BufInfo->Position += OFFSET_OF (EFI_IFR_VARSTORE_EFI, Name);
+  Buf               += OFFSET_OF (EFI_IFR_VARSTORE_EFI, Name);
+
+  Status = AsciiStrCpyS ((CHAR8 *)Buf, StrSize, VarstoreEfi->Name);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  BufInfo->Position += StrSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_VARSTORE_NAME_VALUE opcode into the IFR buffer.
+
+  Insert the EFI_IFR_VARSTORE_NAME_VALUE opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeVarstoreNameValue (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                             *Buf;
+  UINT32                            VarstoreSize;
+  EFI_STATUS                        Status;
+  EFI_IFR_VARSTORE_NAME_VALUE       Varstore;
+  DYN_HII_VARSTORE                  *VarstoreNode;
+  DYN_HII_VARSTORE_NAME_VALUE_DATA  *VarstoreNameValue;
+
+  VarstoreNode      = (DYN_HII_VARSTORE *)Hdr;
+  VarstoreNameValue = &VarstoreNode->Data.NameValue;
+  VarstoreSize      = sizeof (EFI_IFR_VARSTORE_NAME_VALUE);
+  if (VarstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, VarstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Varstore.Header.OpCode = EFI_IFR_VARSTORE_NAME_VALUE_OP;
+  Varstore.Header.Length = (UINT8)VarstoreSize;
+  Varstore.Header.Scope  = 0;
+  CopyMem (&Varstore.Guid, &VarstoreNameValue->Guid, sizeof (EFI_GUID));
+  Varstore.VarStoreId = VarstoreNameValue->VarstoreId;
+
+  CopyMem (Buf, &Varstore, sizeof (EFI_IFR_VARSTORE_NAME_VALUE));
+  BufInfo->Position += sizeof (EFI_IFR_VARSTORE_NAME_VALUE);
+
+  return EFI_SUCCESS;
+}
+
+/** Serialize the varstore data into the IFR buffer.
+
+  Check for the type of varstore and call the appropriate function for
+  serializing the varstore data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_INVALID_PARAMETER  Invalid varstore type.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeVarstore (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  CONST DYN_HII_VARSTORE             *VarstoreNode;
+  static CONST DYN_HII_SERIALIZE_FN  VarstoreSerializers[DynHiiVarstoreMax] = {
+    NULL,                               // 0 is invalid
+    DynHiiSerializeVarstoreBuffer,      // DynHiiVarstoreBuffer
+    DynHiiSerializeVarstoreEfi,         // DynHiiVarstoreEfi
+    DynHiiSerializeVarstoreNameValue    // DynHiiVarstoreNameValue
+  };
+
+  if ((Hdr == NULL) || (Hdr->Type != DynHiiNodeVarstore)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  VarstoreNode = (CONST DYN_HII_VARSTORE *)Hdr;
+  if (VarstoreNode->VarstoreType == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return DynHiiDispatchSerializeHandler (
+           VarstoreSerializers,
+           ARRAY_SIZE (VarstoreSerializers),
+           VarstoreNode->VarstoreType,
+           Hdr,
+           BufInfo
+           );
+}
+
+/** Insert the EFI_IFR_FORM opcode into the IFR buffer.
+
+  Insert the EFI_IFR_FORM opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeForm (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8         *Buf;
+  UINT32        FormSize;
+  EFI_STATUS    Status;
+  EFI_IFR_FORM  Form;
+  DYN_HII_FORM  *FormNode;
+
+  ASSERT (Hdr->Type == DynHiiNodeForm);
+
+  FormNode = (DYN_HII_FORM *)Hdr;
+
+  FormSize = sizeof (EFI_IFR_FORM);
+  if (FormSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, FormSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                = BufInfo->Data + BufInfo->Position;
+  Form.Header.OpCode = EFI_IFR_FORM_OP;
+  Form.Header.Length = (UINT8)FormSize;
+  Form.Header.Scope  = 1;
+
+  Form.FormId    = FormNode->FormId;
+  Form.FormTitle = FormNode->Title;
+
+  CopyMem (Buf, &Form, sizeof (EFI_IFR_FORM));
+  BufInfo->Position += sizeof (EFI_IFR_FORM);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_FORM_SET opcode into the IFR buffer.
+
+  Insert the EFI_IFR_FORM_SET opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeFormset (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8             *Buf;
+  UINT8             Idx;
+  UINT32            FormsetSize;
+  EFI_STATUS        Status;
+  EFI_IFR_FORM_SET  Formset;
+  DYN_HII_FORMSET   *FormsetNode;
+
+  ASSERT (Hdr->Type == DynHiiNodeFormset);
+
+  FormsetNode = (DYN_HII_FORMSET *)Hdr;
+
+  ASSERT (FormsetNode->ClassGuidCount <= 3);
+
+  FormsetSize = sizeof (EFI_IFR_FORM_SET) + FormsetNode->ClassGuidCount * sizeof (EFI_GUID);
+  if (FormsetSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, FormsetSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                   = BufInfo->Data + BufInfo->Position;
+  Formset.Header.OpCode = EFI_IFR_FORM_SET_OP;
+  Formset.Header.Length = (UINT8)FormsetSize;
+  Formset.Header.Scope  = 1;
+
+  CopyMem (&Formset.Guid, &FormsetNode->FormsetGuid, sizeof (EFI_GUID));
+  Formset.FormSetTitle = FormsetNode->Title;
+  Formset.Help         = FormsetNode->Help;
+  Formset.Flags        = FormsetNode->ClassGuidCount & 0x3;
+
+  CopyMem (Buf, &Formset, sizeof (EFI_IFR_FORM_SET));
+  BufInfo->Position += sizeof (EFI_IFR_FORM_SET);
+
+  Buf = BufInfo->Data + BufInfo->Position;
+  for (Idx = 0; Idx < Formset.Flags; Idx++) {
+    CopyMem ((EFI_GUID *)Buf, &FormsetNode->ClassGuid[Idx], sizeof (EFI_GUID));
+    Buf               += sizeof (EFI_GUID);
+    BufInfo->Position += sizeof (EFI_GUID);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_CHECKBOX opcode into the IFR buffer.
+
+  Insert the EFI_IFR_CHECKBOX opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeCheckbox (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                   *Buf;
+  UINT32                  CheckboxSize;
+  EFI_STATUS              Status;
+  EFI_IFR_CHECKBOX        Checkbox;
+  DYN_HII_STATEMENT_DATA  *Data;
+  DYN_HII_STATEMENT       *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  Data          = &StatementNode->Data;
+
+  CheckboxSize = sizeof (EFI_IFR_CHECKBOX);
+  if (CheckboxSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, CheckboxSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Checkbox.Header.OpCode = EFI_IFR_CHECKBOX_OP;
+  Checkbox.Header.Length = (UINT8)CheckboxSize;
+  Checkbox.Header.Scope  = 1;
+
+  Checkbox.Question = Data->QuestionHdr;
+  Checkbox.Flags    = Data->Statement.Checkbox.Flags;
+
+  CopyMem (Buf, &Checkbox, sizeof (EFI_IFR_CHECKBOX));
+  BufInfo->Position += sizeof (EFI_IFR_CHECKBOX);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_ONE_OF opcode into the IFR buffer.
+
+  Insert the EFI_IFR_ONE_OF opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_INVALID_PARAMETER  Invalid data size.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeOneOf (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                   *Buf;
+  UINT32                  OneOfSize;
+  EFI_STATUS              Status;
+  EFI_IFR_ONE_OF          OneOf;
+  DYN_HII_ONE_OF_DATA     *OneOfData;
+  DYN_HII_STATEMENT_DATA  *Data;
+  DYN_HII_STATEMENT       *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  Data          = &StatementNode->Data;
+  OneOfData     = &Data->Statement.OneOf;
+
+  OneOfSize = OFFSET_OF (EFI_IFR_ONE_OF, data);
+  switch (OneOfData->Flags & EFI_IFR_NUMERIC_SIZE) {
+    case EFI_IFR_NUMERIC_SIZE_1:
+      OneOfSize += sizeof (OneOf.data.u8);
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_2:
+      OneOfSize += sizeof (OneOf.data.u16);
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_4:
+      OneOfSize += sizeof (OneOf.data.u32);
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_8:
+      OneOfSize += sizeof (OneOf.data.u64);
+      break;
+
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  if (OneOfSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, OneOfSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                 = BufInfo->Data + BufInfo->Position;
+  OneOf.Header.OpCode = EFI_IFR_ONE_OF_OP;
+  OneOf.Header.Length = (UINT8)OneOfSize;
+  OneOf.Header.Scope  = 1;
+
+  OneOf.Question = Data->QuestionHdr;
+  OneOf.Flags    = OneOfData->Flags;
+
+  switch (OneOf.Flags & EFI_IFR_NUMERIC_SIZE) {
+    case EFI_IFR_NUMERIC_SIZE_1:
+      OneOf.data.u8.MinValue = (UINT8)OneOfData->MinValue;
+      OneOf.data.u8.MaxValue = (UINT8)OneOfData->MaxValue;
+      OneOf.data.u8.Step     = (UINT8)OneOfData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_2:
+      OneOf.data.u16.MinValue = (UINT16)OneOfData->MinValue;
+      OneOf.data.u16.MaxValue = (UINT16)OneOfData->MaxValue;
+      OneOf.data.u16.Step     = (UINT16)OneOfData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_4:
+      OneOf.data.u32.MinValue = (UINT32)OneOfData->MinValue;
+      OneOf.data.u32.MaxValue = (UINT32)OneOfData->MaxValue;
+      OneOf.data.u32.Step     = (UINT32)OneOfData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_8:
+      OneOf.data.u64.MinValue = (UINT64)OneOfData->MinValue;
+      OneOf.data.u64.MaxValue = (UINT64)OneOfData->MaxValue;
+      OneOf.data.u64.Step     = (UINT64)OneOfData->Step;
+      break;
+
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  CopyMem (Buf, &OneOf, OneOfSize);
+  BufInfo->Position += OneOfSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_NUMERIC opcode into the IFR buffer.
+
+  Insert the EFI_IFR_NUMERIC opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_INVALID_PARAMETER  Invalid data size.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeNumeric (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                   *Buf;
+  UINT32                  NumericSize;
+  EFI_STATUS              Status;
+  EFI_IFR_NUMERIC         Numeric;
+  DYN_HII_NUMERIC_DATA    *NumericData;
+  DYN_HII_STATEMENT_DATA  *Data;
+  DYN_HII_STATEMENT       *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  Data          = &StatementNode->Data;
+  NumericData   = &Data->Statement.Numeric;
+
+  NumericSize = OFFSET_OF (EFI_IFR_NUMERIC, data);
+
+  switch (NumericData->Flags & EFI_IFR_NUMERIC_SIZE) {
+    case EFI_IFR_NUMERIC_SIZE_1:
+      NumericSize += sizeof (Numeric.data.u8);
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_2:
+      NumericSize += sizeof (Numeric.data.u16);
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_4:
+      NumericSize += sizeof (Numeric.data.u32);
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_8:
+      NumericSize += sizeof (Numeric.data.u64);
+      break;
+
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  if (NumericSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, NumericSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                   = BufInfo->Data + BufInfo->Position;
+  Numeric.Header.OpCode = EFI_IFR_NUMERIC_OP;
+  Numeric.Header.Length = (UINT8)NumericSize;
+  Numeric.Header.Scope  = 1;
+
+  Numeric.Question = Data->QuestionHdr;
+  Numeric.Flags    = NumericData->Flags;
+
+  switch (Numeric.Flags & EFI_IFR_NUMERIC_SIZE) {
+    case EFI_IFR_NUMERIC_SIZE_1:
+      Numeric.data.u8.MinValue = (UINT8)NumericData->MinValue;
+      Numeric.data.u8.MaxValue = (UINT8)NumericData->MaxValue;
+      Numeric.data.u8.Step     = (UINT8)NumericData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_2:
+      Numeric.data.u16.MinValue = (UINT16)NumericData->MinValue;
+      Numeric.data.u16.MaxValue = (UINT16)NumericData->MaxValue;
+      Numeric.data.u16.Step     = (UINT16)NumericData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_4:
+      Numeric.data.u32.MinValue = (UINT32)NumericData->MinValue;
+      Numeric.data.u32.MaxValue = (UINT32)NumericData->MaxValue;
+      Numeric.data.u32.Step     = (UINT32)NumericData->Step;
+      break;
+
+    case EFI_IFR_NUMERIC_SIZE_8:
+      Numeric.data.u64.MinValue = (UINT64)NumericData->MinValue;
+      Numeric.data.u64.MaxValue = (UINT64)NumericData->MaxValue;
+      Numeric.data.u64.Step     = (UINT64)NumericData->Step;
+      break;
+
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  CopyMem (Buf, &Numeric, NumericSize);
+  BufInfo->Position += NumericSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_REF opcode into the IFR buffer.
+
+  Insert the EFI_IFR_REF opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef1 (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8              *Buf;
+  UINT32             RefSize;
+  EFI_STATUS         Status;
+  EFI_IFR_REF        Ref;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  RefSize = sizeof (EFI_IFR_REF);
+  if (RefSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, RefSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf               = BufInfo->Data + BufInfo->Position;
+  Ref.Header.OpCode = EFI_IFR_REF_OP;
+  Ref.Header.Length = (UINT8)RefSize;
+  Ref.Header.Scope  = 0;
+
+  Ref.Question = StatementNode->Data.QuestionHdr;
+  Ref.FormId   = RefData->FormId;
+
+  CopyMem (Buf, &Ref, sizeof (EFI_IFR_REF));
+  BufInfo->Position += sizeof (EFI_IFR_REF);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_REF2 opcode into the IFR buffer.
+
+  Insert the EFI_IFR_REF2 opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef2 (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8              *Buf;
+  UINT32             RefSize;
+  EFI_STATUS         Status;
+  EFI_IFR_REF2       Ref;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  RefSize = sizeof (EFI_IFR_REF2);
+  if (RefSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, RefSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf               = BufInfo->Data + BufInfo->Position;
+  Ref.Header.OpCode = EFI_IFR_REF_OP;
+  Ref.Header.Length = (UINT8)RefSize;
+  Ref.Header.Scope  = 0;
+
+  Ref.Question   = StatementNode->Data.QuestionHdr;
+  Ref.FormId     = RefData->FormId;
+  Ref.QuestionId = RefData->QuestionId;
+
+  CopyMem (Buf, &Ref, sizeof (EFI_IFR_REF2));
+  BufInfo->Position += sizeof (EFI_IFR_REF2);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_REF3 opcode into the IFR buffer.
+
+  Insert the EFI_IFR_REF3 opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef3 (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8              *Buf;
+  UINT32             RefSize;
+  EFI_STATUS         Status;
+  EFI_IFR_REF3       Ref;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  RefSize = sizeof (EFI_IFR_REF3);
+  if (RefSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, RefSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf               = BufInfo->Data + BufInfo->Position;
+  Ref.Header.OpCode = EFI_IFR_REF_OP;
+  Ref.Header.Length = (UINT8)RefSize;
+  Ref.Header.Scope  = 0;
+
+  Ref.Question   = StatementNode->Data.QuestionHdr;
+  Ref.FormId     = RefData->FormId;
+  Ref.QuestionId = RefData->QuestionId;
+  CopyMem (&Ref.FormSetId, &RefData->FormSetGuid, sizeof (EFI_GUID));
+
+  CopyMem (Buf, &Ref, sizeof (EFI_IFR_REF3));
+  BufInfo->Position += sizeof (EFI_IFR_REF3);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_REF4 opcode into the IFR buffer.
+
+  Insert the EFI_IFR_REF4 opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef4 (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8              *Buf;
+  UINT32             RefSize;
+  EFI_STATUS         Status;
+  EFI_IFR_REF4       Ref;
+  DYN_HII_REF_DATA   *RefData;
+  DYN_HII_STATEMENT  *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  RefSize = sizeof (EFI_IFR_REF4);
+  if (RefSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, RefSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf               = BufInfo->Data + BufInfo->Position;
+  Ref.Header.OpCode = EFI_IFR_REF_OP;
+  Ref.Header.Length = (UINT8)RefSize;
+  Ref.Header.Scope  = 0;
+
+  Ref.Question   = StatementNode->Data.QuestionHdr;
+  Ref.FormId     = RefData->FormId;
+  Ref.QuestionId = RefData->QuestionId;
+  Ref.DevicePath = RefData->DevicePath;
+  CopyMem (&Ref.FormSetId, &RefData->FormSetGuid, sizeof (EFI_GUID));
+
+  CopyMem (Buf, &Ref, sizeof (EFI_IFR_REF4));
+  BufInfo->Position += sizeof (EFI_IFR_REF4);
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_SUBTITLE opcode into the IFR buffer.
+
+  Insert the EFI_IFR_SUBTITLE opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeSubtitle (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                  *Buf;
+  UINT32                 SubtitleSize;
+  EFI_STATUS             Status;
+  EFI_IFR_SUBTITLE       Subtitle;
+  DYN_HII_SUBTITLE_DATA  *SubtitleData;
+  DYN_HII_STATEMENT      *StatementNode;
+
+  StatementNode = (DYN_HII_STATEMENT *)Hdr;
+  SubtitleData  = &StatementNode->Data.Statement.Subtitle;
+
+  SubtitleSize = sizeof (EFI_IFR_SUBTITLE);
+  if (SubtitleSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, SubtitleSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf                    = BufInfo->Data + BufInfo->Position;
+  Subtitle.Header.OpCode = EFI_IFR_SUBTITLE_OP;
+  Subtitle.Header.Length = (UINT8)SubtitleSize;
+  Subtitle.Header.Scope  = 0;
+
+  Subtitle.Statement.Prompt = SubtitleData->Prompt;
+  Subtitle.Statement.Help   = SubtitleData->Help;
+  Subtitle.Flags            = SubtitleData->Flags;
+
+  CopyMem (Buf, &Subtitle, sizeof (EFI_IFR_SUBTITLE));
+  BufInfo->Position += sizeof (EFI_IFR_SUBTITLE);
+
+  return EFI_SUCCESS;
+}
+
+/** Serialize the cross-reference statement data into the IFR buffer.
+
+  Check for the type of cross-reference statement and call the
+  appropriate function for serializing the ref data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_UNSUPPORTED        Currently unsupported Ref type.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters was invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeRef (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  CONST DYN_HII_STATEMENT            *StatementNode;
+  CONST DYN_HII_REF_DATA             *RefData;
+  static CONST DYN_HII_SERIALIZE_FN  RefSerializers[DynHiiRefMax] = {
+    NULL,                   // 0 is invalid
+    DynHiiSerializeRef1,    // DynHiiRef1
+    DynHiiSerializeRef2,    // DynHiiRef2
+    DynHiiSerializeRef3,    // DynHiiRef3
+    DynHiiSerializeRef4,    // DynHiiRef4
+    NULL                    // DynHiiRef5, unsupported
+  };
+
+  if ((Hdr == NULL) || (Hdr->Type != DynHiiNodeStatement)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  StatementNode = (CONST DYN_HII_STATEMENT *)Hdr;
+  RefData       = &StatementNode->Data.Statement.Ref;
+
+  return DynHiiDispatchSerializeHandler (
+           RefSerializers,
+           ARRAY_SIZE (RefSerializers),
+           RefData->RefType,
+           Hdr,
+           BufInfo
+           );
+}
+
+/** Serialize the statement/question data into the IFR buffer.
+
+  Check for the type of statement/question and call the appropriate
+  function for serializing the data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_UNSUPPORTED        Serialization function currently not supported
+                                  for the statement type.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameters was invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeStatement (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  CONST DYN_HII_STATEMENT            *StatementNode;
+  static CONST DYN_HII_SERIALIZE_FN  StatementSerializers[DynHiiStMax] = {
+    NULL,                           // 0 is invalid
+    DynHiiSerializeCheckbox,        // DynHiiStCheckbox
+    DynHiiSerializeNumeric,         // DynHiiStNumeric
+    DynHiiSerializeOneOf,           // DynHiiStOneOf
+    DynHiiSerializeRef,             // DynHiiStRef
+    DynHiiSerializeSubtitle,        // DynHiiStSubtitle
+    NULL,                           // DynHiiStOrderedList, unsupported
+    NULL,                           // DynHiiStAction, unsupported
+    NULL,                           // DynHiiStString, unsupported
+    NULL,                           // DynHiiStText, unsupported
+    NULL,                           // DynHiiStPassword, unsupported
+  };
+
+  if ((Hdr == NULL) || (BufInfo == NULL) ||
+      (Hdr->Type != DynHiiNodeStatement))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  StatementNode = (CONST DYN_HII_STATEMENT *)Hdr;
+
+  return DynHiiDispatchSerializeHandler (
+           StatementSerializers,
+           ARRAY_SIZE (StatementSerializers),
+           StatementNode->StatementType,
+           Hdr,
+           BufInfo
+           );
+}
+
+/** Insert the EFI_IFR_ONE_OF_OPTION opcode into the IFR buffer.
+
+  Insert the EFI_IFR_ONE_OF_OPTION opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeOption (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                  *Buf;
+  UINT32                 OptionSize;
+  EFI_STATUS             Status;
+  EFI_IFR_ONE_OF_OPTION  Option;
+  DYN_HII_ONE_OF_OPTION  *OptionNode;
+
+  OptionNode = (DYN_HII_ONE_OF_OPTION *)Hdr;
+
+  OptionSize = OFFSET_OF (EFI_IFR_ONE_OF_OPTION, Value);
+
+  switch (OptionNode->Type) {
+    case EFI_IFR_TYPE_NUM_SIZE_8:
+      OptionSize += sizeof (UINT8);
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_16:
+      OptionSize += sizeof (UINT16);
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_32:
+      OptionSize += sizeof (UINT32);
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_64:
+      OptionSize += sizeof (UINT64);
+      break;
+
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  if (OptionSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, OptionSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  Option.Header.OpCode = EFI_IFR_ONE_OF_OPTION_OP;
+  Option.Header.Length = (UINT8)OptionSize;
+  Option.Header.Scope  = 0;
+
+  Option.Option = OptionNode->Text;
+  Option.Flags  = OptionNode->Flags;
+  Option.Type   = OptionNode->Type;
+  Option.Value  = OptionNode->Value;
+
+  CopyMem (Buf, &Option, OptionSize);
+  BufInfo->Position += OptionSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_DEFAULT opcode into the IFR buffer.
+
+  Insert the EFI_IFR_DEFAULT opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeDefault (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8            *Buf;
+  UINT32           DefaultSize;
+  EFI_STATUS       Status;
+  EFI_IFR_DEFAULT  Default;
+  DYN_HII_DEFAULT  *DefaultNode;
+
+  DefaultNode = (DYN_HII_DEFAULT *)Hdr;
+
+  DefaultSize = OFFSET_OF (EFI_IFR_DEFAULT, Value);
+
+  switch (DefaultNode->Type) {
+    case EFI_IFR_TYPE_NUM_SIZE_8:
+      DefaultSize += sizeof (UINT8);
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_16:
+      DefaultSize += sizeof (UINT16);
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_32:
+      DefaultSize += sizeof (UINT32);
+      break;
+
+    case EFI_IFR_TYPE_NUM_SIZE_64:
+      DefaultSize += sizeof (UINT64);
+      break;
+
+    case EFI_IFR_TYPE_BOOLEAN:
+      DefaultSize += sizeof (BOOLEAN);
+      break;
+
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  if (DefaultSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, DefaultSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  Default.Header.OpCode = EFI_IFR_DEFAULT_OP;
+  Default.Header.Length = (UINT8)DefaultSize;
+  Default.Header.Scope  = 0;
+
+  Default.DefaultId = DefaultNode->DefaultId;
+  Default.Type      = DefaultNode->Type;
+  Default.Value     = DefaultNode->Value;
+
+  CopyMem (Buf, &Default, DefaultSize);
+  BufInfo->Position += DefaultSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_DEFAULTSTORE opcode into the IFR buffer.
+
+  In absence of an explicit addition of a defaultstore, insert the implicit
+  EFI_IFR_DEFAULTSTORE opcode data into the IFR buffer.
+
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiAddImplicitDefaultstores (
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                 Idx;
+  UINT8                 *Buf;
+  UINT32                DefaultstoreSize;
+  EFI_STATUS            Status;
+  EFI_IFR_DEFAULTSTORE  Defaultstore;
+
+  DefaultstoreSize = 2 * sizeof (EFI_IFR_DEFAULTSTORE);
+  Status           = DynHiiIfrBufferSizeCheck (BufInfo, DefaultstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  DefaultstoreSize = sizeof (EFI_IFR_DEFAULTSTORE);
+  if (DefaultstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  Defaultstore.Header.OpCode = EFI_IFR_DEFAULTSTORE_OP;
+  Defaultstore.Header.Length = (UINT8)DefaultstoreSize;
+  Defaultstore.Header.Scope  = 0;
+
+  Defaultstore.DefaultName = 0x0;
+  for (Idx = 0; Idx < 2; Idx++) {
+    Defaultstore.DefaultId = Idx;
+
+    CopyMem (Buf, &Defaultstore, sizeof (EFI_IFR_DEFAULTSTORE));
+    Buf               += sizeof (EFI_IFR_DEFAULTSTORE);
+    BufInfo->Position += sizeof (EFI_IFR_DEFAULTSTORE);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Insert the EFI_IFR_DEFAULTSTORE opcode into the IFR buffer.
+
+  Insert the EFI_IFR_DEFAULTSTORE opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_BAD_BUFFER_SIZE    Opcode data size greater than 127 bytes.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+DynHiiSerializeDefaultstore (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  UINT8                 *Buf;
+  UINT32                DefaultstoreSize;
+  EFI_STATUS            Status;
+  EFI_IFR_DEFAULTSTORE  Defaultstore;
+  DYN_HII_DEFAULTSTORE  *DefaultstoreNode;
+
+  DefaultstoreNode = (DYN_HII_DEFAULTSTORE *)Hdr;
+
+  DefaultstoreSize = sizeof (EFI_IFR_DEFAULTSTORE);
+  if (DefaultstoreSize > MAX_HII_OPCODE_LENGTH) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Status = DynHiiIfrBufferSizeCheck (BufInfo, DefaultstoreSize);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Buf = BufInfo->Data + BufInfo->Position;
+
+  Defaultstore.Header.OpCode = EFI_IFR_DEFAULTSTORE_OP;
+  Defaultstore.Header.Length = (UINT8)DefaultstoreSize;
+  Defaultstore.Header.Scope  = 0;
+
+  Defaultstore.DefaultName = DefaultstoreNode->DefaultName;
+  Defaultstore.DefaultId   = DefaultstoreNode->DefaultId;
+
+  CopyMem (Buf, &Defaultstore, sizeof (EFI_IFR_DEFAULTSTORE));
+  BufInfo->Position += sizeof (EFI_IFR_DEFAULTSTORE);
+
+  return EFI_SUCCESS;
+}
+
+/** Serialize the given HII node.
+
+  Check for the type of the node, and call the appropriate function for
+  inserting the opcode data into the IFR buffer.
+
+  @param [in]  Hdr                Pointer to the node header.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS            The opcode was added successfully to the IFR
+                                  buffer.
+  @retval  EFI_UNSUPPORTED        The node is currently unsupported.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+DynHiiSerializeNode (
+  IN  CONST    DYN_HII_NODE_HDR    *Hdr,
+  IN           DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  static CONST DYN_HII_SERIALIZE_FN  NodeSerializers[DynHiiNodeMax] = {
+    NULL,                         // 0 is invalid
+    DynHiiSerializeFormset,       // DynHiiNodeFormset
+    DynHiiSerializeForm,          // DynHiiNodeForm
+    DynHiiSerializeDefaultstore,  // DynHiiNodeDefaultStore
+    DynHiiSerializeVarstore,      // DynHiiNodeVarstore
+    DynHiiSerializeStatement,     // DynHiiNodeStatement
+    DynHiiSerializeOption,        // DynHiiNodeOption
+    DynHiiSerializeDefault,       // DynHiiNodeDefault
+    NULL,                         // DynHiiNodeString, unsupported
+    NULL                          // DynHiiNodeExpression, unsupported
+  };
+
+  if ((Hdr == NULL) || (BufInfo == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return DynHiiDispatchSerializeHandler (
+           NodeSerializers,
+           ARRAY_SIZE (NodeSerializers),
+           Hdr->Type,
+           Hdr,
+           BufInfo
+           );
+}
+
+/** Iterate the default list.
+
+  Iterate through the default list, and for each node found, call the function
+  to serialize the node data into the IFR buffer.
+
+  @param [in]  DefaultList        List of default nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the serialization function.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateDefaultList (
+  IN  CONST LIST_ENTRY          *DefaultList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  LIST_ENTRY       *Link;
+  EFI_STATUS       Status;
+  DYN_HII_DEFAULT  *Default;
+
+  Link = GetFirstNode (DefaultList);
+  while (!IsNull (DefaultList, Link)) {
+    Default = BASE_CR (Link, DYN_HII_DEFAULT, Hdr.Link);
+
+    Status = DynHiiSerializeNode (&Default->Hdr, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (DefaultList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Iterate the option list.
+
+  Iterate through the option list, and for each node found, call the function
+  to serialize the node data into the IFR buffer.
+
+  @param [in]  OptionList         List of option nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the serialization function.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateOptionList (
+  IN  CONST LIST_ENTRY          *OptionList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  LIST_ENTRY             *Link;
+  EFI_STATUS             Status;
+  DYN_HII_ONE_OF_OPTION  *Option;
+
+  Link = GetFirstNode (OptionList);
+  while (!IsNull (OptionList, Link)) {
+    Option = BASE_CR (Link, DYN_HII_ONE_OF_OPTION, Hdr.Link);
+
+    Status = DynHiiSerializeNode (&Option->Hdr, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (OptionList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Process the statement/question node.
+
+  Serialize the statement/question node data by calling the corresponding
+  function. Check for any question defaults, and process them if present.
+  Finally, add the end opcode for the statement if the statement is scoped.
+
+  @param [in]  Statement          Statement/Question to be processed.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the processing was successfull or any error code
+                        returned by the serialization functions.
+
+**/
+static
+EFI_STATUS
+DynHiiProcessStatement (
+  IN  CONST DYN_HII_STATEMENT   *Statement,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DynHiiSerializeNode (&Statement->Hdr, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (!IsListEmpty (&Statement->OptionList)) {
+    Status = DynHiiIterateOptionList (&Statement->OptionList, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  if (!IsListEmpty (&Statement->DefaultList)) {
+    Status = DynHiiIterateDefaultList (&Statement->DefaultList, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  return DynHiiInsertEndOp (&Statement->Hdr, BufInfo);
+}
+
+/** Iterate the statement list.
+
+  Iterate through the statement list, and for each node found, call the
+  function to serialize the process the node data.
+
+  @param [in]  StatementList      List of statement nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the processing was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateStatementList (
+  IN  CONST LIST_ENTRY          *StatementList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS         Status;
+  LIST_ENTRY         *Link;
+  DYN_HII_STATEMENT  *Statement;
+
+  Link = GetFirstNode (StatementList);
+  while (!IsNull (StatementList, Link)) {
+    Statement = BASE_CR (Link, DYN_HII_STATEMENT, Hdr.Link);
+
+    Status = DynHiiProcessStatement (Statement, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (StatementList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Process the form node.
+
+  Serialize the form node data by calling the corresponding function. Process
+  the Statements under the form. Finally, add the end opcode for the form.
+
+  @param [in]  Form               Pointer to the Form node.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the processing was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiProcessForm (
+  IN  CONST DYN_HII_FORM        *Form,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DynHiiSerializeNode (&Form->Hdr, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = DynHiiIterateStatementList (&Form->StatementList, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return DynHiiInsertEndOp (&Form->Hdr, BufInfo);
+}
+
+/** Iterate the varstore list.
+
+  Iterate through the varstore list, and for each node found, call the function
+  to serialize the node data into the IFR buffer.
+
+  @param [in]  VarstoreList       List of default nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the serialization function.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateVarstoreList (
+  IN  CONST LIST_ENTRY          *VarstoreList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS        Status;
+  LIST_ENTRY        *Link;
+  DYN_HII_VARSTORE  *Varstore;
+
+  Link = GetFirstNode (VarstoreList);
+  while (!IsNull (VarstoreList, Link)) {
+    Varstore = BASE_CR (Link, DYN_HII_VARSTORE, Hdr.Link);
+
+    Status = DynHiiSerializeNode (&Varstore->Hdr, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (VarstoreList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Iterate the form list.
+
+  Iterate through the form list, and for each node found, call the function
+  to process the form.
+
+  @param [in]  FormList           List of form nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateFormList (
+  IN  CONST LIST_ENTRY          *FormList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS    Status;
+  LIST_ENTRY    *Link;
+  DYN_HII_FORM  *Form;
+
+  Link = GetFirstNode (FormList);
+  while (!IsNull (FormList, Link)) {
+    Form = BASE_CR (Link, DYN_HII_FORM, Hdr.Link);
+
+    Status = DynHiiProcessForm (Form, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (FormList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Iterate the default store list.
+
+  Iterate through the default store list, and for each node found, call the
+  function to serialize the node into the IFR buffer.
+
+  @param [in]  DefaultstoreList   List of default store nodes.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the serialization was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiIterateDefaultstoreList (
+  IN  CONST LIST_ENTRY          *DefaultstoreList,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS            Status;
+  LIST_ENTRY            *Link;
+  DYN_HII_DEFAULTSTORE  *Defaultstore;
+
+  Link = GetFirstNode (DefaultstoreList);
+  while (!IsNull (DefaultstoreList, Link)) {
+    Defaultstore = BASE_CR (Link, DYN_HII_DEFAULTSTORE, Hdr.Link);
+
+    Status = DynHiiSerializeNode (&Defaultstore->Hdr, BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Link = GetNextNode (DefaultstoreList, Link);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Process the formset node.
+
+  Serialize the formset node data by calling the corresponding function. Process
+  the child nodes of the formset, like varstores, forms. Finally, insert the
+  end opcode into the IFR buffer.
+
+  @param [in]  Formset            Pointer to the formset node.
+  @param [in]  BufInfo            Pointer to the DYN_HII_IFR_BUFFER structure.
+
+  @retval  EFI_SUCCESS  If the processing was successfull or any error code
+                        returned by the called functions.
+
+**/
+static
+EFI_STATUS
+DynHiiProcessFormset (
+  IN  CONST DYN_HII_FORMSET     *Formset,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DynHiiSerializeNode (&Formset->Hdr, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (!IsListEmpty (&Formset->DefaultstoreList)) {
+    Status = DynHiiIterateDefaultstoreList (
+               &Formset->DefaultstoreList,
+               BufInfo
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  } else {
+    Status = DynHiiAddImplicitDefaultstores (BufInfo);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  Status = DynHiiIterateVarstoreList (&Formset->VarstoreList, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = DynHiiIterateFormList (&Formset->FormList, BufInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return DynHiiInsertEndOp (&Formset->Hdr, BufInfo);
+}
+
+/** Initialize the Form Package header.
+
+  Initialize the EFI_HII_PACKAGE_HEADER for the forms package.
+
+  @param [in]  IfrBuf             Pointer to the IFR byte buffer.
+  @param [in]  Length             Length of the Forms package, including the
+                                  preceding four bytes for array length.
+
+**/
+static
+VOID
+DynHiiInitFormPkgHdr (
+  IN  UINT8   *IfrBuf,
+  IN  UINT32  Length
+  )
+{
+  UINT8                   *PkgHdr;
+  UINT32                  *Buf;
+  EFI_HII_PACKAGE_HEADER  Hdr;
+
+  Buf  = (UINT32 *)IfrBuf;
+  *Buf = Length;
+
+  PkgHdr     = IfrBuf + sizeof (UINT32);
+  Hdr.Length = Length - sizeof (UINT32);
+  Hdr.Type   = EFI_HII_PACKAGE_FORMS;
+
+  CopyMem (PkgHdr, &Hdr, sizeof (EFI_HII_PACKAGE_HEADER));
+}
+
+/** Dump the contents of the IFR buffer.
+
+  Useful for debugging.
+
+  @param [in]  IfrBuf         Pointer to the IFR byte buffer.
+  @param [in]  Size           Size in bytes of the IFR byte buffer.
+
+**/
+static
+VOID
+DumpIfrBuffer (
+  IN   CONST     UINT8   *IfrBuf,
+  IN   CONST     UINT32  Size
+  )
+{
+  CONST  UINT8  *Buf;
+  UINT32        Idx;
+  UINT32        Idx1;
+
+  if (Size <= 8) {
+    return;
+  }
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "INFO: %a: IfrBuf => %p, "
+    "IfrBuf Size => 0x%x\n",
+    __func__,
+    IfrBuf,
+    Size
+    ));
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "***** Generated IFR Byte Stream *****\n"
+    ));
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "IfrByteStream[] = {\n"
+    ));
+
+  Buf = IfrBuf;
+  for (Idx = 0; Idx < 4; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n\n"));
+
+  for (Idx = 0; Idx < 4; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n\n"));
+
+  for (Idx = 0; Idx < Size - 8;) {
+    for (Idx1 = 0; Idx < (Size - 8) && Idx1 < 16; Idx1++, Idx++) {
+      DEBUG ((
+        DEBUG_VERBOSE,
+        "0x%02x, ",
+        *Buf++
+        ));
+    }
+
+    DEBUG ((DEBUG_VERBOSE, "\n"));
+  }
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "};\n\n"
+    ));
+}
+
+/** Generate the IFR byte-stream for the Formset.
+
+  Serialize the Formset and it's child nodes to generate an IFR byte-stream
+  based Form package. This can then be added to the HII database through the
+  HiiAddPackages() call.
+
+  The serialized IFR buffer is passed back to the caller in IfrBuf. It is
+  the caller's responsibility to free up the IFR buffer through a call to
+  FreePool().
+
+  @param [in]  FormsetHandle      The formset hierarchy that needs to be
+                                  serialized.
+  @param [out] IfrBuf             Pointer to the IFR data buffer.
+
+  @retval  EFI_SUCCESS            The Default was created successfully.
+  @retval  EFI_INVALID_PARAMETER  One of the input parameter is invalid.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiGenerateFormPackage (
+  IN  CONST DYN_HII_FORMSET_HANDLE  FormsetHandle,
+  OUT       UINT8                   **IfrBuf
+  )
+{
+  UINT8               *Buf;
+  EFI_STATUS          Status;
+  DYN_HII_FORMSET     *Formset;
+  DYN_HII_IFR_BUFFER  BufInfo;
+
+  Formset = FormsetHandle;
+  if ((Formset == NULL) || (Formset->Hdr.Type != DynHiiNodeFormset) ||
+      (IfrBuf == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *IfrBuf = NULL;
+  ZeroMem (&BufInfo, sizeof (DYN_HII_IFR_BUFFER));
+
+  Status = DynHiiInitIfrByteBuffer (&BufInfo);
+  if (Status == EFI_OUT_OF_RESOURCES) {
+    return Status;
+  }
+
+  Status = DynHiiProcessFormset (Formset, &BufInfo);
+  if (EFI_ERROR (Status)) {
+    goto err_handle;
+  } else {
+    Buf = ReallocatePool (
+            BufInfo.Size,
+            BufInfo.Position,
+            BufInfo.Data
+            );
+    if (Buf == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto err_handle;
+    }
+
+    DynHiiInitFormPkgHdr (Buf, BufInfo.Position);
+    *IfrBuf = Buf;
+  }
+
+  DumpIfrBuffer (Buf, BufInfo.Position);
+
+  return EFI_SUCCESS;
+
+err_handle:
+  if (BufInfo.Data != NULL) {
+    FreePool (BufInfo.Data);
+  }
+
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormsLib.inf
+++ b/DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormsLib.inf
@@ -1,0 +1,31 @@
+## @file
+#  Dynamic HII Forms Library
+#
+#  Copyright (c) 2026, Arm Limited. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = HiiFormsLib
+  FILE_GUID      = 0AD56587-31B3-4908-BD20-5B169DF87D53
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = HiiFormsLib
+
+[Sources]
+  HiiFormGenerator.c
+  HiiFormSerialize.c
+  InternalHiiFormsLib.h
+
+[Packages]
+  DynamicTablesPkg/DynamicTablesPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib

--- a/DynamicTablesPkg/Library/Common/HiiFormsLib/InternalHiiFormsLib.h
+++ b/DynamicTablesPkg/Library/Common/HiiFormsLib/InternalHiiFormsLib.h
@@ -1,0 +1,459 @@
+/** @file
+  Data structures for dynamically building Formsets.
+
+  This file contains data structures and other
+  related information that is needed for
+  generating Formsets and it's underlying nodes
+  dynamically.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+    - Dyn        - Dynamic
+    - Qt         - Question Type
+    - Ref        - Cross-link Reference
+**/
+
+#pragma once
+
+#include <Base.h>
+#include <Library/HiiFormsLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+/** The max value is as per the description in the UEFI specification,
+    version 2.11, section 33.3.8.3.26.
+*/
+#define MAX_FORMSET_CLASS_GUID  3
+
+/** The DYN_HII_NODE_TYPE enum object defines the various
+    types of nodes that can be present under a Formset.
+*/
+typedef enum {
+  DynHiiNodeFormset = 1,
+  DynHiiNodeForm,
+  DynHiiNodeDefaultStore,
+  DynHiiNodeVarstore,
+  DynHiiNodeStatement,
+  DynHiiNodeOption,
+  DynHiiNodeDefault,
+  DynHiiNodeString,
+  DynHiiNodeExpression,
+  DynHiiNodeMax
+} DYN_HII_NODE_TYPE;
+
+/** The DYN_HII_STATEMENT_TYPE enum object defines the
+    different Question types that can put put in the
+    Formset.
+*/
+typedef enum {
+  DynHiiStAction = 1,
+  DynHiiStCheckbox,
+  DynHiiStNumeric,
+  DynHiiStOneOf,
+  DynHiiStOrderedList,
+  DynHiiStPassword,
+  DynHiiStRef,
+  DynHiiStString,
+  DynHiiStText,
+  DynHiiStSubtitle,
+  DynHiiStMax
+} DYN_HII_STATEMENT_TYPE;
+
+/** The DYN_HII_VARSTORE_TYPE enum type defines the different
+    types of Variable Stores that can be defined in the
+    Formset.
+*/
+typedef enum {
+  DynHiiVarstoreBuffer = 1,
+  DynHiiVarstoreEfi,
+  DynHiiVarstoreNameValue,
+  DynHiiVarstoreMax
+} DYN_HII_VARSTORE_TYPE;
+
+/** The DYN_HII_REF_QUESTION_TYPE enum type defines the different
+    type of allowed cross-reference Question variants.
+
+    There are five variants of the cross-reference question type,
+    as described in the UEFI 2.11 specification, section
+    33.3.8.3.59
+*/
+typedef enum {
+  DynHiiRef1 = 1,
+  DynHiiRef2,
+  DynHiiRef3,
+  DynHiiRef4,
+  DynHiiRef5,
+  DynHiiRefMax
+} DYN_HII_REF_QUESTION_TYPE;
+
+/** A header for all the nodes that form
+    part of the formset.
+*/
+typedef struct {
+  /// A link to another node
+  LIST_ENTRY    Link;
+
+  /// Type of the node. Refer DYN_HII_NODE_TYPE
+  UINT16        Type;
+
+  /// Whether the node opens a scope. This
+  /// indicates that the node has another
+  /// node as it's child
+  BOOLEAN       Scope;
+} DYN_HII_NODE_HDR;
+
+/** A structure for Buffer type
+    variable store (Varstore).
+*/
+typedef struct {
+  /// The Varstore GUID
+  EFI_GUID           Guid;
+
+  /// The Varstore ID associated
+  /// with this varstore. Unique
+  /// within a formset.
+  EFI_VARSTORE_ID    VarstoreId;
+
+  /// Size of the varstore
+  UINT16             Size;
+
+  /// Varstore Name as an Ascii string
+  CHAR8              *Name;
+} DYN_HII_VARSTORE_BUFFER_DATA;
+
+/** A structure for EFI type
+    variable store (Varstore).
+*/
+typedef struct {
+  /// The Varstore GUID
+  EFI_GUID           Guid;
+
+  /// The Varstore ID associated
+  /// with this varstore. Unique
+  /// within a formset.
+  EFI_VARSTORE_ID    VarstoreId;
+
+  /// Flags for the varstore
+  UINT32             Attributes;
+
+  /// Size of the varstore
+  UINT16             Size;
+
+  /// Varstore Name as an Ascii string
+  CHAR8              *Name;
+} DYN_HII_VARSTORE_EFI_DATA;
+
+/** A structure for name-value
+    type variable store (Varstore).
+*/
+typedef struct {
+  /// The Varstore GUID
+  EFI_GUID           Guid;
+
+  /// The Varstore ID associated
+  /// with this varstore. Unique
+  /// within a formset.
+  EFI_VARSTORE_ID    VarstoreId;
+} DYN_HII_VARSTORE_NAME_VALUE_DATA;
+
+/** A union that can hold any type of
+    Varstore data type.
+*/
+typedef union {
+  /// A buffer type varstore
+  DYN_HII_VARSTORE_BUFFER_DATA        Buffer;
+
+  /// An EFI variable type varstore
+  DYN_HII_VARSTORE_EFI_DATA           Efi;
+
+  /// A name-value type varstore
+  DYN_HII_VARSTORE_NAME_VALUE_DATA    NameValue;
+} DYN_HII_VARSTORE_DATA;
+
+/** A structure to hold all the relevant Varstore
+    information.
+*/
+typedef struct {
+  /// Varstore node header
+  DYN_HII_NODE_HDR         Hdr;
+
+  /// Type of the varstore
+  DYN_HII_VARSTORE_TYPE    VarstoreType;
+
+  /// The varstore data
+  DYN_HII_VARSTORE_DATA    Data;
+} DYN_HII_VARSTORE;
+
+/** A structure for Checkbox Question
+    specific information.
+*/
+typedef struct {
+  /// The Flags associated with the
+  /// checkbox question
+  UINT8    Flags;
+} DYN_HII_CHECKBOX_DATA;
+
+/** A structure for Numeric Question
+    specific information.
+*/
+typedef struct {
+  /// The flags associated with the
+  /// numeric question
+  UINT8     Flags;
+
+  /// Minimum value allowed for the
+  /// question
+  UINT64    MinValue;
+
+  /// Maximum value allowed for the
+  /// question
+  UINT64    MaxValue;
+
+  /// The step size in which the question's
+  /// value can be incremented/decremented
+  UINT64    Step;
+} DYN_HII_NUMERIC_DATA;
+
+/** A structure for Cross Reference Question
+    specific information.
+*/
+typedef struct {
+  /// Type of Ref question
+  /// (Ref1/Ref2/Ref3/Ref4/Ref5)
+  DYN_HII_REF_QUESTION_TYPE    RefType;
+
+  /// Target form ID to which the question is
+  /// referring
+  EFI_FORM_ID                  FormId;
+
+  /// Target question ID to which the question
+  /// is referring
+  EFI_QUESTION_ID              QuestionId;
+
+  /// Target formset to which the question is
+  /// referring
+  EFI_GUID                     FormSetGuid;
+
+  /// Target device path to which the question is
+  /// referring
+  EFI_STRING_ID                DevicePath;
+} DYN_HII_REF_DATA;
+
+/** A structure for OneOf Question
+    specific information.
+*/
+typedef struct {
+  /// The flags associated with the
+  /// one-of question
+  UINT8     Flags;
+
+  /// Minimum value allowed for the
+  /// question
+  UINT64    MinValue;
+
+  /// Maximum value allowed for the
+  /// question
+  UINT64    MaxValue;
+
+  /// The step size in which the question's
+  /// value can be incremented/decremented
+  UINT64    Step;
+
+  /// The type/size of numeric value that is
+  /// associated with this question
+  UINT8     ValueType;
+} DYN_HII_ONE_OF_DATA;
+
+/** A structure for OneOf Question
+    specific information.
+*/
+typedef struct {
+  /// The flags associated with the
+  /// one-of question
+  UINT8            Flags;
+
+  /// Subtitle prompt string ID
+  EFI_STRING_ID    Prompt;
+
+  /// Subtitle help string ID
+  EFI_STRING_ID    Help;
+} DYN_HII_SUBTITLE_DATA;
+
+/** A union for holding data for Question
+    data types.
+*/
+typedef union {
+  /// Checkbox question type data
+  DYN_HII_CHECKBOX_DATA    Checkbox;
+
+  /// Numeric question type data
+  DYN_HII_NUMERIC_DATA     Numeric;
+
+  /// Cross-reference question type data
+  DYN_HII_REF_DATA         Ref;
+
+  /// One-Of question type data
+  DYN_HII_ONE_OF_DATA      OneOf;
+
+  /// Subtitle statement type data
+  DYN_HII_SUBTITLE_DATA    Subtitle;
+} DYN_HII_STATEMENT_PAYLOAD;
+
+/** A structure for holding all data associated
+    with a Question.
+*/
+typedef struct {
+  /// A header for holding Question metadata
+  EFI_IFR_QUESTION_HEADER      QuestionHdr;
+
+  /// Payload of the question depending on the
+  /// question type
+  DYN_HII_STATEMENT_PAYLOAD    Statement;
+} DYN_HII_STATEMENT_DATA;
+
+/** A structure for holding information associated
+    with an OneOf Option for a Question.
+*/
+typedef struct {
+  /// Default node header
+  DYN_HII_NODE_HDR      Hdr;
+
+  /// String ID for the option text
+  EFI_STRING_ID         Text;
+
+  /// Option Flags
+  UINT8                 Flags;
+
+  /// Type of option
+  UINT8                 Type;
+
+  /// Option Value, governed by the option type
+  EFI_IFR_TYPE_VALUE    Value;
+} DYN_HII_ONE_OF_OPTION;
+
+/** A structure for holding information associated
+    with a Default for a Question.
+*/
+typedef struct {
+  /// Default node header
+  DYN_HII_NODE_HDR      Hdr;
+
+  /// Default store associated with this
+  /// default value
+  UINT16                DefaultId;
+
+  /// Type of data in the value field
+  UINT8                 Type;
+
+  /// The default value
+  EFI_IFR_TYPE_VALUE    Value;
+} DYN_HII_DEFAULT;
+
+/** A structure for holding information associated
+    with a Defaultstore for the formset.
+*/
+typedef struct {
+  /// Defaultstore node header
+  DYN_HII_NODE_HDR    Hdr;
+
+  /// String ID for the associated default
+  /// name string
+  EFI_STRING_ID       DefaultName;
+
+  /// Default ID which is unique within
+  /// a formset
+  UINT16              DefaultId;
+} DYN_HII_DEFAULTSTORE;
+
+/** A structure for holding information associated
+    with a Statement/Question.
+*/
+typedef struct {
+  /// Statement/Question node header
+  DYN_HII_NODE_HDR          Hdr;
+
+  /// Type of question/statement
+  DYN_HII_STATEMENT_TYPE    StatementType;
+
+  /// Question/Statement data
+  DYN_HII_STATEMENT_DATA    Data;
+
+  /// List of options for the question
+  LIST_ENTRY                OptionList;
+
+  /// List of default values for the question
+  LIST_ENTRY                DefaultList;
+} DYN_HII_STATEMENT;
+
+/** A structure for holding information associated
+    with a Form.
+*/
+typedef struct {
+  /// Form node header
+  DYN_HII_NODE_HDR    Hdr;
+
+  /// Form Id for the form
+  EFI_FORM_ID         FormId;
+
+  /// Form title string ID
+  EFI_STRING_ID       Title;
+
+  /// List of statements/questions in
+  /// the form
+  LIST_ENTRY          StatementList;
+} DYN_HII_FORM;
+
+/** A structure for holding information associated
+    with a Formset.
+*/
+typedef struct {
+  /// Formset node header
+  DYN_HII_NODE_HDR    Hdr;
+
+  /// Formset GUID
+  EFI_GUID            FormsetGuid;
+
+  /// Formset title string ID
+  EFI_STRING_ID       Title;
+
+  /// Formset help string ID
+  EFI_STRING_ID       Help;
+
+  /// Number of class identifier GUID's
+  /// in the formset
+  UINT8               ClassGuidCount;
+
+  /// Class identifier GUID array
+  EFI_GUID            ClassGuid[MAX_FORMSET_CLASS_GUID];
+
+  EFI_FORM_ID         FormIdCounter;
+
+  /// List of variable stores associated
+  /// with this formset
+  LIST_ENTRY          VarstoreList;
+
+  /// List of default stores associated
+  /// with this formset
+  LIST_ENTRY          DefaultstoreList;
+
+  /// List of forms associated with this
+  /// formset
+  LIST_ENTRY          FormList;
+} DYN_HII_FORMSET;
+
+/** A structure for holding information associated
+    with the IFR Form package.
+*/
+typedef struct {
+  /// Pointer to the IFR buffer
+  UINT8     *Data;
+
+  /// Size of the IFR Buffer
+  UINT32    Size;
+
+  /// Current position of the buffer
+  UINT32    Position;
+} DYN_HII_IFR_BUFFER;

--- a/DynamicTablesPkg/Library/Common/HiiFormsLib/InternalHiiFormsLib.h
+++ b/DynamicTablesPkg/Library/Common/HiiFormsLib/InternalHiiFormsLib.h
@@ -1,0 +1,479 @@
+/** @file
+  Data structures for dynamically building Formsets.
+
+  This file contains data structures and other
+  related information that is needed for
+  generating Formsets and it's underlying nodes
+  dynamically.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+    - Dyn        - Dynamic
+    - Qt         - Question Type
+    - Ref        - Cross-link Reference
+
+  @par Reference(s):
+  - UEFI specification 2.11, section 33.3.8 Forms Package
+
+**/
+
+#pragma once
+
+#include <Base.h>
+#include <Library/HiiFormsLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+/** The max value is as per the description in the UEFI specification,
+    version 2.11, section 33.3.8.3.26.
+*/
+#define MAX_FORMSET_CLASS_GUID  3
+
+/** The DYN_HII_NODE_TYPE enum object defines the various
+    types of nodes that can be present under a Formset.
+*/
+typedef enum {
+  DynHiiNodeFormset = 1,
+  DynHiiNodeForm,
+  DynHiiNodeDefaultStore,
+  DynHiiNodeVarstore,
+  DynHiiNodeStatement,
+  DynHiiNodeOption,
+  DynHiiNodeDefault,
+  DynHiiNodeString,
+  DynHiiNodeExpression,
+  DynHiiNodeMax
+} DYN_HII_NODE_TYPE;
+
+/** The DYN_HII_STATEMENT_TYPE enum object defines the
+    different Question types that can put put in the
+    Formset.
+*/
+typedef enum {
+  DynHiiStCheckbox = 1,
+  DynHiiStNumeric,
+  DynHiiStOneOf,
+  DynHiiStRef,
+  DynHiiStSubtitle,
+  DynHiiStOrderedList,
+  DynHiiStAction,
+  DynHiiStString,
+  DynHiiStText,
+  DynHiiStPassword,
+  DynHiiStMax
+} DYN_HII_STATEMENT_TYPE;
+
+/** The DYN_HII_VARSTORE_TYPE enum type defines the different
+    types of Variable Stores that can be defined in the
+    Formset.
+*/
+typedef enum {
+  DynHiiVarstoreBuffer = 1,
+  DynHiiVarstoreEfi,
+  DynHiiVarstoreNameValue,
+  DynHiiVarstoreMax
+} DYN_HII_VARSTORE_TYPE;
+
+/** The DYN_HII_REF_QUESTION_TYPE enum type defines the different
+    type of allowed cross-reference Question variants.
+
+    There are five variants of the cross-reference question type,
+    as described in the UEFI 2.11 specification, section
+    33.3.8.3.59
+*/
+typedef enum {
+  DynHiiRef1 = 1,
+  DynHiiRef2,
+  DynHiiRef3,
+  DynHiiRef4,
+  DynHiiRef5,
+  DynHiiRefMax
+} DYN_HII_REF_QUESTION_TYPE;
+
+/** Mask for valid numeric flags */
+#define NUMERIC_FLAGS_MASK  (UINT8)0x33
+
+/** A header for all the nodes that form
+    part of the formset.
+*/
+typedef struct {
+  /// A link to another node
+  LIST_ENTRY    Link;
+
+  /// Type of the node. Refer DYN_HII_NODE_TYPE
+  UINT16        Type;
+
+  /// Whether the node opens a scope. This
+  /// indicates that the node has another
+  /// node as it's child
+  BOOLEAN       Scope;
+} DYN_HII_NODE_HDR;
+
+/** A structure for Buffer type
+    variable store (Varstore).
+*/
+typedef struct {
+  /// The Varstore GUID
+  EFI_GUID           Guid;
+
+  /// The Varstore ID associated
+  /// with this varstore. Unique
+  /// within a formset.
+  EFI_VARSTORE_ID    VarstoreId;
+
+  /// Size of the varstore
+  UINT16             Size;
+
+  /// Varstore Name as an Ascii string
+  CHAR8              *Name;
+} DYN_HII_VARSTORE_BUFFER_DATA;
+
+/** A structure for EFI type
+    variable store (Varstore).
+*/
+typedef struct {
+  /// The Varstore GUID
+  EFI_GUID           Guid;
+
+  /// The Varstore ID associated
+  /// with this varstore. Unique
+  /// within a formset.
+  EFI_VARSTORE_ID    VarstoreId;
+
+  /// Flags for the varstore
+  UINT32             Attributes;
+
+  /// Size of the varstore
+  UINT16             Size;
+
+  /// Varstore Name as an Ascii string
+  CHAR8              *Name;
+} DYN_HII_VARSTORE_EFI_DATA;
+
+/** A structure for name-value
+    type variable store (Varstore).
+*/
+typedef struct {
+  /// The Varstore GUID
+  EFI_GUID           Guid;
+
+  /// The Varstore ID associated
+  /// with this varstore. Unique
+  /// within a formset.
+  EFI_VARSTORE_ID    VarstoreId;
+} DYN_HII_VARSTORE_NAME_VALUE_DATA;
+
+/** A union that can hold any type of
+    Varstore data type.
+*/
+typedef union {
+  /// A buffer type varstore
+  DYN_HII_VARSTORE_BUFFER_DATA        Buffer;
+
+  /// An EFI variable type varstore
+  DYN_HII_VARSTORE_EFI_DATA           Efi;
+
+  /// A name-value type varstore
+  DYN_HII_VARSTORE_NAME_VALUE_DATA    NameValue;
+} DYN_HII_VARSTORE_DATA;
+
+/** A structure to hold all the relevant Varstore
+    information.
+*/
+typedef struct {
+  /// Varstore node header
+  DYN_HII_NODE_HDR         Hdr;
+
+  /// Type of the varstore
+  DYN_HII_VARSTORE_TYPE    VarstoreType;
+
+  /// The varstore data
+  DYN_HII_VARSTORE_DATA    Data;
+} DYN_HII_VARSTORE;
+
+/** A structure for Checkbox Question
+    specific information.
+*/
+typedef struct {
+  /// The Flags associated with the
+  /// checkbox question
+  UINT8    Flags;
+} DYN_HII_CHECKBOX_DATA;
+
+/** A structure for Numeric Question
+    specific information.
+*/
+typedef struct {
+  /// The flags associated with the
+  /// numeric question
+  UINT8     Flags;
+
+  /// Minimum value allowed for the
+  /// question
+  UINT64    MinValue;
+
+  /// Maximum value allowed for the
+  /// question
+  UINT64    MaxValue;
+
+  /// The step size in which the question's
+  /// value can be incremented/decremented
+  UINT64    Step;
+} DYN_HII_NUMERIC_DATA;
+
+/** A structure for Cross Reference Question
+    specific information.
+*/
+typedef struct {
+  /// Type of Ref question
+  /// (Ref1/Ref2/Ref3/Ref4/Ref5)
+  DYN_HII_REF_QUESTION_TYPE    RefType;
+
+  /// Target form ID to which the question is
+  /// referring
+  EFI_FORM_ID                  FormId;
+
+  /// Target question ID to which the question
+  /// is referring
+  EFI_QUESTION_ID              QuestionId;
+
+  /// Target formset to which the question is
+  /// referring
+  EFI_GUID                     FormSetGuid;
+
+  /// Target device path to which the question is
+  /// referring
+  EFI_STRING_ID                DevicePath;
+} DYN_HII_REF_DATA;
+
+/** A structure for OneOf Question
+    specific information.
+*/
+typedef struct {
+  /// The flags associated with the
+  /// one-of question
+  UINT8      Flags;
+
+  /// Minimum value allowed for the
+  /// question
+  UINT64     MinValue;
+
+  /// Maximum value allowed for the
+  /// question
+  UINT64     MaxValue;
+
+  /// The step size in which the question's
+  /// value can be incremented/decremented
+  UINT64     Step;
+
+  /// The type/size of numeric value that is
+  /// associated with this question
+  UINT8      ValueType;
+
+  /// Flag to indicate if MinValue and
+  /// MaxValue have been set
+  BOOLEAN    MinMaxSet;
+} DYN_HII_ONE_OF_DATA;
+
+/** A structure for OneOf Question
+    specific information.
+*/
+typedef struct {
+  /// The flags associated with the
+  /// one-of question
+  UINT8            Flags;
+
+  /// Subtitle prompt string ID
+  EFI_STRING_ID    Prompt;
+
+  /// Subtitle help string ID
+  EFI_STRING_ID    Help;
+} DYN_HII_SUBTITLE_DATA;
+
+/** A union for holding data for Question
+    data types.
+*/
+typedef union {
+  /// Checkbox question type data
+  DYN_HII_CHECKBOX_DATA    Checkbox;
+
+  /// Numeric question type data
+  DYN_HII_NUMERIC_DATA     Numeric;
+
+  /// Cross-reference question type data
+  DYN_HII_REF_DATA         Ref;
+
+  /// One-Of question type data
+  DYN_HII_ONE_OF_DATA      OneOf;
+
+  /// Subtitle statement type data
+  DYN_HII_SUBTITLE_DATA    Subtitle;
+} DYN_HII_STATEMENT_PAYLOAD;
+
+/** A structure for holding all data associated
+    with a Question.
+*/
+typedef struct {
+  /// A header for holding Question metadata
+  EFI_IFR_QUESTION_HEADER      QuestionHdr;
+
+  /// Payload of the question depending on the
+  /// question type
+  DYN_HII_STATEMENT_PAYLOAD    Statement;
+} DYN_HII_STATEMENT_DATA;
+
+/** A structure for holding information associated
+    with an OneOf Option for a Question.
+*/
+typedef struct {
+  /// Default node header
+  DYN_HII_NODE_HDR      Hdr;
+
+  /// String ID for the option text
+  EFI_STRING_ID         Text;
+
+  /// Option Flags
+  UINT8                 Flags;
+
+  /// Type of option
+  UINT8                 Type;
+
+  /// Option Value, governed by the option type
+  EFI_IFR_TYPE_VALUE    Value;
+} DYN_HII_ONE_OF_OPTION;
+
+/** A structure for holding information associated
+    with a Default for a Question.
+*/
+typedef struct {
+  /// Default node header
+  DYN_HII_NODE_HDR      Hdr;
+
+  /// Default store associated with this
+  /// default value
+  UINT16                DefaultId;
+
+  /// Type of data in the value field
+  UINT8                 Type;
+
+  /// The default value
+  EFI_IFR_TYPE_VALUE    Value;
+} DYN_HII_DEFAULT;
+
+/** A structure for holding information associated
+    with a Defaultstore for the formset.
+*/
+typedef struct {
+  /// Defaultstore node header
+  DYN_HII_NODE_HDR    Hdr;
+
+  /// String ID for the associated default
+  /// name string
+  EFI_STRING_ID       DefaultName;
+
+  /// Default ID which is unique within
+  /// a formset
+  UINT16              DefaultId;
+} DYN_HII_DEFAULTSTORE;
+
+/** A structure for holding information associated
+    with a Statement/Question.
+*/
+typedef struct {
+  /// Statement/Question node header
+  DYN_HII_NODE_HDR          Hdr;
+
+  /// Type of question/statement
+  DYN_HII_STATEMENT_TYPE    StatementType;
+
+  /// Question/Statement data
+  DYN_HII_STATEMENT_DATA    Data;
+
+  /// List of options for the question
+  LIST_ENTRY                OptionList;
+
+  /// List of default values for the question
+  LIST_ENTRY                DefaultList;
+} DYN_HII_STATEMENT;
+
+/** A structure for holding information associated
+    with a Form.
+*/
+typedef struct {
+  /// Form node header
+  DYN_HII_NODE_HDR    Hdr;
+
+  /// Form Id for the form
+  EFI_FORM_ID         FormId;
+
+  /// Form title string ID
+  EFI_STRING_ID       Title;
+
+  /// List of statements/questions in
+  /// the form
+  LIST_ENTRY          StatementList;
+} DYN_HII_FORM;
+
+/** A structure for holding information associated
+    with a Formset.
+*/
+typedef struct {
+  /// Formset node header
+  DYN_HII_NODE_HDR    Hdr;
+
+  /// Formset GUID
+  EFI_GUID            FormsetGuid;
+
+  /// Formset title string ID
+  EFI_STRING_ID       Title;
+
+  /// Formset help string ID
+  EFI_STRING_ID       Help;
+
+  /// Number of class identifier GUID's
+  /// in the formset
+  UINT8               ClassGuidCount;
+
+  /// Class identifier GUID array
+  EFI_GUID            ClassGuid[MAX_FORMSET_CLASS_GUID];
+
+  EFI_FORM_ID         FormIdCounter;
+
+  /// List of variable stores associated
+  /// with this formset
+  LIST_ENTRY          VarstoreList;
+
+  /// List of default stores associated
+  /// with this formset
+  LIST_ENTRY          DefaultstoreList;
+
+  /// List of forms associated with this
+  /// formset
+  LIST_ENTRY          FormList;
+} DYN_HII_FORMSET;
+
+/** A structure for holding information associated
+    with the IFR Form package.
+*/
+typedef struct {
+  /// Pointer to the IFR buffer
+  UINT8     *Data;
+
+  /// Size of the IFR Buffer
+  UINT32    Size;
+
+  /// Current position of the buffer
+  UINT32    Position;
+} DYN_HII_IFR_BUFFER;
+
+/** Function pointer for serializing functions.
+*/
+typedef
+EFI_STATUS
+(*DYN_HII_SERIALIZE_FN)(
+  IN  CONST DYN_HII_NODE_HDR    *Hdr,
+  IN        DYN_HII_IFR_BUFFER  *BufInfo
+  );

--- a/DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringGenerator.c
+++ b/DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringGenerator.c
@@ -1,0 +1,1168 @@
+/** @file
+  Dynamic Hii String and String Package generation API functions.
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "InternalHiiStringsLib.h"
+
+/** Get the length occupied by all the strings in the string package.
+
+  Add up the length of all the strings to be added in the string package,
+  along with the block header(EFI_HII_SIBT_STRING_UCS2) length.
+
+  @param [in]  StrList           List of strings.
+
+  @retval Total length of all the strings in the package, including their
+          respective block headers(EFI_HII_SIBT_STRING_UCS2).
+
+**/
+static
+UINTN
+DynHiiGetStrLength (
+  IN   CONST LIST_ENTRY  *StrList
+  )
+{
+  UINTN             StrLen;
+  LIST_ENTRY        *List;
+  DYN_HII_STR_INFO  *StrInfo;
+
+  StrLen = 0;
+  List   = GetFirstNode (StrList);
+  while (!IsNull (StrList, List)) {
+    StrInfo = BASE_CR (List, DYN_HII_STR_INFO, Link);
+
+    StrLen += StrInfo->Length;
+
+    List = GetNextNode (StrList, List);
+  }
+
+  return StrLen;
+}
+
+/** Copy all the strings into the string package.
+
+  Copy all the added strings to the string package. Each string is prefixed
+  with EFI_HII_SIBT_STRING_UCS2.
+
+  @param [in]  StrList           List of strings to be added.
+  @param [in]  StrPkg            Pointer to the string package where the
+                                 strings are to be added.
+
+  @retval Pointer to the location where the EFI_HII_SIBT_END_BLOCK would
+          be added.
+
+**/
+static
+UINT8 *
+DynHiiSetStrings (
+  IN   CONST LIST_ENTRY  *StrList,
+  IN   UINT8             *StrPkg
+  )
+{
+  LIST_ENTRY        *List;
+  DYN_HII_STR_INFO  *StrInfo;
+
+  List = GetFirstNode (StrList);
+  while (!IsNull (StrList, List)) {
+    StrInfo = BASE_CR (List, DYN_HII_STR_INFO, Link);
+
+    CopyMem (StrPkg, StrInfo->String, StrInfo->Length);
+
+    StrPkg += StrInfo->Length;
+
+    List = GetNextNode (StrList, List);
+  }
+
+  return StrPkg;
+}
+
+/** Set the EFI_HII_SIBT_END_BLOCK in the string package.
+
+  Set the EFI_HII_SIBT_END_BLOCK in the string package once all the
+  strings have been added to the package.
+
+  @param [in]  StrPkg           Pointer to the string package.
+
+**/
+static
+VOID
+DynHiiSetEndBlock (
+  IN   UINT8  *StrPkg
+  )
+{
+  EFI_HII_STRING_BLOCK  *Block;
+
+  Block = (EFI_HII_STRING_BLOCK *)StrPkg;
+
+  Block->BlockType = EFI_HII_SIBT_END;
+}
+
+/** Get the size of null terminated unicode string in bytes
+
+  Returns the size of a possibly unaligned null terminated unicode
+  string in bytes, including the null-terminator.
+
+  @param [in]  String           Pointer to the unicode string.
+
+  @retval  Size of the string.
+
+**/
+static
+UINT32
+DynHiiGetStrSize (
+  IN  CONST CHAR16  *String
+  )
+{
+  UINT32  StrLen;
+  CHAR16  Str;
+
+  for (StrLen = 1; (Str = ReadUnaligned16 (String++)) != L'\0'; StrLen++) {
+  }
+
+  return StrLen * sizeof (CHAR16);
+}
+
+/** Dump the contents of the end skip2 block.
+
+  Dump the contents of a EFI_HII_SIBT_SKIP2_BLOCK string block.
+
+  @param [in]  Buf               Pointer to the string block.
+
+**/
+static
+VOID
+DynHiiDumpSkip2Block (
+  IN   UINT8  *Buf
+  )
+{
+  UINT32  Idx;
+  UINT32  BlockSize;
+
+  BlockSize = sizeof (EFI_HII_SIBT_SKIP2_BLOCK);
+  for (Idx = 0; Idx < BlockSize; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+}
+
+/** Dump the contents of the end string block.
+
+  Dump the contents of a EFI_HII_SIBT_END_BLOCK string block.
+
+  @param [in]  Buf               Pointer to the string block.
+
+**/
+static
+VOID
+DynHiiDumpEndBlock (
+  IN   UINT8  *Buf
+  )
+{
+  UINT32  Idx;
+  UINT32  BlockSize;
+
+  BlockSize = sizeof (EFI_HII_SIBT_END_BLOCK);
+  for (Idx = 0; Idx < BlockSize; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+}
+
+/** Dump the contents of a UCS2 string block.
+
+  Dump the contents of a UCS2 string block.
+
+  @param [in]  Buf               Pointer to the string block.
+  @param [in]  StrLen            Length of the string associated
+                                 with the block.
+
+**/
+static
+VOID
+DynHiiDumpUcs2Block (
+  IN   UINT8   *Buf,
+  IN   UINT32  StrLen
+  )
+{
+  UINT32  Idx;
+  UINT32  Idx1;
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "0x%02x, ",
+    *Buf++
+    ));
+
+  for (Idx = 0; Idx < StrLen;) {
+    for (Idx1 = 0; Idx < StrLen && Idx1 < 16; Idx1++, Idx++) {
+      DEBUG ((
+        DEBUG_VERBOSE,
+        "0x%02x, ",
+        *Buf++
+        ));
+    }
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+}
+
+/** Dump the contents of a String package.
+
+  Dump the contents of a string package. Useful for debugging.
+
+  @param [in]  StrPkg            Pointer to the string package.
+  @param [in]  StrPkgLen         Length of the string package.
+
+  @retval  EFI_INVALID_PARAMETER  If any of the checks fail.
+  @retval  EFI_SUCCESS            No issues found.
+
+**/
+static
+EFI_STATUS
+DynHiiDumpStrPkg (
+  IN          UINT8   *StrPkg,
+  IN          UINT32  StrPkgLen
+  )
+{
+  UINT8                 *Buf;
+  UINT32                Idx;
+  UINT32                Idx1;
+  UINT32                HdrLen;
+  UINT32                StrLen;
+  EFI_STATUS            Status;
+  EFI_HII_STRING_BLOCK  *StrBlock;
+
+  Buf    = StrPkg;
+  Status = EFI_SUCCESS;
+  HdrLen = ReadUnaligned32 (Buf + sizeof (EFI_HII_PACKAGE_HEADER));
+
+  for (Idx = 0; Idx < HdrLen;) {
+    for (Idx1 = 0; Idx < HdrLen && Idx1 < 16; Idx1++, Idx++) {
+      DEBUG ((
+        DEBUG_VERBOSE,
+        "0x%02x, ",
+        *Buf++
+        ));
+    }
+
+    DEBUG ((DEBUG_VERBOSE, "\n"));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n\n"));
+
+  while (StrPkgLen != 0) {
+    StrBlock = (EFI_HII_STRING_BLOCK *)Buf;
+
+    switch (StrBlock->BlockType) {
+      case EFI_HII_SIBT_SKIP2:
+        DynHiiDumpSkip2Block (Buf);
+        Buf       += sizeof (EFI_HII_SIBT_SKIP2_BLOCK);
+        StrPkgLen -= sizeof (EFI_HII_SIBT_SKIP2_BLOCK);
+        break;
+
+      case EFI_HII_SIBT_STRING_UCS2:
+        StrLen = DynHiiGetStrSize (
+                   (CHAR16 *)(Buf + sizeof (EFI_HII_STRING_BLOCK))
+                   );
+        DynHiiDumpUcs2Block (Buf, StrLen);
+        Buf       += StrLen + sizeof (EFI_HII_STRING_BLOCK);
+        StrPkgLen -= StrLen + sizeof (EFI_HII_STRING_BLOCK);
+        break;
+
+      case EFI_HII_SIBT_END:
+        DynHiiDumpEndBlock (Buf);
+        Buf       += sizeof (EFI_HII_SIBT_END_BLOCK);
+        StrPkgLen -= sizeof (EFI_HII_SIBT_END_BLOCK);
+        break;
+
+      default:
+        DEBUG ((DEBUG_VERBOSE, "Received Invalid String Block Type.\n"));
+        Status = EFI_INVALID_PARAMETER;
+        goto out;
+    }
+  }
+
+out:
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "};\n\n"
+    ));
+
+  return Status;
+}
+
+/** Dump the contents of the String buffer.
+
+  Dump the contents of all the string packages. Useful for debugging.
+
+  @param [in]  StrPkg            Pointer to the string package array.
+  @param [in]  StrPkgLen         Length of the string package array.
+
+  @retval  EFI_INVALID_PARAMETER  If any of the checks fail.
+  @retval  EFI_SUCCESS            No issues found.
+
+**/
+static
+EFI_STATUS
+DynHiiDumpStrPkgBuf (
+  IN          UINT8   *StrPkg,
+  IN          UINT32  StrPkgLen
+  )
+{
+  UINT8       *Buf;
+  UINT32      Idx;
+  UINT32      PkgLen;
+  EFI_STATUS  Status;
+
+  if ((StrPkg == NULL) || (StrPkgLen == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "INFO: StrPkg => %p, StrPkgLen => 0x%x\n",
+    StrPkg,
+    StrPkgLen
+    ));
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "***** Generated String Package *****\n"
+    ));
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "StrByteStream[] = {\n"
+    ));
+
+  Buf = StrPkg;
+  for (Idx = 0; Idx < 4; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n\n"));
+
+  while (StrPkgLen != 0) {
+    PkgLen = ReadUnaligned24 (Buf);
+
+    if (StrPkgLen < PkgLen) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    Status = DynHiiDumpStrPkg (Buf, PkgLen);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Buf       += PkgLen;
+    StrPkgLen -= PkgLen;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Get number of string packages in the sting package array.
+
+  The string package array may consists of multiple string packages, each
+  associated with a language-code. Count the number of such string packages
+  in the array, and perform basic checks on the string packages, like they
+  actually are string packages.
+
+  @param [in]  StrPkgArr         Array of string packages.
+  @param [out] NumStrPkg         Number of string packages found in the
+                                 array.
+
+  @retval  EFI_INVALID_PARAMETER  If any of the checks fail.
+  @retval  EFI_SUCCESS            No issues found.
+
+**/
+static
+EFI_STATUS
+DynHiiGetNumStrPkg (
+  IN   CONST   UINT8   *StrPkgArr,
+  OUT          UINT32  *NumStrPkg
+  )
+{
+  CONST UINT8  *StrArr;
+  UINT8        PkgType;
+  UINT32       StrArrLen;
+  UINT32       PkgLen;
+  UINT32       TotalPkgLen;
+  UINT32       ReadPkgLen;
+  UINT32       PkgHdr;
+
+  ReadPkgLen = ReadUnaligned32 (StrPkgArr);
+  StrArrLen  = ReadPkgLen - sizeof (UINT32);
+
+  // The string package array generated by the
+  // AutoGen tool consists of a 4 byte array
+  // length member which has to be discarded.
+  StrArr = StrPkgArr + sizeof (UINT32);
+
+  *NumStrPkg  = 0;
+  TotalPkgLen = sizeof (UINT32);
+
+  while (StrArrLen != 0) {
+    PkgHdr  = ReadUnaligned32 (StrArr);
+    PkgType = (PkgHdr & 0xFF000000) >> 24;
+    PkgLen  = PkgHdr & 0x00FFFFFF;
+
+    if (PkgType != EFI_HII_PACKAGE_STRINGS) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (StrArrLen < PkgLen) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    StrArrLen   -= PkgLen;
+    StrArr      += PkgLen;
+    TotalPkgLen += PkgLen;
+
+    (*NumStrPkg)++;
+  }
+
+  if (ReadPkgLen != TotalPkgLen) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Build a list of strings under a given string package
+
+  The string package consists of multiple string blocks. The supported
+  types of string blocks are EFI_HII_SIBT_STRING_UCS2, EFI_HII_SIBT_SKIP2
+  and EFI_HII_SIBT_END. This function iterates through the existing string
+  package, and splits up the strings into a list of string blocks. The
+  EFI_HII_SIBT_END is not added to the list.
+
+  @param [in]  StrArr            String package array.
+  @param [in]  StrPkgInstance    An instance of a string package.
+
+  @retval  EFI_UNSUPPORTED        Unsupported string block type.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+  @retval  EFI_SUCCESS            The string list was built successfully.
+
+**/
+static
+EFI_STATUS
+DynHiiGenStringList (
+  IN CONST   UINT8                     *StrArr,
+  IN         DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance
+  )
+{
+  UINT32                          AllocLen;
+  UINT32                          PkgLen;
+  UINT32                          HdrLen;
+  CONST UINT8                     *StrOffset;
+  EFI_STRING_ID                   StringId;
+  DYN_HII_STR_INFO                *StrInfo;
+  CONST EFI_HII_STRING_BLOCK      *StrBlock;
+  CONST EFI_HII_SIBT_SKIP2_BLOCK  *Skip2Block;
+
+  PkgLen   = ReadUnaligned24 (StrArr);
+  HdrLen   = ReadUnaligned32 (StrArr + sizeof (EFI_HII_PACKAGE_HEADER));
+  StringId = 0;
+
+  PkgLen   -= HdrLen;
+  StrOffset = StrArr + HdrLen;
+
+  while (PkgLen != 0) {
+    StrBlock = (CONST EFI_HII_STRING_BLOCK *)StrOffset;
+    if ((StrBlock->BlockType != EFI_HII_SIBT_STRING_UCS2) &&
+        (StrBlock->BlockType != EFI_HII_SIBT_SKIP2) &&
+        (StrBlock->BlockType != EFI_HII_SIBT_END))
+    {
+      return EFI_UNSUPPORTED;
+    }
+
+    if (StrBlock->BlockType == EFI_HII_SIBT_SKIP2) {
+      AllocLen   = sizeof (EFI_HII_SIBT_SKIP2_BLOCK);
+      Skip2Block = (CONST EFI_HII_SIBT_SKIP2_BLOCK *)StrOffset;
+      StringId  += Skip2Block->SkipCount;
+    } else if (StrBlock->BlockType == EFI_HII_SIBT_END) {
+      PkgLen -= sizeof (EFI_HII_SIBT_END_BLOCK);
+      continue;
+    } else {
+      AllocLen = DynHiiGetStrSize (
+                   (CONST CHAR16 *)(StrOffset +
+                                    sizeof (EFI_HII_STRING_BLOCK))
+                   ) +
+                 sizeof (EFI_HII_STRING_BLOCK);
+      StringId++;
+    }
+
+    StrInfo = AllocateZeroPool (sizeof (*StrInfo));
+    if (StrInfo == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    StrInfo->String = AllocateZeroPool (AllocLen);
+    if (StrInfo->String == NULL) {
+      FreePool (StrInfo);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    StrInfo->StringId = StringId;
+    StrInfo->Length   = AllocLen;
+    CopyMem (StrInfo->String, StrOffset, AllocLen);
+    StrPkgInstance->MaxStringId = StringId;
+
+    InitializeListHead (&StrInfo->Link);
+    InsertTailList (&StrPkgInstance->StringList, &StrInfo->Link);
+
+    StrOffset += AllocLen;
+    PkgLen    -= AllocLen;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Initialize a string package instance.
+
+  The string package array may contain multiple string packages, each
+  associated with a language-code. Information about each such string
+  package is stored in a string instance structure. Initialize and
+  populate a string instance for a string package. Add the string
+  instance to the list of string instance list.
+
+  @param [in]  PkgIdx            Index of theString package.
+  @param [in]  StrPkgArr         Array of string packages.
+  @param [in]  StrPkg            Top-level string package information
+                                 structure.
+
+  @retval  EFI_UNSUPPORTED        Unsupported string block type.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+  @retval  EFI_SUCCESS            The string list was built successfully.
+
+**/
+static
+EFI_STATUS
+DynHiiInitStrPkgInstance (
+  IN          UINT32           PkgIdx,
+  IN  CONST   UINT8            *StrPkgArr,
+  IN          DYN_HII_STR_PKG  *StrPkg
+  )
+{
+  CONST UINT8               *StrArr;
+  UINT32                    Idx;
+  UINT32                    PkgLen;
+  UINT32                    HdrLen;
+  UINT32                    LangLen;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  // The string package array generated by the
+  // AutoGen tool consists of a 4 byte array
+  // length member which has to be discarded.
+  StrArr = StrPkgArr + sizeof (UINT32);
+
+  for (Idx = 0; Idx < PkgIdx; Idx++) {
+    PkgLen  = ReadUnaligned24 (StrArr);
+    StrArr += PkgLen;
+  }
+
+  StrPkgInstance = AllocateZeroPool (sizeof (*StrPkgInstance));
+  if (StrPkgInstance == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  StrPkgInstance->MaxStringId = 0;
+  InitializeListHead (&StrPkgInstance->StringList);
+  InitializeListHead (&StrPkgInstance->Link);
+  InsertTailList (&StrPkg->StrPkgList, &StrPkgInstance->Link);
+
+  HdrLen                    = ReadUnaligned32 (StrArr + sizeof (EFI_HII_PACKAGE_HEADER));
+  StrPkgInstance->StrPkgHdr = AllocateZeroPool (HdrLen);
+  if (StrPkgInstance->StrPkgHdr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (StrPkgInstance->StrPkgHdr, StrArr, HdrLen);
+
+  LangLen                      = HdrLen - OFFSET_OF (EFI_HII_STRING_PACKAGE_HDR, Language);
+  StrPkgInstance->LanguageCode = AllocateZeroPool (LangLen);
+  if (StrPkgInstance->LanguageCode == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  AsciiStrCpyS (
+    StrPkgInstance->LanguageCode,
+    LangLen,
+    (CONST CHAR8 *)StrArr + OFFSET_OF (EFI_HII_STRING_PACKAGE_HDR, Language)
+    );
+
+  return DynHiiGenStringList (StrArr, StrPkgInstance);
+}
+
+/** Check if a language is supported in the string package list
+
+  Check the list of string packages for a given language support.
+
+  @param [in]  StrPkg            Top-level string package information
+                                 structure.
+  @param [in]  Language          Language to check for.
+
+  @retval TRUE if the language is supported, FALSE otherwise.
+
+**/
+static
+BOOLEAN
+DynHiiIsLanguageSupported (
+  IN  CONST  DYN_HII_STR_PKG  *StrPkg,
+  IN  CONST  CHAR8            *Language
+  )
+{
+  LIST_ENTRY                *List;
+  DYN_HII_STR_PKG_INSTANCE  *Tmp;
+
+  List = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, List)) {
+    Tmp = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    if (AsciiStrCmp (Tmp->LanguageCode, Language) == 0) {
+      return TRUE;
+    }
+
+    List = GetNextNode (&StrPkg->StrPkgList, List);
+  }
+
+  return FALSE;
+}
+
+/** Append a string to the given string instance
+
+  Append a string block, either consisting of a real string or a dummy
+  EFI_HII_SIBT_STRING_UCS2 block to the list of strings under the string
+  instance passed to the function.
+
+  @param [in]  StrPkgInstance    An instance of a string package.
+  @param [in]  String            A UCS2 string.
+  @param [in]  DummyStr          Boolean flag indicating if a dummy
+                                 string block is to be added.
+
+  @retval  EFI_BAD_BUFFER_SIZE    Input is too large to fit under a
+                                  string package.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+  @retval  EFI_SUCCESS            The string was appended successfully.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+DynHiiStringAppend (
+  IN        DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance,
+  IN  CONST EFI_STRING                String,
+  IN        BOOLEAN                   DummyStr
+  )
+{
+  UINT8                           *Buf;
+  UINTN                           StrBytes;
+  DYN_HII_STR_INFO                *NewStr;
+  EFI_HII_STRING_BLOCK            StrBlock;
+  EFI_HII_SIBT_STRING_UCS2_BLOCK  *Ucs2Block;
+
+  NewStr = AllocateZeroPool (sizeof (*NewStr));
+  if (NewStr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  StrBytes = DummyStr ? sizeof (*Ucs2Block) :
+             DynHiiGetStrSize (String) + sizeof (EFI_HII_STRING_BLOCK);
+  if (StrBytes > MAX_UINT32) {
+    FreePool (NewStr);
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  NewStr->String = AllocateZeroPool (StrBytes);
+  if (NewStr->String == NULL) {
+    FreePool (NewStr);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  InitializeListHead (&NewStr->Link);
+  InsertTailList (&StrPkgInstance->StringList, &NewStr->Link);
+  NewStr->StringId = StrPkgInstance->MaxStringId;
+  NewStr->Length   = (UINT32)StrBytes;
+
+  if (DummyStr) {
+    Ucs2Block                   = (EFI_HII_SIBT_STRING_UCS2_BLOCK *)NewStr->String;
+    Ucs2Block->Header.BlockType = EFI_HII_SIBT_STRING_UCS2;
+  } else {
+    StrBlock.BlockType = EFI_HII_SIBT_STRING_UCS2;
+    CopyMem (NewStr->String, &StrBlock, sizeof (EFI_HII_STRING_BLOCK));
+    Buf = (UINT8 *)NewStr->String + sizeof (EFI_HII_STRING_BLOCK);
+    CopyMem (Buf, String, StrBytes - sizeof (EFI_HII_STRING_BLOCK));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Update the length of the string package header.
+
+  Based on the total length of the string blocks computed, added
+  to the size of EFI_HII_STRING_PACKAGE_HDR, update the string
+  package size.
+
+  @param [in]  StrPkgHdr         String package header.
+  @param [in]  StrLen            Combined length of all string
+                                 blocks for the string package.
+
+  @retval  EFI_BAD_BUFFER_SIZE    Input is too large to fit under a
+                                  string package.
+  @retval  EFI_SUCCESS            The string package header was updated
+                                  successfully.
+
+**/
+static
+EFI_STATUS
+DynHiiUpdateStrPkgHdrLen (
+  IN  EFI_HII_STRING_PACKAGE_HDR  *StrPkgHdr,
+  IN  UINT32                      StrLen
+  )
+{
+  UINT8   *PkgHdr;
+  UINT32  HdrLen;
+  UINT32  PkgLen;
+
+  PkgHdr = (UINT8 *)StrPkgHdr;
+  HdrLen = ReadUnaligned32 (PkgHdr + sizeof (EFI_HII_PACKAGE_HEADER));
+
+  PkgLen = HdrLen + StrLen;
+  if (PkgLen >= SIZE_16MB) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  WriteUnaligned24 ((UINT8 *)StrPkgHdr, PkgLen);
+
+  return EFI_SUCCESS;
+}
+
+/** Check if all the MaxStringId's match
+
+  Iterate through all the string packages that have been added, and
+  check that the MaxStrinId value in all the packages match.
+
+  @param [in]  StrPkgList        List of string packages.
+
+  @retval TRUE if the ID's match, FALSE otherwise.
+
+**/
+static
+BOOLEAN
+DynHiiStrIdMatch (
+  IN   LIST_ENTRY  *StrPkgList
+  )
+{
+  LIST_ENTRY                *List;
+  EFI_STRING_ID             CachedStrId;
+  EFI_STRING_ID             ReadStrId;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  CachedStrId = 0;
+  ReadStrId   = 0;
+
+  List = GetFirstNode (StrPkgList);
+  while (!IsNull (StrPkgList, List)) {
+    StrPkgInstance = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+    ReadStrId      = StrPkgInstance->MaxStringId;
+
+    if (CachedStrId == 0) {
+      CachedStrId = ReadStrId;
+    }
+
+    if (ReadStrId != CachedStrId) {
+      return FALSE;
+    }
+
+    List = GetNextNode (StrPkgList, List);
+  }
+
+  return TRUE;
+}
+
+/** Initialize the string package structure.
+
+  Initialize the DYN_HII_STR_PKG structure by allocating memory for
+  certain members of the structure and then initializing them with data
+  that were passed to the function.
+
+  @param [in]  StrPkgArr        Existing string package array which might
+                                consist of multiple language string arrays
+  @param [out] StrPkgHandle     Pointer to the DYN_HII_STR_HANDLE to hold
+                                the string package structure.
+
+  @retval  EFI_SUCCESS            The structure was initialized successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrPkgInfo or LanguageCode is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiInitStringPkg (
+  IN  CONST   UINT8               *StrPkgArr,
+  OUT         DYN_HII_STR_HANDLE  *StrPkgHandle
+  )
+{
+  UINT32           NumStrPkg;
+  UINT32           Idx;
+  EFI_STATUS       Status;
+  DYN_HII_STR_PKG  *StrPkg;
+
+  if ((StrPkgArr == NULL) || (StrPkgHandle == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = DynHiiGetNumStrPkg (StrPkgArr, &NumStrPkg);
+  if ((EFI_ERROR (Status)) || (NumStrPkg == 0)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Incorrect string package array received.\n",
+      __func__
+      ));
+    return Status;
+  }
+
+  StrPkg = AllocateZeroPool (sizeof (DYN_HII_STR_PKG));
+  if (StrPkg == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  StrPkg->LanguageCount = NumStrPkg;
+  StrPkg->Signature     = DYN_HII_STR_PKG_SIGNATURE;
+  InitializeListHead (&StrPkg->StrPkgList);
+
+  for (Idx = 0; Idx < NumStrPkg; Idx++) {
+    Status = DynHiiInitStrPkgInstance (Idx, StrPkgArr, StrPkg);
+    if (EFI_ERROR (Status)) {
+      goto err_out;
+    }
+  }
+
+  if (!DynHiiStrIdMatch (&StrPkg->StrPkgList)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: MaxStrId mismatch found in string packages.\n",
+      __func__
+      ));
+
+    Status = EFI_INVALID_PARAMETER;
+    goto err_out;
+  }
+
+  *StrPkgHandle = StrPkg;
+  return EFI_SUCCESS;
+
+err_out:
+  DynHiiFreeStringPackage (StrPkg);
+
+  return Status;
+}
+
+/** Add a string to the string list.
+
+  Add the string passed to the function to a list of strings that would be
+  added to form the string package.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+  @param [in]   Language          Language for which string is to be added.
+  @param [in]   String            The string that is to be added.
+  @param [out]  StringId          String Identifier assigned for this string.
+
+  @retval  EFI_SUCCESS            The string was added to the list successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrList or String is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddString (
+  IN  CONST DYN_HII_STR_HANDLE  StrPkgHandle,
+  IN  CONST CHAR8               *Language,
+  IN  CONST EFI_STRING          String,
+  OUT       EFI_STRING_ID       *StringId
+  )
+{
+  EFI_STATUS                Status;
+  LIST_ENTRY                *List;
+  DYN_HII_STR_PKG           *StrPkg;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  if ((StrPkgHandle == NULL) || (String == NULL) || (Language == NULL) ||
+      (StringId == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  StrPkg = StrPkgHandle;
+  if (StrPkg->Signature != DYN_HII_STR_PKG_SIGNATURE) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!DynHiiIsLanguageSupported (StrPkg, Language)) {
+    return EFI_NOT_FOUND;
+  }
+
+  List = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, List)) {
+    StrPkgInstance = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    StrPkgInstance->MaxStringId++;
+    *StringId = StrPkgInstance->MaxStringId;
+
+    Status = DynHiiStringAppend (
+               StrPkgInstance,
+               String,
+               AsciiStrCmp (StrPkgInstance->LanguageCode, Language) != 0
+               );
+
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    List = GetNextNode (&StrPkg->StrPkgList, List);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Generate string package.
+
+  Generate the string package from the input parameter. The string package is
+  subsequently added to the HII database through the HiiAddPackages() call.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+  @param [out]  StrPkgData        The generated array of string package(s).
+
+  @retval  EFI_SUCCESS            The string was added to the list successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrPkgInfo or LanguageCode is NULL.
+  @retval  EFI_ALREADY_STARTED    If StrPkgBuf is not NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiGenerateStringPackage (
+  IN   DYN_HII_STR_HANDLE  StrPkgHandle,
+  OUT  UINT8               **StrPkgData
+  )
+{
+  UINT8                     *StrPkgBuf;
+  UINT32                    *Arr;
+  UINT32                    StrPkgLen;
+  UINTN                     PkgLen;
+  UINTN                     TmpLen;
+  LIST_ENTRY                *List;
+  EFI_STATUS                Status;
+  DYN_HII_STR_PKG           *StrPkg;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  if ((StrPkgHandle == NULL) || (StrPkgData == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  StrPkg = StrPkgHandle;
+  if (StrPkg->Signature != DYN_HII_STR_PKG_SIGNATURE) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!DynHiiStrIdMatch (&StrPkg->StrPkgList)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: MaxStrId mismatch found in string packages.\n",
+      __func__
+      ));
+
+    return EFI_INVALID_PARAMETER;
+  }
+
+  TmpLen = 0;
+  List   = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, List)) {
+    PkgLen         = 0;
+    StrPkgInstance = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    PkgLen  = DynHiiGetStrLength (&StrPkgInstance->StringList);
+    PkgLen += sizeof (EFI_HII_SIBT_END_BLOCK);
+
+    if (PkgLen > MAX_UINT32) {
+      return EFI_BAD_BUFFER_SIZE;
+    }
+
+    Status = DynHiiUpdateStrPkgHdrLen (
+               StrPkgInstance->StrPkgHdr,
+               (UINT32)PkgLen
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    PkgLen += StrPkgInstance->StrPkgHdr->HdrSize;
+
+    TmpLen += PkgLen;
+
+    List = GetNextNode (&StrPkg->StrPkgList, List);
+  }
+
+  TmpLen += sizeof (UINT32);
+  if (TmpLen > MAX_UINT32) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  StrPkgLen = (UINT32)TmpLen;
+
+  StrPkgBuf = AllocateZeroPool (StrPkgLen);
+  if (StrPkgBuf == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Arr         = (UINT32 *)StrPkgBuf;
+  *Arr        = StrPkgLen;
+  *StrPkgData = StrPkgBuf;
+  StrPkgBuf  += sizeof (UINT32);
+
+  List = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, List)) {
+    PkgLen         = 0;
+    StrPkgInstance = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    CopyMem (
+      StrPkgBuf,
+      StrPkgInstance->StrPkgHdr,
+      StrPkgInstance->StrPkgHdr->HdrSize
+      );
+    StrPkgBuf += StrPkgInstance->StrPkgHdr->HdrSize;
+
+    StrPkgBuf = DynHiiSetStrings (
+                  &StrPkgInstance->StringList,
+                  StrPkgBuf
+                  );
+
+    DynHiiSetEndBlock (StrPkgBuf);
+    StrPkgBuf += sizeof (EFI_HII_SIBT_END_BLOCK);
+
+    List = GetNextNode (&StrPkg->StrPkgList, List);
+  }
+
+  DynHiiDumpStrPkgBuf (StrPkgBuf, StrPkgLen);
+
+  return EFI_SUCCESS;
+}
+
+/** Free all the strings in a string list.
+
+  Iterate through the string list, and free up memory allocated for the
+  string and the DYN_HII_STR_INFO structure that contains information about
+  that string.
+
+  @param [in]  StringList       The list of strings to be freed.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeStrings (
+  IN LIST_ENTRY  *StringList
+  )
+{
+  LIST_ENTRY        *Link;
+  LIST_ENTRY        *Next;
+  DYN_HII_STR_INFO  *StrInfo;
+
+  if (StringList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (StringList);
+  while (!IsNull (StringList, Link)) {
+    Next = GetNextNode (StringList, Link);
+
+    StrInfo = BASE_CR (Link, DYN_HII_STR_INFO, Link);
+    RemoveEntryList (Link);
+
+    FreePool (StrInfo->String);
+    FreePool (StrInfo);
+
+    Link = Next;
+  }
+
+  InitializeListHead (StringList);
+}
+
+/** Free up the string package buffer.
+
+  Free up the string package buffer along with any other allocations that
+  were done for the string package information structure.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeStringPackage (
+  IN   DYN_HII_STR_HANDLE  StrPkgHandle
+  )
+{
+  LIST_ENTRY                *Link;
+  LIST_ENTRY                *Next;
+  DYN_HII_STR_PKG           *StrPkg;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  if (StrPkgHandle == NULL) {
+    return;
+  }
+
+  StrPkg = StrPkgHandle;
+  if (StrPkg->Signature != DYN_HII_STR_PKG_SIGNATURE) {
+    return;
+  }
+
+  Link = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, Link)) {
+    Next           = GetNextNode (&StrPkg->StrPkgList, Link);
+    StrPkgInstance = BASE_CR (Link, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    if (StrPkgInstance->StrPkgHdr != NULL) {
+      FreePool (StrPkgInstance->StrPkgHdr);
+    }
+
+    if (StrPkgInstance->LanguageCode != NULL) {
+      FreePool (StrPkgInstance->LanguageCode);
+    }
+
+    DynHiiFreeStrings (&StrPkgInstance->StringList);
+    FreePool (StrPkgInstance);
+    RemoveEntryList (Link);
+
+    Link = Next;
+  }
+
+  FreePool (StrPkg);
+}

--- a/DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringGenerator.c
+++ b/DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringGenerator.c
@@ -1,0 +1,1314 @@
+/** @file
+  Dynamic Hii String and String Package generation API functions.
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Reference(s):
+  - UEFI specification 2.11, section 33.3.6 String Package
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "InternalHiiStringsLib.h"
+
+/** Get the length occupied by all the strings in the string package.
+
+  Add up the length of all the strings to be added in the string package,
+  along with the block header(EFI_HII_SIBT_STRING_UCS2) length.
+
+  @param [in]  StrList           List of strings.
+
+  @retval Total length of all the strings in the package, including their
+          respective block headers(EFI_HII_SIBT_STRING_UCS2).
+
+**/
+static
+UINTN
+DynHiiGetStrLength (
+  IN   CONST LIST_ENTRY  *StrList
+  )
+{
+  UINTN             StrLen;
+  LIST_ENTRY        *List;
+  DYN_HII_STR_INFO  *StrInfo;
+
+  StrLen = 0;
+  List   = GetFirstNode (StrList);
+  while (!IsNull (StrList, List)) {
+    StrInfo = BASE_CR (List, DYN_HII_STR_INFO, Link);
+
+    StrLen += StrInfo->Length;
+
+    List = GetNextNode (StrList, List);
+  }
+
+  return StrLen;
+}
+
+/** Copy all the strings into the string package.
+
+  Copy all the added strings to the string package. Each string is prefixed
+  with EFI_HII_SIBT_STRING_UCS2.
+
+  @param [in]  StrList           List of strings to be added.
+  @param [in]  StrPkgBuf         Pointer to the string package where the
+                                 strings are to be added.
+
+**/
+static
+VOID
+DynHiiSetStrings (
+  IN   CONST LIST_ENTRY        *StrList,
+  IN   DYN_HII_STR_PKG_BUFFER  *StrPkgBuf
+  )
+{
+  UINT8             *Buf;
+  LIST_ENTRY        *List;
+  DYN_HII_STR_INFO  *StrInfo;
+
+  Buf = StrPkgBuf->Data + StrPkgBuf->Position;
+
+  List = GetFirstNode (StrList);
+  while (!IsNull (StrList, List)) {
+    StrInfo = BASE_CR (List, DYN_HII_STR_INFO, Link);
+
+    CopyMem (Buf, StrInfo->String, StrInfo->Length);
+
+    Buf                 += StrInfo->Length;
+    StrPkgBuf->Position += StrInfo->Length;
+
+    List = GetNextNode (StrList, List);
+  }
+}
+
+/** Set the EFI_HII_SIBT_END_BLOCK in the string package.
+
+  Set the EFI_HII_SIBT_END_BLOCK in the string package once all the
+  strings have been added to the package.
+
+  @param [in]  StrPkgBuf        Pointer to the string package buffer.
+
+**/
+static
+VOID
+DynHiiSetEndBlock (
+  IN  DYN_HII_STR_PKG_BUFFER  *StrPkgBuf
+  )
+{
+  UINT8                 *Buf;
+  EFI_HII_STRING_BLOCK  *Block;
+
+  Buf   = StrPkgBuf->Data + StrPkgBuf->Position;
+  Block = (EFI_HII_STRING_BLOCK *)Buf;
+
+  Block->BlockType = EFI_HII_SIBT_END;
+
+  StrPkgBuf->Position += sizeof (EFI_HII_STRING_BLOCK);
+}
+
+/** Get the size of null terminated unicode string in bytes
+
+  Returns the size of a possibly unaligned null terminated unicode
+  string in bytes, including the null-terminator.
+
+  @param [in]  String           Pointer to the unicode string.
+
+  @retval  Size of the string.
+
+**/
+static
+UINT32
+DynHiiGetStrSize (
+  IN  CONST CHAR16  *String
+  )
+{
+  UINT32  StrLen;
+  CHAR16  Str;
+
+  for (StrLen = 1; (Str = ReadUnaligned16 (String++)) != L'\0'; StrLen++) {
+  }
+
+  return StrLen * sizeof (CHAR16);
+}
+
+/** Dump the contents of the end skip2 block.
+
+  Dump the contents of a EFI_HII_SIBT_SKIP2_BLOCK string block.
+
+  @param [in]  Buf               Pointer to the string block.
+
+**/
+static
+VOID
+DynHiiDumpSkip2Block (
+  IN   UINT8  *Buf
+  )
+{
+  UINT32  Idx;
+  UINT32  BlockSize;
+
+  BlockSize = sizeof (EFI_HII_SIBT_SKIP2_BLOCK);
+  for (Idx = 0; Idx < BlockSize; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+}
+
+/** Dump the contents of the end string block.
+
+  Dump the contents of a EFI_HII_SIBT_END_BLOCK string block.
+
+  @param [in]  Buf               Pointer to the string block.
+
+**/
+static
+VOID
+DynHiiDumpEndBlock (
+  IN   UINT8  *Buf
+  )
+{
+  UINT32  Idx;
+  UINT32  BlockSize;
+
+  BlockSize = sizeof (EFI_HII_SIBT_END_BLOCK);
+  for (Idx = 0; Idx < BlockSize; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+}
+
+/** Dump the contents of a UCS2 string block.
+
+  Dump the contents of a UCS2 string block.
+
+  @param [in]  Buf               Pointer to the string block.
+  @param [in]  StrLen            Length of the string associated
+                                 with the block.
+
+**/
+static
+VOID
+DynHiiDumpUcs2Block (
+  IN   UINT8   *Buf,
+  IN   UINT32  StrLen
+  )
+{
+  UINT32  Idx;
+  UINT32  Idx1;
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "0x%02x, ",
+    *Buf++
+    ));
+
+  for (Idx = 0; Idx < StrLen;) {
+    for (Idx1 = 0; Idx < StrLen && Idx1 < 16; Idx1++, Idx++) {
+      DEBUG ((
+        DEBUG_VERBOSE,
+        "0x%02x, ",
+        *Buf++
+        ));
+    }
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+}
+
+/** Dump the contents of a String package.
+
+  Dump the contents of a string package. Useful for debugging.
+
+  @param [in]  StrPkg            Pointer to the string package.
+  @param [in]  StrPkgLen         Length of the string package.
+
+  @retval  EFI_INVALID_PARAMETER  If any of the checks fail.
+  @retval  EFI_SUCCESS            No issues found.
+
+**/
+static
+EFI_STATUS
+DynHiiDumpStrPkg (
+  IN          UINT8   *StrPkg,
+  IN          UINT32  StrPkgLen
+  )
+{
+  UINT8                 *Buf;
+  UINT32                Idx;
+  UINT32                Idx1;
+  UINT32                HdrLen;
+  UINT32                StrLen;
+  EFI_STATUS            Status;
+  EFI_HII_STRING_BLOCK  *StrBlock;
+
+  Buf    = StrPkg;
+  Status = EFI_SUCCESS;
+  HdrLen = ReadUnaligned32 (Buf + sizeof (EFI_HII_PACKAGE_HEADER));
+
+  for (Idx = 0; Idx < HdrLen;) {
+    for (Idx1 = 0; Idx < HdrLen && Idx1 < 16; Idx1++, Idx++) {
+      DEBUG ((
+        DEBUG_VERBOSE,
+        "0x%02x, ",
+        *Buf++
+        ));
+    }
+
+    DEBUG ((DEBUG_VERBOSE, "\n"));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n\n"));
+  StrPkgLen -= HdrLen;
+
+  while (StrPkgLen != 0) {
+    StrBlock = (EFI_HII_STRING_BLOCK *)Buf;
+
+    switch (StrBlock->BlockType) {
+      case EFI_HII_SIBT_SKIP2:
+        DynHiiDumpSkip2Block (Buf);
+        Buf       += sizeof (EFI_HII_SIBT_SKIP2_BLOCK);
+        StrPkgLen -= sizeof (EFI_HII_SIBT_SKIP2_BLOCK);
+        break;
+
+      case EFI_HII_SIBT_STRING_UCS2:
+        StrLen = DynHiiGetStrSize (
+                   (CHAR16 *)(Buf + sizeof (EFI_HII_STRING_BLOCK))
+                   );
+        DynHiiDumpUcs2Block (Buf, StrLen);
+        Buf       += StrLen + sizeof (EFI_HII_STRING_BLOCK);
+        StrPkgLen -= StrLen + sizeof (EFI_HII_STRING_BLOCK);
+        break;
+
+      case EFI_HII_SIBT_END:
+        DynHiiDumpEndBlock (Buf);
+        Buf       += sizeof (EFI_HII_SIBT_END_BLOCK);
+        StrPkgLen -= sizeof (EFI_HII_SIBT_END_BLOCK);
+        break;
+
+      default:
+        DEBUG ((DEBUG_VERBOSE, "Received Invalid String Block Type.\n"));
+        Status = EFI_INVALID_PARAMETER;
+        goto out;
+    }
+  }
+
+out:
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "};\n\n"
+    ));
+
+  return Status;
+}
+
+/** Dump the contents of the String buffer.
+
+  Dump the contents of all the string packages. Useful for debugging.
+
+  @param [in]  StrPkg            Pointer to the string package array.
+  @param [in]  StrPkgLen         Length of the string package array.
+
+  @retval  EFI_INVALID_PARAMETER  If any of the checks fail.
+  @retval  EFI_SUCCESS            No issues found.
+
+**/
+static
+EFI_STATUS
+DynHiiDumpStrPkgBuf (
+  IN          UINT8   *StrPkg,
+  IN          UINT32  StrPkgLen
+  )
+{
+  UINT8       *Buf;
+  UINT32      Idx;
+  UINT32      PkgLen;
+  EFI_STATUS  Status;
+
+  if ((StrPkg == NULL) || (StrPkgLen == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "INFO: StrPkg => %p, StrPkgLen => 0x%x\n",
+    StrPkg,
+    StrPkgLen
+    ));
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "***** Generated String Package *****\n"
+    ));
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "StrByteStream[] = {\n"
+    ));
+
+  Buf = StrPkg;
+  for (Idx = 0; Idx < 4; Idx++) {
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "0x%02x, ",
+      *Buf++
+      ));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n\n"));
+  StrPkgLen -= sizeof (UINT32);
+
+  while (StrPkgLen != 0) {
+    PkgLen = ReadUnaligned24 (Buf);
+
+    if (StrPkgLen < PkgLen) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    Status = DynHiiDumpStrPkg (Buf, PkgLen);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Buf       += PkgLen;
+    StrPkgLen -= PkgLen;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Get number of string packages in the sting package array.
+
+  The string package array may consists of multiple string packages, each
+  associated with a language-code. Count the number of such string packages
+  in the array, and perform basic checks on the string packages, like they
+  actually are string packages.
+
+  @param [in]  StrPkgArr         Array of string packages.
+  @param [out] NumStrPkg         Number of string packages found in the
+                                 array.
+
+  @retval  EFI_INVALID_PARAMETER  If any of the checks fail.
+  @retval  EFI_SUCCESS            No issues found.
+
+**/
+static
+EFI_STATUS
+DynHiiGetNumStrPkg (
+  IN   CONST   UINT8   *StrPkgArr,
+  OUT          UINT32  *NumStrPkg
+  )
+{
+  CONST UINT8  *StrArr;
+  UINT8        PkgType;
+  UINT32       StrArrLen;
+  UINT32       PkgLen;
+  UINT32       TotalPkgLen;
+  UINT32       ReadPkgLen;
+  UINT32       PkgHdr;
+
+  ReadPkgLen = ReadUnaligned32 (StrPkgArr);
+  StrArrLen  = ReadPkgLen - sizeof (UINT32);
+
+  // The string package array generated by the
+  // AutoGen tool consists of a 4 byte array
+  // length member which has to be discarded.
+  StrArr = StrPkgArr + sizeof (UINT32);
+
+  *NumStrPkg  = 0;
+  TotalPkgLen = sizeof (UINT32);
+
+  while (StrArrLen != 0) {
+    PkgHdr  = ReadUnaligned32 (StrArr);
+    PkgType = (PkgHdr & 0xFF000000) >> 24;
+    PkgLen  = PkgHdr & 0x00FFFFFF;
+
+    if (PkgType != EFI_HII_PACKAGE_STRINGS) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (StrArrLen < PkgLen) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    StrArrLen   -= PkgLen;
+    StrArr      += PkgLen;
+    TotalPkgLen += PkgLen;
+
+    (*NumStrPkg)++;
+  }
+
+  if (ReadPkgLen != TotalPkgLen) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Build a list of strings under a given string package
+
+  The string package consists of multiple string blocks. The supported
+  types of string blocks are EFI_HII_SIBT_STRING_UCS2, EFI_HII_SIBT_SKIP2
+  and EFI_HII_SIBT_END. This function iterates through the existing string
+  package, and splits up the strings into a list of string blocks. The
+  EFI_HII_SIBT_END is not added to the list.
+
+  @param [in]  StrArr            String package array.
+  @param [in]  StrPkgInstance    An instance of a string package.
+
+  @retval  EFI_UNSUPPORTED        Unsupported string block type.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+  @retval  EFI_SUCCESS            The string list was built successfully.
+
+**/
+static
+EFI_STATUS
+DynHiiBuildStrBlocks (
+  IN CONST   UINT8                     *StrArr,
+  IN         DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance
+  )
+{
+  UINT32                          AllocLen;
+  UINT32                          PkgLen;
+  UINT32                          HdrLen;
+  CONST UINT8                     *StrOffset;
+  EFI_STRING_ID                   StringId;
+  DYN_HII_STR_INFO                *StrInfo;
+  CONST EFI_HII_STRING_BLOCK      *StrBlock;
+  CONST EFI_HII_SIBT_SKIP2_BLOCK  *Skip2Block;
+
+  PkgLen   = ReadUnaligned24 (StrArr);
+  HdrLen   = ReadUnaligned32 (StrArr + sizeof (EFI_HII_PACKAGE_HEADER));
+  StringId = 0;
+
+  PkgLen   -= HdrLen;
+  StrOffset = StrArr + HdrLen;
+
+  while (PkgLen != 0) {
+    StrBlock = (CONST EFI_HII_STRING_BLOCK *)StrOffset;
+    if ((StrBlock->BlockType != EFI_HII_SIBT_STRING_UCS2) &&
+        (StrBlock->BlockType != EFI_HII_SIBT_SKIP2) &&
+        (StrBlock->BlockType != EFI_HII_SIBT_END))
+    {
+      return EFI_UNSUPPORTED;
+    }
+
+    if (StrBlock->BlockType == EFI_HII_SIBT_SKIP2) {
+      AllocLen   = sizeof (EFI_HII_SIBT_SKIP2_BLOCK);
+      Skip2Block = (CONST EFI_HII_SIBT_SKIP2_BLOCK *)StrOffset;
+      StringId  += Skip2Block->SkipCount;
+    } else if (StrBlock->BlockType == EFI_HII_SIBT_END) {
+      PkgLen -= sizeof (EFI_HII_SIBT_END_BLOCK);
+      continue;
+    } else {
+      AllocLen = DynHiiGetStrSize (
+                   (CONST CHAR16 *)(StrOffset +
+                                    sizeof (EFI_HII_STRING_BLOCK))
+                   ) +
+                 sizeof (EFI_HII_STRING_BLOCK);
+      StringId++;
+    }
+
+    StrInfo = AllocateZeroPool (sizeof (*StrInfo));
+    if (StrInfo == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    StrInfo->String = AllocateZeroPool (AllocLen);
+    if (StrInfo->String == NULL) {
+      FreePool (StrInfo);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    StrInfo->StringId = StringId;
+    StrInfo->Length   = AllocLen;
+    CopyMem (StrInfo->String, StrOffset, AllocLen);
+    StrPkgInstance->MaxStringId = StringId;
+
+    InitializeListHead (&StrInfo->Link);
+    InsertTailList (&StrPkgInstance->StringList, &StrInfo->Link);
+
+    StrOffset += AllocLen;
+    PkgLen    -= AllocLen;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Initialize a string package instance.
+
+  The string package array may contain multiple string packages, each
+  associated with a language-code. Information about each such string
+  package is stored in a string instance structure. Initialize and
+  populate a string instance for a string package. Add the string
+  instance to the list of string instance list.
+
+  @param [in]  PkgIdx            Index of the string package.
+  @param [in]  StrPkgArr         Array of string packages.
+  @param [in]  StrPkg            Top-level string package information
+                                 structure.
+
+  @retval  EFI_UNSUPPORTED        Unsupported string block type.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+  @retval  EFI_SUCCESS            The string list was built successfully.
+
+**/
+static
+EFI_STATUS
+DynHiiInitStrPkgInstance (
+  IN          UINT32           PkgIdx,
+  IN  CONST   UINT8            *StrPkgArr,
+  IN          DYN_HII_STR_PKG  *StrPkg
+  )
+{
+  CONST UINT8               *StrArr;
+  UINT32                    Idx;
+  UINT32                    PkgLen;
+  UINT32                    HdrLen;
+  UINT32                    LangLen;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  // The string package array generated by the
+  // AutoGen tool consists of a 4 byte array
+  // length member which has to be discarded.
+  StrArr = StrPkgArr + sizeof (UINT32);
+
+  for (Idx = 0; Idx < PkgIdx; Idx++) {
+    PkgLen  = ReadUnaligned24 (StrArr);
+    StrArr += PkgLen;
+  }
+
+  StrPkgInstance = AllocateZeroPool (sizeof (*StrPkgInstance));
+  if (StrPkgInstance == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  StrPkgInstance->MaxStringId = 0;
+  InitializeListHead (&StrPkgInstance->StringList);
+  InitializeListHead (&StrPkgInstance->Link);
+  InsertTailList (&StrPkg->StrPkgList, &StrPkgInstance->Link);
+
+  HdrLen                    = ReadUnaligned32 (StrArr + sizeof (EFI_HII_PACKAGE_HEADER));
+  StrPkgInstance->StrPkgHdr = AllocateZeroPool (HdrLen);
+  if (StrPkgInstance->StrPkgHdr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (StrPkgInstance->StrPkgHdr, StrArr, HdrLen);
+
+  LangLen                      = HdrLen - OFFSET_OF (EFI_HII_STRING_PACKAGE_HDR, Language);
+  StrPkgInstance->LanguageCode = AllocateZeroPool (LangLen);
+  if (StrPkgInstance->LanguageCode == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  AsciiStrCpyS (
+    StrPkgInstance->LanguageCode,
+    LangLen,
+    (CONST CHAR8 *)StrArr + OFFSET_OF (EFI_HII_STRING_PACKAGE_HDR, Language)
+    );
+
+  return DynHiiBuildStrBlocks (StrArr, StrPkgInstance);
+}
+
+/** Check if a language-code is supported in the string package list
+
+
+
+  Check the list of string packages for a given language support.
+
+  @param [in]  StrPkg            Top-level string package information
+                                 structure.
+  @param [in]  Language          Language to check for.
+
+  @retval TRUE if the language is supported, FALSE otherwise.
+
+**/
+static
+BOOLEAN
+DynHiiLangCodeSupported (
+  IN  CONST  DYN_HII_STR_PKG  *StrPkg,
+  IN  CONST  CHAR8            *Language
+  )
+{
+  LIST_ENTRY                *List;
+  DYN_HII_STR_PKG_INSTANCE  *Tmp;
+
+  List = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, List)) {
+    Tmp = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    if (AsciiStrCmp (Tmp->LanguageCode, Language) == 0) {
+      return TRUE;
+    }
+
+    List = GetNextNode (&StrPkg->StrPkgList, List);
+  }
+
+  return FALSE;
+}
+
+/** Check for duplicate entries of languagecode.
+
+  Check if there are any duplicate languagecode entries in the StrTable
+  array. The number of supported languages is not going to be a large
+  number, hence this brute-force approach should be fine.
+
+  @param [in]   StrTable          An array of entries of languagecode and
+                                  string pair.
+  @param [in]   StrCount          Number of entries of StrTable.
+
+  @retval TRUE if there is duplication, FALSE otherwise.
+
+**/
+static
+BOOLEAN
+DynHiiDupStrTableEntry (
+  IN  CONST DYN_HII_STR_ENTRY  *StrTable,
+  IN        UINT32             StrCount
+  )
+{
+  UINT32                   Idx;
+  UINT32                   Idx1;
+  CONST DYN_HII_STR_ENTRY  *Entry;
+
+  for (Idx = 0; Idx < StrCount; Idx++) {
+    Entry = &StrTable[Idx];
+
+    for (Idx1 = Idx + 1; Idx1 < StrCount; Idx1++) {
+      if (AsciiStrCmp (Entry->LanguageCode, StrTable[Idx1].LanguageCode) == 0) {
+        return TRUE;
+      }
+    }
+  }
+
+  return FALSE;
+}
+
+/** Look for a language-code in the string table array.
+
+  Look for a language-code match in the string table array. This would
+  indicate if a string is to be added for the language-code parameter
+  that has been passed to this function.
+
+  @param [in]   LanguageCode      Language code to look for.
+  @param [in]   StrTable          An array of entries of languagecode and
+                                  string pair.
+  @param [in]   StrCount          Number of entries of StrTable.
+
+
+  @retval Pointer to the StrTable entry, NULL if no match found.
+
+**/
+static
+CONST DYN_HII_STR_ENTRY *
+DynHiiMatchStrTableEntry (
+  IN  CONST  CHAR8             *LanguageCode,
+  IN  CONST DYN_HII_STR_ENTRY  *StrTable,
+  IN        UINT32             StrCount
+  )
+{
+  UINT32  Idx;
+
+  for (Idx = 0; Idx < StrCount; Idx++) {
+    if (AsciiStrCmp (StrTable[Idx].LanguageCode, LanguageCode) == 0) {
+      return &StrTable[Idx];
+    }
+  }
+
+  return NULL;
+}
+
+/** Update the length of the string package header.
+
+  Based on the total length of the string blocks computed, added
+  to the size of EFI_HII_STRING_PACKAGE_HDR, update the string
+  package size.
+
+  @param [in]  StrPkgHdr         String package header.
+  @param [in]  StrLen            Combined length of all string
+                                 blocks for the string package.
+
+  @retval  EFI_BAD_BUFFER_SIZE    Input is too large to fit under a
+                                  string package.
+  @retval  EFI_SUCCESS            The string package header was updated
+                                  successfully.
+
+**/
+static
+EFI_STATUS
+DynHiiUpdateStrPkgHdrLen (
+  IN  EFI_HII_STRING_PACKAGE_HDR  *StrPkgHdr,
+  IN  UINT32                      StrLen
+  )
+{
+  UINT8   *PkgHdr;
+  UINT32  HdrLen;
+  UINT32  PkgLen;
+
+  PkgHdr = (UINT8 *)StrPkgHdr;
+  HdrLen = ReadUnaligned32 (PkgHdr + sizeof (EFI_HII_PACKAGE_HEADER));
+
+  PkgLen = HdrLen + StrLen;
+  if (PkgLen >= SIZE_16MB) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  WriteUnaligned24 ((UINT8 *)StrPkgHdr, PkgLen);
+
+  return EFI_SUCCESS;
+}
+
+/** Check if all the MaxStringId's match
+
+  Iterate through all the string packages that have been added, and
+  check that the MaxStrinId value in all the packages match.
+
+  @param [in]  StrPkgList        List of string packages.
+
+  @retval TRUE if the ID's match, FALSE otherwise.
+
+**/
+static
+BOOLEAN
+DynHiiStrIdMatch (
+  IN   LIST_ENTRY  *StrPkgList
+  )
+{
+  LIST_ENTRY                *List;
+  EFI_STRING_ID             CachedStrId;
+  EFI_STRING_ID             ReadStrId;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  CachedStrId = 0;
+  ReadStrId   = 0;
+
+  List = GetFirstNode (StrPkgList);
+  while (!IsNull (StrPkgList, List)) {
+    StrPkgInstance = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+    ReadStrId      = StrPkgInstance->MaxStringId;
+
+    if (CachedStrId == 0) {
+      CachedStrId = ReadStrId;
+    }
+
+    if (ReadStrId != CachedStrId) {
+      return FALSE;
+    }
+
+    List = GetNextNode (StrPkgList, List);
+  }
+
+  return TRUE;
+}
+
+/** Append a string to the given string instance
+
+  Append a string block, either consisting of a real string or a dummy
+  EFI_HII_SIBT_STRING_UCS2 block to the list of strings under the string
+  instance passed to the function.
+
+  @param [in]  StrPkgInstance    An instance of a string package.
+  @param [in]  StringId          String ID to be assigned for the
+                                 string.
+  @param [in]  String            A UCS2 string.
+
+  @retval  EFI_BAD_BUFFER_SIZE    Input is too large to fit under a
+                                  string package.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+  @retval  EFI_SUCCESS            The string was appended successfully.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+DynHiiStringAppend (
+  IN        DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance,
+  IN        EFI_STRING_ID             StringId,
+  IN  CONST EFI_STRING                String
+  )
+{
+  UINT8                           *Buf;
+  UINT64                          StrBytes;
+  BOOLEAN                         DummyStr;
+  DYN_HII_STR_INFO                *NewStr;
+  EFI_HII_STRING_BLOCK            StrBlock;
+  EFI_HII_SIBT_STRING_UCS2_BLOCK  *Ucs2Block;
+
+  NewStr = AllocateZeroPool (sizeof (*NewStr));
+  if (NewStr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  DummyStr = String == NULL ? TRUE : FALSE;
+
+  StrBytes = DummyStr ? sizeof (*Ucs2Block) :
+             DynHiiGetStrSize (String) + sizeof (EFI_HII_STRING_BLOCK);
+  if (StrBytes > MAX_UINT32) {
+    FreePool (NewStr);
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  NewStr->String = AllocateZeroPool (StrBytes);
+  if (NewStr->String == NULL) {
+    FreePool (NewStr);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  InitializeListHead (&NewStr->Link);
+  InsertTailList (&StrPkgInstance->StringList, &NewStr->Link);
+  NewStr->StringId = StringId;
+  NewStr->Length   = (UINT32)StrBytes;
+
+  if (DummyStr) {
+    Ucs2Block                   = (EFI_HII_SIBT_STRING_UCS2_BLOCK *)NewStr->String;
+    Ucs2Block->Header.BlockType = EFI_HII_SIBT_STRING_UCS2;
+  } else {
+    StrBlock.BlockType = EFI_HII_SIBT_STRING_UCS2;
+    CopyMem (NewStr->String, &StrBlock, sizeof (EFI_HII_STRING_BLOCK));
+    Buf = (UINT8 *)NewStr->String + sizeof (EFI_HII_STRING_BLOCK);
+    CopyMem (Buf, String, StrBytes - sizeof (EFI_HII_STRING_BLOCK));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Add a string to the string list.
+
+  Add the string(s) passed to the function to a list of strings that would
+  be added to form the string package. Each index of StrTable is a pair of
+  languagecode and the corresponding string. If there are multiple
+  languages that are supported, strings for those languages can be added.
+  Alternatively, it is also possible to not add a string for a supported
+  language, in which case the string is left blank.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+  @param [in]   StrTable          An array of entries of languagecode and
+                                  string pair to be added.
+  @param [in]   StrCount          Number of entries of StrTable.
+  @param [out]  StringId          String Identifier assigned for this set
+                                  of strings.
+
+  @retval  EFI_SUCCESS            The string was added to the list successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrList or String is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiAddString (
+  IN  CONST DYN_HII_STR_HANDLE  StrPkgHandle,
+  IN  CONST DYN_HII_STR_ENTRY   *StrTable,
+  IN        UINT32              StrCount,
+  OUT       EFI_STRING_ID       *StringId
+  )
+{
+  UINT32                    Idx;
+  EFI_STATUS                Status;
+  LIST_ENTRY                *List;
+  EFI_STRING_ID             NewStringId;
+  DYN_HII_STR_PKG           *StrPkg;
+  CONST DYN_HII_STR_ENTRY   *Entry;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  if ((StrPkgHandle == NULL) || (StrTable == NULL) || (StringId == NULL) ||
+      (StrCount == 0))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  StrPkg = StrPkgHandle;
+  if (StrPkg->Signature != DYN_HII_STR_PKG_SIGNATURE) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!DynHiiStrIdMatch (&StrPkg->StrPkgList)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: MaxStrId mismatch found in string packages.\n",
+      __func__
+      ));
+
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Idx = 0; Idx < StrCount; Idx++) {
+    if ((StrTable[Idx].LanguageCode == NULL) ||
+        (StrTable[Idx].String == NULL))
+    {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (!DynHiiLangCodeSupported (StrPkg, StrTable[Idx].LanguageCode)) {
+      return EFI_NOT_FOUND;
+    }
+  }
+
+  if (DynHiiDupStrTableEntry (StrTable, StrCount)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Duplicate language-code entries found.\n",
+      __func__
+      ));
+
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NewStringId = 0;
+  List        = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, List)) {
+    StrPkgInstance = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    StrPkgInstance->MaxStringId++;
+    NewStringId = StrPkgInstance->MaxStringId;
+    Entry       = DynHiiMatchStrTableEntry (
+                    StrPkgInstance->LanguageCode,
+                    StrTable,
+                    StrCount
+                    );
+
+    Status = DynHiiStringAppend (
+               StrPkgInstance,
+               StrPkgInstance->MaxStringId,
+               Entry == NULL ? NULL : Entry->String
+               );
+
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    List = GetNextNode (&StrPkg->StrPkgList, List);
+  }
+
+  *StringId = NewStringId;
+
+  return EFI_SUCCESS;
+}
+
+/** Initialize the string package structure.
+
+  Initialize the DYN_HII_STR_PKG structure by allocating memory for
+  certain members of the structure and then initializing them with data
+  that were passed to the function.
+
+  @param [in]  StrPkgArr        Existing string package array which might
+                                consist of multiple language string arrays
+  @param [out] StrPkgHandle     Pointer to the DYN_HII_STR_HANDLE to hold
+                                the string package structure.
+
+  @retval  EFI_SUCCESS            The structure was initialized successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrPkgInfo or LanguageCode is NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiInitStringPkg (
+  IN  CONST   UINT8               *StrPkgArr,
+  OUT         DYN_HII_STR_HANDLE  *StrPkgHandle
+  )
+{
+  UINT32           NumStrPkg;
+  UINT32           Idx;
+  EFI_STATUS       Status;
+  DYN_HII_STR_PKG  *StrPkg;
+
+  if ((StrPkgArr == NULL) || (StrPkgHandle == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = DynHiiGetNumStrPkg (StrPkgArr, &NumStrPkg);
+  if ((EFI_ERROR (Status)) || (NumStrPkg == 0)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Incorrect string package array received.\n",
+      __func__
+      ));
+    return Status;
+  }
+
+  StrPkg = AllocateZeroPool (sizeof (DYN_HII_STR_PKG));
+  if (StrPkg == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  StrPkg->LanguageCount = NumStrPkg;
+  StrPkg->Signature     = DYN_HII_STR_PKG_SIGNATURE;
+  InitializeListHead (&StrPkg->StrPkgList);
+
+  for (Idx = 0; Idx < NumStrPkg; Idx++) {
+    Status = DynHiiInitStrPkgInstance (Idx, StrPkgArr, StrPkg);
+    if (EFI_ERROR (Status)) {
+      goto err_out;
+    }
+  }
+
+  if (!DynHiiStrIdMatch (&StrPkg->StrPkgList)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: MaxStrId mismatch found in string packages.\n",
+      __func__
+      ));
+
+    Status = EFI_INVALID_PARAMETER;
+    goto err_out;
+  }
+
+  *StrPkgHandle = StrPkg;
+  return EFI_SUCCESS;
+
+err_out:
+  DynHiiFreeStringPackage (StrPkg);
+
+  return Status;
+}
+
+/** Generate string package.
+
+  Generate the string package from the input parameter. The string package is
+  subsequently added to the HII database through the HiiAddPackages() call.
+
+  The serialized string package buffer is passed back to the caller in
+  StrPkgData. It is the caller's responsibility to free up the string package
+  buffer through a call to FreePool().
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+  @param [out]  StrPkgData        The generated array of string package(s).
+
+  @retval  EFI_SUCCESS            The string was added to the list successfully.
+  @retval  EFI_INVALID_PARAMETER  The StrPkgInfo or LanguageCode is NULL.
+  @retval  EFI_ALREADY_STARTED    If StrPkgBuf is not NULL.
+  @retval  EFI_OUT_OF_RESOURCES   Unable to allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DynHiiGenerateStringPackage (
+  IN   DYN_HII_STR_HANDLE  StrPkgHandle,
+  OUT  UINT8               **StrPkgData
+  )
+{
+  UINT8                     *Buf;
+  UINT64                    PkgLen;
+  UINT64                    TmpLen;
+  LIST_ENTRY                *List;
+  EFI_STATUS                Status;
+  DYN_HII_STR_PKG           *StrPkg;
+  DYN_HII_STR_PKG_BUFFER    StrPkgBuf;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  if ((StrPkgHandle == NULL) || (StrPkgData == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  StrPkg = StrPkgHandle;
+  if (StrPkg->Signature != DYN_HII_STR_PKG_SIGNATURE) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!DynHiiStrIdMatch (&StrPkg->StrPkgList)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: MaxStrId mismatch found in string packages.\n",
+      __func__
+      ));
+
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *StrPkgData = NULL;
+  ZeroMem (&StrPkgBuf, sizeof (DYN_HII_STR_PKG_BUFFER));
+  TmpLen = 0;
+  List   = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, List)) {
+    PkgLen         = 0;
+    StrPkgInstance = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    PkgLen  = DynHiiGetStrLength (&StrPkgInstance->StringList);
+    PkgLen += sizeof (EFI_HII_SIBT_END_BLOCK);
+
+    if (PkgLen > MAX_UINT32) {
+      return EFI_BAD_BUFFER_SIZE;
+    }
+
+    Status = DynHiiUpdateStrPkgHdrLen (
+               StrPkgInstance->StrPkgHdr,
+               (UINT32)PkgLen
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    PkgLen += StrPkgInstance->StrPkgHdr->HdrSize;
+
+    TmpLen += PkgLen;
+
+    List = GetNextNode (&StrPkg->StrPkgList, List);
+  }
+
+  TmpLen += sizeof (UINT32);
+  if (TmpLen > MAX_UINT32) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  StrPkgBuf.Size = (UINT32)TmpLen;
+
+  StrPkgBuf.Data = AllocateZeroPool (StrPkgBuf.Size);
+  if (StrPkgBuf.Data == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // The string package array generated by the
+  // AutoGen tool consists of a 4 byte array
+  // length member. This needs to be populated
+  // as well.
+  *(UINT32 *)StrPkgBuf.Data = StrPkgBuf.Size;
+  StrPkgBuf.Position        = sizeof (UINT32);
+
+  List = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, List)) {
+    StrPkgInstance = BASE_CR (List, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    Buf = StrPkgBuf.Data + StrPkgBuf.Position;
+    CopyMem (
+      Buf,
+      StrPkgInstance->StrPkgHdr,
+      StrPkgInstance->StrPkgHdr->HdrSize
+      );
+    StrPkgBuf.Position += StrPkgInstance->StrPkgHdr->HdrSize;
+
+    DynHiiSetStrings (&StrPkgInstance->StringList, &StrPkgBuf);
+    DynHiiSetEndBlock (&StrPkgBuf);
+
+    List = GetNextNode (&StrPkg->StrPkgList, List);
+  }
+
+  if (StrPkgBuf.Size != StrPkgBuf.Position) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Error constructing the string package.\n",
+      __func__
+      ));
+
+    FreePool (StrPkgBuf.Data);
+
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  *StrPkgData = StrPkgBuf.Data;
+
+  DynHiiDumpStrPkgBuf (StrPkgBuf.Data, StrPkgBuf.Size);
+
+  return EFI_SUCCESS;
+}
+
+/** Free all the strings in a string list.
+
+  Iterate through the string list, and free up memory allocated for the
+  string and the DYN_HII_STR_INFO structure that contains information about
+  that string.
+
+  @param [in]  StringList       The list of strings to be freed.
+
+**/
+static
+VOID
+EFIAPI
+DynHiiFreeStrings (
+  IN LIST_ENTRY  *StringList
+  )
+{
+  LIST_ENTRY        *Link;
+  LIST_ENTRY        *Next;
+  DYN_HII_STR_INFO  *StrInfo;
+
+  if (StringList == NULL) {
+    return;
+  }
+
+  Link = GetFirstNode (StringList);
+  while (!IsNull (StringList, Link)) {
+    Next = GetNextNode (StringList, Link);
+
+    StrInfo = BASE_CR (Link, DYN_HII_STR_INFO, Link);
+    RemoveEntryList (Link);
+
+    FreePool (StrInfo->String);
+    FreePool (StrInfo);
+
+    Link = Next;
+  }
+
+  InitializeListHead (StringList);
+}
+
+/** Free up the string package data structures.
+
+  Free up all the structures that were used for building up the string
+  package.
+
+  @param [in]   StrPkgHandle      Handle to the top-level string package
+                                  information structure.
+
+**/
+VOID
+EFIAPI
+DynHiiFreeStringPackage (
+  IN   DYN_HII_STR_HANDLE  StrPkgHandle
+  )
+{
+  LIST_ENTRY                *Link;
+  LIST_ENTRY                *Next;
+  DYN_HII_STR_PKG           *StrPkg;
+  DYN_HII_STR_PKG_INSTANCE  *StrPkgInstance;
+
+  if (StrPkgHandle == NULL) {
+    return;
+  }
+
+  StrPkg = StrPkgHandle;
+  if (StrPkg->Signature != DYN_HII_STR_PKG_SIGNATURE) {
+    return;
+  }
+
+  Link = GetFirstNode (&StrPkg->StrPkgList);
+  while (!IsNull (&StrPkg->StrPkgList, Link)) {
+    Next           = GetNextNode (&StrPkg->StrPkgList, Link);
+    StrPkgInstance = BASE_CR (Link, DYN_HII_STR_PKG_INSTANCE, Link);
+
+    if (StrPkgInstance->StrPkgHdr != NULL) {
+      FreePool (StrPkgInstance->StrPkgHdr);
+    }
+
+    if (StrPkgInstance->LanguageCode != NULL) {
+      FreePool (StrPkgInstance->LanguageCode);
+    }
+
+    DynHiiFreeStrings (&StrPkgInstance->StringList);
+    RemoveEntryList (Link);
+    FreePool (StrPkgInstance);
+
+    Link = Next;
+  }
+
+  FreePool (StrPkg);
+}

--- a/DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringsLib.inf
+++ b/DynamicTablesPkg/Library/Common/HiiStringsLib/HiiStringsLib.inf
@@ -1,0 +1,30 @@
+## @file
+#  Dynamic HII Strings Library
+#
+#  Copyright (c) 2026, Arm Limited. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = HiiStringsLib
+  FILE_GUID      = 8C34C70F-DCE2-45B9-A399-7BEA995EC433
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = HiiStringsLib
+
+[Sources]
+  HiiStringGenerator.c
+  InternalHiiStringsLib.h
+
+[Packages]
+  DynamicTablesPkg/DynamicTablesPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib

--- a/DynamicTablesPkg/Library/Common/HiiStringsLib/InternalHiiStringsLib.h
+++ b/DynamicTablesPkg/Library/Common/HiiStringsLib/InternalHiiStringsLib.h
@@ -1,0 +1,80 @@
+/** @file
+  Data structures for dynamically building a HII string package.
+
+  This file contains data structures that are needed for
+  generating string package dynamically.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+**/
+
+#pragma once
+
+#include <Base.h>
+#include <Library/HiiStringsLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+/// Signature for DYN_HII_STR_PKG
+#define DYN_HII_STR_PKG_SIGNATURE  SIGNATURE_32 ('D', 'H', 'S', 'P')
+
+/** A structure for a string to be
+    added to the string package.
+*/
+typedef struct {
+  /// A link to another string
+  LIST_ENTRY       Link;
+
+  /// String ID of the corresponding
+  /// string
+  EFI_STRING_ID    StringId;
+
+  /// String to be added to the string
+  /// package
+  CHAR16           *String;
+
+  /// Combined length of the string and
+  /// the EFI_HII_STRING_BLOCK structure
+  UINT32           Length;
+} DYN_HII_STR_INFO;
+
+/** A structure for keeping information
+    specific to a string package.
+*/
+typedef struct {
+  /// A link to another language package
+  LIST_ENTRY                    Link;
+
+  /// List of strings in the form of
+  /// DYN_HII_STR_INFO that are associated
+  /// with this string package
+  LIST_ENTRY                    StringList;
+
+  /// The package header for this string
+  /// package
+  EFI_HII_STRING_PACKAGE_HDR    *StrPkgHdr;
+
+  /// Language code string associated with
+  /// the string package. The StringId for
+  /// the language string will always be 1
+  CHAR8                         *LanguageCode;
+
+  /// Max string ID for this package
+  EFI_STRING_ID                 MaxStringId;
+} DYN_HII_STR_PKG_INSTANCE;
+
+typedef struct {
+  /// Signature for the structure
+  UINT32        Signature;
+
+  /// A list of string packages, corresponding to
+  /// the DYN_HII_STR_PKG_INSTANCE structure.
+  LIST_ENTRY    StrPkgList;
+
+  /// Number of languages that are part of the
+  /// string package array.
+  UINT32        LanguageCount;
+} DYN_HII_STR_PKG;

--- a/DynamicTablesPkg/Library/Common/HiiStringsLib/InternalHiiStringsLib.h
+++ b/DynamicTablesPkg/Library/Common/HiiStringsLib/InternalHiiStringsLib.h
@@ -1,0 +1,103 @@
+/** @file
+  Data structures for dynamically building a HII string package.
+
+  This file contains data structures that are needed for
+  generating string package dynamically.
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+
+  @par Reference(s):
+  - UEFI specification 2.11, section 33.3.6 String Package
+
+**/
+
+#pragma once
+
+#include <Base.h>
+#include <Library/HiiStringsLib.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+/// Signature for DYN_HII_STR_PKG
+#define DYN_HII_STR_PKG_SIGNATURE  SIGNATURE_32 ('D', 'H', 'S', 'P')
+
+/** A structure for a string to be
+    added to the string package.
+*/
+typedef struct {
+  /// A link to another string
+  LIST_ENTRY       Link;
+
+  /// String ID of the corresponding
+  /// string
+  EFI_STRING_ID    StringId;
+
+  /// String to be added to the string
+  /// package
+  CHAR16           *String;
+
+  /// Combined length of the string and
+  /// the EFI_HII_STRING_BLOCK structure
+  UINT32           Length;
+} DYN_HII_STR_INFO;
+
+/** A structure for keeping information
+    specific to a string package.
+*/
+typedef struct {
+  /// A link to another language package
+  LIST_ENTRY                    Link;
+
+  /// List of strings in the form of
+  /// DYN_HII_STR_INFO that are associated
+  /// with this string package
+  LIST_ENTRY                    StringList;
+
+  /// The package header for this string
+  /// package
+  EFI_HII_STRING_PACKAGE_HDR    *StrPkgHdr;
+
+  /// Language code string associated with
+  /// the string package. The StringId for
+  /// the language string will always be 1
+  CHAR8                         *LanguageCode;
+
+  /// Max string ID. Should be the same for all
+  /// string package instances.
+  EFI_STRING_ID                 MaxStringId;
+} DYN_HII_STR_PKG_INSTANCE;
+
+/** A structure for holding information for all
+    the string packages.
+*/
+typedef struct {
+  /// Signature for the structure
+  UINT32        Signature;
+
+  /// A list of string packages, corresponding to
+  /// the DYN_HII_STR_PKG_INSTANCE structure
+  LIST_ENTRY    StrPkgList;
+
+  /// Number of languages that are part of the
+  /// string package array. This is same as the
+  /// count of elements in the StrPkgList
+  UINT32        LanguageCount;
+} DYN_HII_STR_PKG;
+
+/** A structure for holding information associated
+    with the serialized string package.
+*/
+typedef struct {
+  /// Pointer to the string package buffer
+  UINT8     *Data;
+
+  /// Size of the string package Buffer
+  UINT32    Size;
+
+  /// Current position of the buffer
+  UINT32    Position;
+} DYN_HII_STR_PKG_BUFFER;

--- a/DynamicTablesPkg/Library/Hii/CpuFormGenerator/ArmCpuFormGenerator.c
+++ b/DynamicTablesPkg/Library/Hii/CpuFormGenerator/ArmCpuFormGenerator.c
@@ -1,0 +1,1055 @@
+/** @file
+  Dynamic Hii Cpu Form Generator for Arm platforms.
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PrintLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerHelper.h>
+#include <ConfigurationManagerObject.h>
+#include <HiiFormsGenerator.h>
+#include <Guid/MdeModuleHii.h>
+#include <Library/DevicePathLib.h>
+#include <Library/HiiFormsLib.h>
+#include <Library/HiiLib.h>
+#include <Library/HiiStringsLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/TableHelperLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "ArmCpuFormGenerator.h"
+
+static EFI_QUESTION_ID  mQuestionId = DYN_HII_ARM_CPU_QUESTION_ID_START;
+extern UINT8            CpuFormGeneratorStrings[];
+
+HII_VENDOR_DEVICE_PATH  mHiiVendorDevicePath0 = {
+  {
+    {
+      HARDWARE_DEVICE_PATH,
+      HW_VENDOR_DP,
+      {
+        (UINT8)(sizeof (VENDOR_DEVICE_PATH)),
+        (UINT8)((sizeof (VENDOR_DEVICE_PATH)) >> 8)
+      }
+    },
+    DYNAMIC_PLATFORM_CFG_ARM_CPU_GUID
+  },
+  {
+    END_DEVICE_PATH_TYPE,
+    END_ENTIRE_DEVICE_PATH_SUBTYPE,
+    {
+      (UINT8)(END_DEVICE_PATH_LENGTH),
+      (UINT8)((END_DEVICE_PATH_LENGTH) >> 8)
+    }
+  }
+};
+
+/** This macro expands to a function that retrieves the GIC
+    CPU interface Information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArm,
+  EArmObjGicCInfo,
+  CM_ARM_GICC_INFO
+  );
+
+/**
+  This function allows a caller to extract the current configuration for one
+  or more named elements from the target driver.
+
+  @param  This                   Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param  Request                A null-terminated Unicode string in
+                                 <ConfigRequest> format.
+  @param  Progress               On return, points to a character in the Request
+                                 string. Points to the string's null terminator if
+                                 request was successful. Points to the most recent
+                                 '&' before the first failing name/value pair (or
+                                 the beginning of the string if the failure is in
+                                 the first name/value pair) if the request was not
+                                 successful.
+  @param  Results                A null-terminated Unicode string in
+                                 <ConfigAltResp> format which has all values filled
+                                 in for the names in the Request string. String to
+                                 be allocated by the called function.
+
+  @retval EFI_SUCCESS            The Results is filled with the requested values.
+  @retval EFI_OUT_OF_RESOURCES   Not enough memory to store the results.
+  @retval EFI_INVALID_PARAMETER  Request is illegal syntax, or unknown name.
+  @retval EFI_NOT_FOUND          Routing data doesn't match any storage in this
+                                 driver.
+**/
+EFI_STATUS
+EFIAPI
+ExtractConfig (
+  IN  CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN  CONST EFI_STRING                      Request,
+  OUT EFI_STRING                            *Progress,
+  OUT EFI_STRING                            *Results
+  )
+{
+  HII_ARM_CPU_GEN_PRIV             *Priv;
+  CHAR16                           *StrPointer;
+  UINTN                            Size;
+  BOOLEAN                          AllocatedRequest;
+  EFI_STRING                       ConfigRequest;
+  UINTN                            BufferSize;
+  EFI_STATUS                       Status;
+  EFI_STRING                       ConfigRequestHdr;
+  EFI_HII_CONFIG_ROUTING_PROTOCOL  *HiiConfigRouting;
+  CONST CHAR16                     VariableName[]       = L"ArmCpuVar";
+  CONST EFI_GUID                   DynPlatCfgCpuVarGuid = DYN_PLATFORM_CPU_VARSTORE_GUID;
+
+  if ((Progress == NULL) || (Results == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Priv             = DYN_HII_ARM_CPU_GEN_PRIVATE_FROM_THIS (This);
+  HiiConfigRouting = Priv->HiiConfigRouting;
+
+  AllocatedRequest = FALSE;
+  BufferSize       = Priv->ArmCpuVarSize;
+
+  if (Request == NULL) {
+    // NULL Request indicates request for entire config database. Build a
+    // Request string from the ConfigHdr with appended OFFSET and WIDTH.
+    ConfigRequestHdr = HiiConstructConfigHdr (
+                         (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                         (CHAR16 *)VariableName,
+                         Priv->DevHandle
+                         );
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (0);
+      return EFI_UNSUPPORTED;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    if (ConfigRequest == NULL) {
+      ASSERT (0);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    AllocatedRequest = TRUE;
+    UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
+    FreePool (ConfigRequestHdr);
+    ConfigRequestHdr = NULL;
+  } else {
+    if (!HiiIsConfigHdrMatch (Request, (EFI_GUID *)&DynPlatCfgCpuVarGuid, NULL)) {
+      return EFI_NOT_FOUND;
+    }
+
+    // Check if Request specifies an element. If not then add OFFSET and WIDTH
+    // for the entire config database.
+    StrPointer = StrStr (Request, L"PATH");
+    if (StrPointer == NULL) {
+      ASSERT (StrPointer != NULL);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (StrStr (StrPointer, L"&") == NULL) {
+      if (Request == NULL) {
+        ASSERT (Request != NULL);
+        return EFI_INVALID_PARAMETER;
+      }
+
+      Size          = (StrLen (Request) + 32 + 1) * sizeof (CHAR16);
+      ConfigRequest = AllocateZeroPool (Size);
+      if (ConfigRequest == NULL) {
+        ASSERT (ConfigRequest != NULL);
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      AllocatedRequest = TRUE;
+      UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", Request, (UINT64)BufferSize);
+    } else {
+      ConfigRequest = Request;
+    }
+  }
+
+  if (StrStr (ConfigRequest, L"OFFSET") == NULL) {
+    ASSERT (StrStr (ConfigRequest, L"OFFSET") != NULL);
+
+    if (AllocatedRequest) {
+      FreePool (ConfigRequest);
+    }
+
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Use helper function BlockToConfig() to extract config data and produce
+  // results string.
+  Status = HiiConfigRouting->BlockToConfig (
+                               HiiConfigRouting,
+                               ConfigRequest,
+                               (UINT8 *)Priv->ArmCpuVar,
+                               BufferSize,
+                               Results,
+                               Progress
+                               );
+
+  if (AllocatedRequest) {
+    FreePool (ConfigRequest);
+  }
+
+  if (EFI_ERROR (Status)) {
+    ASSERT (!EFI_ERROR (Status));
+    return Status;
+  }
+
+  // Update Progress to point to the terminator in the Request string. If
+  // Request was NULL then Progress should also be NULL.
+  if (Request == NULL) {
+    *Progress = NULL;
+  } else if (StrStr (Request, L"OFFSET") == NULL) {
+    *Progress = Request + StrLen (Request);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function processes the results of changes in configuration.
+
+  @param  This                   Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param  Configuration          A null-terminated Unicode string in <ConfigResp>
+                                 format.
+  @param  Progress               A pointer to a string filled in with the offset of
+                                 the most recent '&' before the first failing
+                                 name/value pair (or the beginning of the string if
+                                 the failure is in the first name/value pair) or
+                                 the terminating NULL if all was successful.
+
+  @retval EFI_SUCCESS            The Results is processed successfully.
+  @retval EFI_INVALID_PARAMETER  Configuration is NULL.
+  @retval EFI_NOT_FOUND          Routing data doesn't match any storage in this
+                                 driver.
+  @retval EFI_DEVICE_ERROR       If value is 44, return error for testing.
+
+**/
+EFI_STATUS
+EFIAPI
+RouteConfig (
+  IN  CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN  CONST EFI_STRING                      Configuration,
+  OUT EFI_STRING                            *Progress
+  )
+{
+  HII_ARM_CPU_GEN_PRIV             *Priv;
+  UINTN                            BufferSize;
+  EFI_STATUS                       Status;
+  EFI_HII_CONFIG_ROUTING_PROTOCOL  *HiiConfigRouting;
+  CONST CHAR16                     VariableName[]       = L"ArmCpuVar";
+  CONST EFI_GUID                   DynPlatCfgCpuVarGuid = DYN_PLATFORM_CPU_VARSTORE_GUID;
+
+  if ((Configuration == NULL) || (Progress == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Priv             = DYN_HII_ARM_CPU_GEN_PRIVATE_FROM_THIS (This);
+  HiiConfigRouting = Priv->HiiConfigRouting;
+
+  if (!HiiIsConfigHdrMatch (Configuration, (EFI_GUID *)&DynPlatCfgCpuVarGuid, NULL)) {
+    return EFI_NOT_FOUND;
+  }
+
+  BufferSize = Priv->ArmCpuVarSize;
+  Status     = gRT->GetVariable (
+                      (CHAR16 *)VariableName,
+                      (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                      NULL,
+                      &BufferSize,
+                      Priv->ArmCpuVar
+                      );
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    ASSERT (Status == EFI_NOT_FOUND);
+    return Status;
+  }
+
+  BufferSize = Priv->ArmCpuVarSize;
+  Status     = HiiConfigRouting->ConfigToBlock (
+                                   HiiConfigRouting,
+                                   Configuration,
+                                   (UINT8 *)Priv->ArmCpuVar,
+                                   &BufferSize,
+                                   Progress
+                                   );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gRT->SetVariable (
+                  (CHAR16 *)VariableName,
+                  (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                  EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                  Priv->ArmCpuVarSize,
+                  Priv->ArmCpuVar
+                  );
+  ASSERT (!EFI_ERROR (Status));
+
+  return Status;
+}
+
+/**
+  This function processes the results of changes in configuration.
+
+  @param  This                   Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param  Action                 Specifies the type of action taken by the browser.
+  @param  QuestionId             A unique value which is sent to the original
+                                 exporting driver so that it can identify the type
+                                 of data to expect.
+  @param  Type                   The type of value for the question.
+  @param  Value                  A pointer to the data being sent to the original
+                                 exporting driver.
+  @param  ActionRequest          On return, points to the action requested by the
+                                 callback function.
+
+  @retval EFI_SUCCESS            The callback successfully handled the action.
+  @retval EFI_OUT_OF_RESOURCES   Not enough storage is available to hold the
+                                 variable and its data.
+  @retval EFI_DEVICE_ERROR       The variable could not be saved.
+  @retval EFI_UNSUPPORTED        The specified Action is not supported by the
+                                 callback.
+
+**/
+EFI_STATUS
+EFIAPI
+DriverCallback (
+  IN  CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN  EFI_BROWSER_ACTION                    Action,
+  IN  EFI_QUESTION_ID                       QuestionId,
+  IN  UINT8                                 Type,
+  IN  EFI_IFR_TYPE_VALUE                    *Value,
+  OUT EFI_BROWSER_ACTION_REQUEST            *ActionRequest
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/** Add all Question objects to the Form
+
+  Add all the Question objects to the Form.
+
+  @param [in]  CpuCount   Number of CPU's on the platform.
+  @param [in]  Priv       Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Questions were added successfully or other
+                        failure codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+PopulateQuestionObjs (
+  IN      UINT32                CpuCount,
+  IN      HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  UINT32         Idx;
+  CHAR16         PromptStr[64];
+  UINT32         QuestionCount;
+  UINT32         MaxCpu;
+  UINT64         MaxValue;
+  EFI_STATUS     Status;
+  EFI_STRING_ID  Prompt;
+  EFI_STRING_ID  Help;
+
+  QuestionCount = Priv->QuestionCount;
+  ZeroMem (PromptStr, sizeof (PromptStr));
+
+  for (Idx = 0; Idx < QuestionCount; Idx++) {
+    MaxCpu = (Idx * 32);
+    MaxCpu = Idx < CpuCount / 32 ? MaxCpu + 31 : MaxCpu + (CpuCount % 32) - 1;
+
+    UnicodeSPrint (
+      PromptStr,
+      sizeof (PromptStr),
+      L"CPU [%u - %u] Enable/Disable",
+      Idx * 32,
+      MaxCpu
+      );
+
+    Status = DynHiiAddString (
+               Priv->StrPkg,
+               "en-US",
+               PromptStr,
+               &Prompt
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Status = DynHiiAddString (
+               Priv->StrPkg,
+               "en-US",
+               L"Enable or Disable the CPUs",
+               &Help
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    MaxValue = (Idx < (CpuCount / 32)) ? MAX_UINT32 : ((1U << (CpuCount % 32)) - 1U);
+
+    Status = DynHiiAddNumeric (
+               DynHiiGetForm (Priv->FormsetHandle, 1),
+               mQuestionId++,
+               (EFI_VARSTORE_ID)DYN_HII_ARM_CPU_VARSTORE_ID,
+               (UINT16)(Idx * sizeof (UINT32)),
+               Prompt,
+               Help,
+               EFI_IFR_FLAG_RESET_REQUIRED,
+               EFI_IFR_DISPLAY_UINT_HEX | EFI_IFR_NUMERIC_SIZE_4,
+               1,
+               MaxValue,
+               1
+               );
+    if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
+      return Status;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Add the varstore object to the Formset.
+
+  Add the varstore to the given formset.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the varstore was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormsetVarstores (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  CONST CHAR8     VarstoreName[] = "ArmCpuVar";
+  CONST EFI_GUID  VarstoreGuid   = DYN_PLATFORM_CPU_VARSTORE_GUID;
+
+  return DynHiiAddVarstoreBuffer (
+           Priv->FormsetHandle,
+           &VarstoreGuid,
+           (EFI_VARSTORE_ID)DYN_HII_ARM_CPU_VARSTORE_ID,
+           (UINT16)(Priv->QuestionCount * sizeof (UINT32)),
+           VarstoreName
+           );
+}
+
+/** Add the Form object to the Formset
+
+  Add the form to the given formset.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Form was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormsetForms (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  EFI_FORM_ID  TempId;
+
+  return DynHiiAddForm (
+           Priv->FormsetHandle,
+           STRING_TOKEN (STR_CPU_GEN_FORM_TITLE),
+           &TempId
+           );
+}
+
+/** Create the Formset object for the form.
+
+  Add the Formset object for the form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Formset was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormset (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  CONST EFI_GUID  FormsetGuid = DYNAMIC_PLATFORM_CFG_ARM_CPU_GUID;
+
+  return DynHiiCreateFormSet (
+           &FormsetGuid,
+           NULL,
+           STRING_TOKEN (STR_CPU_GEN_FORM_SET_TITLE),
+           STRING_TOKEN (STR_CPU_GEN_FORM_SET_TITLE_HELP),
+           0,
+           &Priv->FormsetHandle
+           );
+}
+
+/** Initialize the string package info structure.
+
+  Initialize the structure that contains information needed for the generation
+  of the string package.
+
+  @param [out]  StrPkg      Pointer to the string package info structure.
+
+  @retval  EFI_SUCCESS  If the structure was successfully initialized or other
+                        failure codes as returned by the string generation
+                        API's.
+
+**/
+static
+EFI_STATUS
+InitStringPkg (
+  OUT DYN_HII_STR_HANDLE  *StrPkg
+  )
+{
+  return DynHiiInitStringPkg (
+           CpuFormGeneratorStrings,
+           StrPkg
+           );
+}
+
+/** Initialize the form's private data structure.
+
+  Allocate and initialize the form's private data structure.
+
+  @param [in]  CpuCount         Number of CPU's on the platform.
+  @param [out] ArmCpuPriv       Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the structure was initialized successfully or other
+                        failure codes as returned by the string generation
+                        API's.
+
+**/
+static
+EFI_STATUS
+InitFormPrivateData (
+  IN      UINT32                CpuCount,
+  OUT     HII_ARM_CPU_GEN_PRIV  **ArmCpuPriv
+  )
+{
+  EFI_STATUS            Status;
+  HII_ARM_CPU_GEN_PRIV  *Priv;
+
+  Priv = AllocateZeroPool (sizeof (*Priv));
+  if (Priv == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  *ArmCpuPriv     = Priv;
+  Priv->Signature = DYN_HII_ARM_CPU_GEN_SIGNATURE;
+
+  Priv->ConfigAccess.ExtractConfig = ExtractConfig;
+  Priv->ConfigAccess.RouteConfig   = RouteConfig;
+  Priv->ConfigAccess.Callback      = DriverCallback;
+
+  Priv->QuestionCount = BASE_DIV_ROUND_UP (CpuCount, 32);
+  Priv->VarstoreCount = 1; // only a single variable store entry needed in the form
+
+  Priv->ArmCpuVar = AllocateZeroPool (Priv->QuestionCount * sizeof (UINT32));
+  if (Priv->ArmCpuVar == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Priv->ArmCpuVarSize = Priv->QuestionCount * sizeof (UINT32);
+
+  Status = InitStringPkg (&Priv->StrPkg);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Setup the EFI variables for storing Question data.
+
+  Set the EFI variables needed for storing the data associated with the
+  Questions on the form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the variables were setup successfully or other
+                        failure codes as returned by the Set/Get variable
+                        API's.
+
+**/
+static
+EFI_STATUS
+SetupEfiVarBackend (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  UINTN           BufferSize;
+  BOOLEAN         ActionFlag;
+  EFI_STATUS      Status;
+  EFI_STRING      ConfigRequestHdr;
+  CONST CHAR16    VariableName[]       = L"ArmCpuVar";
+  CONST EFI_GUID  DynPlatCfgCpuVarGuid = DYN_PLATFORM_CPU_VARSTORE_GUID;
+
+  //
+  // Try to read NV config EFI variable first
+  //
+  ConfigRequestHdr = HiiConstructConfigHdr (
+                       (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                       (CHAR16 *)VariableName,
+                       Priv->DevHandle
+                       );
+  if (ConfigRequestHdr == NULL) {
+    ASSERT (0);
+    Status = EFI_UNSUPPORTED;
+    goto err_out;
+  }
+
+  BufferSize = Priv->ArmCpuVarSize;
+  Status     = gRT->GetVariable (
+                      (CHAR16 *)VariableName,
+                      (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                      NULL,
+                      &BufferSize,
+                      Priv->ArmCpuVar
+                      );
+  if (EFI_ERROR (Status)) {
+    Status = gRT->SetVariable (
+                    (CHAR16 *)VariableName,
+                    (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                    EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                    Priv->ArmCpuVarSize,
+                    Priv->ArmCpuVar
+                    );
+    if (EFI_ERROR (Status)) {
+      ASSERT (!EFI_ERROR (Status));
+      goto err_out;
+    }
+
+    ActionFlag = HiiSetToDefaults (ConfigRequestHdr, EFI_HII_DEFAULT_CLASS_STANDARD);
+    if (!ActionFlag) {
+      Status = EFI_INVALID_PARAMETER;
+      goto err_out;
+    }
+
+    BufferSize = Priv->ArmCpuVarSize;
+    Status     = gRT->GetVariable (
+                        (CHAR16 *)VariableName,
+                        (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                        NULL,
+                        &BufferSize,
+                        Priv->ArmCpuVar
+                        );
+    if (EFI_ERROR (Status)) {
+      goto err_out;
+    }
+  } else {
+    ActionFlag = HiiValidateSettings (ConfigRequestHdr);
+    if (!ActionFlag) {
+      Status = EFI_INVALID_PARAMETER;
+      goto err_out;
+    }
+  }
+
+  Status = EFI_SUCCESS;
+
+err_out:
+  if (ConfigRequestHdr != NULL) {
+    FreePool (ConfigRequestHdr);
+  }
+
+  return Status;
+}
+
+/** Construct Hii Forms with Cpu based Questions.
+
+  This function invokes the Configuration Manager protocol interface
+  to get the required information for generating the Cpu based
+  Hii Forms. It then calls the HII Form and String Generation API's
+  for building the form and string package, and then adds these
+  packages to the HII database through a call to HiiAddPackages().
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXRes function.
+
+  @param [in]  This            Pointer to the HII forms generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII forms information.
+  @param [in]  CfgMgrProtocol  Pointer to the Configuration Manager
+                               Protocol interface.
+  @param [in]  HiiHandleList   List of all Hii handles to which this
+                               form creates references.
+  @param [out] HiiHandle       Hii handle of this form.
+
+  @retval EFI_SUCCESS            Form generated successfully.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+BuildHiiArmCpuForm (
+  IN        HII_FORMS_GENERATOR                            *This,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                  *CONST  HiiFormsInfo  OPTIONAL,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  IN  CONST LIST_ENTRY                                     *HiiHandleList OPTIONAL,
+  OUT       EFI_HII_HANDLE                                 *HiiHandle
+  )
+{
+  EFI_STATUS            Status;
+  UINT32                CpuCount;
+  CM_ARM_GICC_INFO      *GicCInfo;
+  HII_ARM_CPU_GEN_PRIV  *Priv;
+  CONST EFI_GUID        FormsetGuid = DYNAMIC_PLATFORM_CFG_ARM_CPU_GUID;
+
+  *HiiHandle = NULL;
+
+  /// Get the Gicc object first. Rest of the form
+  /// formation would depend upon information
+  /// obtained from that object
+  Status = GetEArmObjGicCInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &GicCInfo,
+             &CpuCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii-ARM: Failed to get GICC Info. Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  if (CpuCount == 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii-ARM: GIC CPU Interface information not provided.\n"
+      ));
+    ASSERT (CpuCount != 0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  This->Priv = NULL;
+  Status     = InitFormPrivateData (CpuCount, (HII_ARM_CPU_GEN_PRIV **)&This->Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to Initialise the private data structure for the form."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Priv = This->Priv;
+
+  //
+  // Locate ConfigRouting protocol
+  //
+  Status = gBS->LocateProtocol (&gEfiHiiConfigRoutingProtocolGuid, NULL, (VOID **)&Priv->HiiConfigRouting);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &Priv->DevHandle,
+                  &gEfiDevicePathProtocolGuid,
+                  &mHiiVendorDevicePath0,
+                  &gEfiHiiConfigAccessProtocolGuid,
+                  &Priv->ConfigAccess,
+                  NULL
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = SetupEfiVarBackend (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to setup the Efi var backend information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = SetupFormset (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Formset Strings."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = SetupFormsetVarstores (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Varstore information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "INFO: %a: Done with Setting up Formset Varstores\n",
+    __func__
+    ));
+
+  Status = SetupFormsetForms (Priv);
+  if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Varstore information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = PopulateQuestionObjs (CpuCount, Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Cpu Question information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = DynHiiGenerateFormPackage (
+             Priv->FormsetHandle,
+             &Priv->IfrBufHandle,
+             &Priv->IfrBuffer
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to serialize the IFR Byte Buffer."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = DynHiiGenerateStringPackage (Priv->StrPkg, &Priv->StrPkgBuf);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to serialize the String Package Buffer."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  /// Add the template data to the Hii Package list
+  *HiiHandle = HiiAddPackages (
+                 &FormsetGuid,
+                 Priv->DevHandle,
+                 Priv->IfrBuffer,
+                 Priv->StrPkgBuf,
+                 NULL
+                 );
+  if (*HiiHandle == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to add packages to Hii Database\n",
+      __func__
+      ));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  return Status;
+}
+
+/** Free up all resources associated with this form.
+
+  Free up all resources associated with this form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+**/
+static
+VOID
+DeInitPrivateData (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  DynHiiFreeFormSet (Priv->FormsetHandle);
+  DynHiiFreeFormPackage (Priv->IfrBufHandle);
+  DynHiiFreeStringPackage (Priv->StrPkg);
+
+  if (Priv->StrPkgBuf != NULL) {
+    FreePool (Priv->StrPkgBuf);
+  }
+
+  if (Priv->ArmCpuVar != NULL) {
+    FreePool (Priv->ArmCpuVar);
+  }
+
+  FreePool (Priv);
+}
+
+/** Free up all resources associated with this form.
+
+  Free up all resources associated with this form. In addition remove
+  the Hii Handle from the Hii database.
+
+  @param [in]  This            Pointer to the HII forms generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII forms information.
+  @param [in]  HiiHandle       Hii handle of this form.
+
+  @retval The resources were freed successfully.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+FreeHiiArmCpuForm (
+  IN        HII_FORMS_GENERATOR                            *This,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                  *CONST  HiiFormsInfo,
+  IN  EFI_HII_HANDLE                                       *HiiHandle
+  )
+{
+  HII_ARM_CPU_GEN_PRIV  *Priv;
+
+  ASSERT (This != NULL);
+  ASSERT (This->GeneratorID == HiiFormsInfo->FormGeneratorId);
+
+  if (*HiiHandle != NULL) {
+    HiiRemovePackages (*HiiHandle);
+  }
+
+  if (This->Priv == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  Priv = This->Priv;
+  if (Priv->DevHandle != NULL) {
+    gBS->UninstallMultipleProtocolInterfaces (
+           Priv->DevHandle,
+           &gEfiDevicePathProtocolGuid,
+           &mHiiVendorDevicePath0,
+           &gEfiHiiConfigAccessProtocolGuid,
+           &Priv->ConfigAccess,
+           NULL
+           );
+  }
+
+  DeInitPrivateData (This->Priv);
+
+  return EFI_SUCCESS;
+}
+
+/** The interface for the Cpu Form Generator.
+*/
+static
+HII_FORMS_GENERATOR  HiiCpuFormGenGeneric = {
+  // Generator ID
+  CREATE_HII_FORMS_GEN_ID (EStdHiiFormsIdCpuArm),
+  // Generator Description
+  L"HII.STD.ARM.CPU.FORM.GENERATOR",
+  // Private structure for the Form (to be populated at runtime)
+  NULL,
+  // Build form function.
+  BuildHiiArmCpuForm,
+  // Free form function.
+  FreeHiiArmCpuForm,
+};
+
+/** Register the Generator with the HII Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+HiiCpuFormConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterHiiFormsGenerator (&HiiCpuFormGenGeneric);
+  DEBUG ((
+    DEBUG_INFO,
+    "HII-Cpu: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the HII Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+HiiCpuFormDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterHiiFormsGenerator (&HiiCpuFormGenGeneric);
+  DEBUG ((
+    DEBUG_INFO,
+    "HII-Cpu: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Hii/CpuFormGenerator/ArmCpuFormGenerator.c
+++ b/DynamicTablesPkg/Library/Hii/CpuFormGenerator/ArmCpuFormGenerator.c
@@ -1,0 +1,1050 @@
+/** @file
+  Dynamic Hii Cpu Form Generator for Arm platforms.
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PrintLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerHelper.h>
+#include <ConfigurationManagerObject.h>
+#include <HiiFormsGenerator.h>
+#include <Guid/MdeModuleHii.h>
+#include <Library/DevicePathLib.h>
+#include <Library/HiiFormsLib.h>
+#include <Library/HiiLib.h>
+#include <Library/HiiStringsLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/TableHelperLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "ArmCpuFormGenerator.h"
+
+static EFI_QUESTION_ID  mQuestionId = DYN_HII_ARM_CPU_QUESTION_ID_START;
+extern UINT8            CpuFormGeneratorStrings[];
+
+HII_VENDOR_DEVICE_PATH  mHiiVendorDevicePath0 = {
+  {
+    {
+      HARDWARE_DEVICE_PATH,
+      HW_VENDOR_DP,
+      {
+        (UINT8)(sizeof (VENDOR_DEVICE_PATH)),
+        (UINT8)((sizeof (VENDOR_DEVICE_PATH)) >> 8)
+      }
+    },
+    DYNAMIC_PLATFORM_CFG_ARM_CPU_GUID
+  },
+  {
+    END_DEVICE_PATH_TYPE,
+    END_ENTIRE_DEVICE_PATH_SUBTYPE,
+    {
+      (UINT8)(END_DEVICE_PATH_LENGTH),
+      (UINT8)((END_DEVICE_PATH_LENGTH) >> 8)
+    }
+  }
+};
+
+/** This macro expands to a function that retrieves the GIC
+    CPU interface Information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArm,
+  EArmObjGicCInfo,
+  CM_ARM_GICC_INFO
+  );
+
+/**
+  This function allows a caller to extract the current configuration for one
+  or more named elements from the target driver.
+
+  @param  This                   Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param  Request                A null-terminated Unicode string in
+                                 <ConfigRequest> format.
+  @param  Progress               On return, points to a character in the Request
+                                 string. Points to the string's null terminator if
+                                 request was successful. Points to the most recent
+                                 '&' before the first failing name/value pair (or
+                                 the beginning of the string if the failure is in
+                                 the first name/value pair) if the request was not
+                                 successful.
+  @param  Results                A null-terminated Unicode string in
+                                 <ConfigAltResp> format which has all values filled
+                                 in for the names in the Request string. String to
+                                 be allocated by the called function.
+
+  @retval EFI_SUCCESS            The Results is filled with the requested values.
+  @retval EFI_OUT_OF_RESOURCES   Not enough memory to store the results.
+  @retval EFI_INVALID_PARAMETER  Request is illegal syntax, or unknown name.
+  @retval EFI_NOT_FOUND          Routing data doesn't match any storage in this
+                                 driver.
+**/
+EFI_STATUS
+EFIAPI
+ExtractConfig (
+  IN  CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN  CONST EFI_STRING                      Request,
+  OUT EFI_STRING                            *Progress,
+  OUT EFI_STRING                            *Results
+  )
+{
+  HII_ARM_CPU_GEN_PRIV             *Priv;
+  CHAR16                           *StrPointer;
+  UINTN                            Size;
+  BOOLEAN                          AllocatedRequest;
+  EFI_STRING                       ConfigRequest;
+  UINTN                            BufferSize;
+  EFI_STATUS                       Status;
+  EFI_STRING                       ConfigRequestHdr;
+  EFI_HII_CONFIG_ROUTING_PROTOCOL  *HiiConfigRouting;
+  CONST CHAR16                     VariableName[]       = L"ArmCpuVar";
+  CONST EFI_GUID                   DynPlatCfgCpuVarGuid = DYN_PLATFORM_CPU_VARSTORE_GUID;
+
+  if ((Progress == NULL) || (Results == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Priv             = DYN_HII_ARM_CPU_GEN_PRIVATE_FROM_THIS (This);
+  HiiConfigRouting = Priv->HiiConfigRouting;
+
+  AllocatedRequest = FALSE;
+  BufferSize       = Priv->ArmCpuVarSize;
+
+  if (Request == NULL) {
+    // NULL Request indicates request for entire config database. Build a
+    // Request string from the ConfigHdr with appended OFFSET and WIDTH.
+    ConfigRequestHdr = HiiConstructConfigHdr (
+                         (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                         (CHAR16 *)VariableName,
+                         Priv->DevHandle
+                         );
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (0);
+      return EFI_UNSUPPORTED;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    if (ConfigRequest == NULL) {
+      ASSERT (0);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    AllocatedRequest = TRUE;
+    UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
+    FreePool (ConfigRequestHdr);
+    ConfigRequestHdr = NULL;
+  } else {
+    if (!HiiIsConfigHdrMatch (Request, (EFI_GUID *)&DynPlatCfgCpuVarGuid, NULL)) {
+      return EFI_NOT_FOUND;
+    }
+
+    // Check if Request specifies an element. If not then add OFFSET and WIDTH
+    // for the entire config database.
+    StrPointer = StrStr (Request, L"PATH");
+    if (StrPointer == NULL) {
+      ASSERT (StrPointer != NULL);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (StrStr (StrPointer, L"&") == NULL) {
+      if (Request == NULL) {
+        ASSERT (Request != NULL);
+        return EFI_INVALID_PARAMETER;
+      }
+
+      Size          = (StrLen (Request) + 32 + 1) * sizeof (CHAR16);
+      ConfigRequest = AllocateZeroPool (Size);
+      if (ConfigRequest == NULL) {
+        ASSERT (ConfigRequest != NULL);
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      AllocatedRequest = TRUE;
+      UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", Request, (UINT64)BufferSize);
+    } else {
+      ConfigRequest = Request;
+    }
+  }
+
+  if (StrStr (ConfigRequest, L"OFFSET") == NULL) {
+    ASSERT (StrStr (ConfigRequest, L"OFFSET") != NULL);
+
+    if (AllocatedRequest) {
+      FreePool (ConfigRequest);
+    }
+
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Use helper function BlockToConfig() to extract config data and produce
+  // results string.
+  Status = HiiConfigRouting->BlockToConfig (
+                               HiiConfigRouting,
+                               ConfigRequest,
+                               (UINT8 *)Priv->ArmCpuVar,
+                               BufferSize,
+                               Results,
+                               Progress
+                               );
+
+  if (AllocatedRequest) {
+    FreePool (ConfigRequest);
+  }
+
+  if (EFI_ERROR (Status)) {
+    ASSERT (!EFI_ERROR (Status));
+    return Status;
+  }
+
+  // Update Progress to point to the terminator in the Request string. If
+  // Request was NULL then Progress should also be NULL.
+  if (Request == NULL) {
+    *Progress = NULL;
+  } else if (StrStr (Request, L"OFFSET") == NULL) {
+    *Progress = Request + StrLen (Request);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function processes the results of changes in configuration.
+
+  @param  This                   Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param  Configuration          A null-terminated Unicode string in <ConfigResp>
+                                 format.
+  @param  Progress               A pointer to a string filled in with the offset of
+                                 the most recent '&' before the first failing
+                                 name/value pair (or the beginning of the string if
+                                 the failure is in the first name/value pair) or
+                                 the terminating NULL if all was successful.
+
+  @retval EFI_SUCCESS            The Results is processed successfully.
+  @retval EFI_INVALID_PARAMETER  Configuration is NULL.
+  @retval EFI_NOT_FOUND          Routing data doesn't match any storage in this
+                                 driver.
+  @retval EFI_DEVICE_ERROR       If value is 44, return error for testing.
+
+**/
+EFI_STATUS
+EFIAPI
+RouteConfig (
+  IN  CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN  CONST EFI_STRING                      Configuration,
+  OUT EFI_STRING                            *Progress
+  )
+{
+  HII_ARM_CPU_GEN_PRIV             *Priv;
+  UINTN                            BufferSize;
+  EFI_STATUS                       Status;
+  EFI_HII_CONFIG_ROUTING_PROTOCOL  *HiiConfigRouting;
+  CONST CHAR16                     VariableName[]       = L"ArmCpuVar";
+  CONST EFI_GUID                   DynPlatCfgCpuVarGuid = DYN_PLATFORM_CPU_VARSTORE_GUID;
+
+  if ((Configuration == NULL) || (Progress == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Priv             = DYN_HII_ARM_CPU_GEN_PRIVATE_FROM_THIS (This);
+  HiiConfigRouting = Priv->HiiConfigRouting;
+
+  if (!HiiIsConfigHdrMatch (Configuration, (EFI_GUID *)&DynPlatCfgCpuVarGuid, NULL)) {
+    return EFI_NOT_FOUND;
+  }
+
+  BufferSize = Priv->ArmCpuVarSize;
+  Status     = gRT->GetVariable (
+                      (CHAR16 *)VariableName,
+                      (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                      NULL,
+                      &BufferSize,
+                      Priv->ArmCpuVar
+                      );
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    ASSERT (Status == EFI_NOT_FOUND);
+    return Status;
+  }
+
+  BufferSize = Priv->ArmCpuVarSize;
+  Status     = HiiConfigRouting->ConfigToBlock (
+                                   HiiConfigRouting,
+                                   Configuration,
+                                   (UINT8 *)Priv->ArmCpuVar,
+                                   &BufferSize,
+                                   Progress
+                                   );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gRT->SetVariable (
+                  (CHAR16 *)VariableName,
+                  (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                  EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                  Priv->ArmCpuVarSize,
+                  Priv->ArmCpuVar
+                  );
+  ASSERT (!EFI_ERROR (Status));
+
+  return Status;
+}
+
+/**
+  This function processes the results of changes in configuration.
+
+  @param  This                   Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param  Action                 Specifies the type of action taken by the browser.
+  @param  QuestionId             A unique value which is sent to the original
+                                 exporting driver so that it can identify the type
+                                 of data to expect.
+  @param  Type                   The type of value for the question.
+  @param  Value                  A pointer to the data being sent to the original
+                                 exporting driver.
+  @param  ActionRequest          On return, points to the action requested by the
+                                 callback function.
+
+  @retval EFI_SUCCESS            The callback successfully handled the action.
+  @retval EFI_OUT_OF_RESOURCES   Not enough storage is available to hold the
+                                 variable and its data.
+  @retval EFI_DEVICE_ERROR       The variable could not be saved.
+  @retval EFI_UNSUPPORTED        The specified Action is not supported by the
+                                 callback.
+
+**/
+EFI_STATUS
+EFIAPI
+DriverCallback (
+  IN  CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN  EFI_BROWSER_ACTION                    Action,
+  IN  EFI_QUESTION_ID                       QuestionId,
+  IN  UINT8                                 Type,
+  IN  EFI_IFR_TYPE_VALUE                    *Value,
+  OUT EFI_BROWSER_ACTION_REQUEST            *ActionRequest
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/** Add all Question objects to the Form
+
+  Add all the Question objects to the Form.
+
+  @param [in]  CpuCount   Number of CPU's on the platform.
+  @param [in]  Priv       Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Questions were added successfully or other
+                        failure codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+PopulateQuestionObjs (
+  IN      UINT32                CpuCount,
+  IN      HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  UINT32               Idx;
+  CHAR16               PromptStr[64];
+  UINT32               QuestionCount;
+  UINT32               MaxCpu;
+  UINT64               MaxValue;
+  EFI_STATUS           Status;
+  EFI_STRING_ID        Prompt;
+  DYN_HII_FORM_HANDLE  FormHandle;
+  DYN_HII_STR_ENTRY    StrTable = {
+    .LanguageCode = "en-US",
+    .String       = PromptStr
+  };
+
+  QuestionCount = Priv->QuestionCount;
+  ZeroMem (PromptStr, sizeof (PromptStr));
+  FormHandle = DynHiiGetForm (Priv->FormsetHandle, 1);
+
+  for (Idx = 0; Idx < QuestionCount; Idx++) {
+    MaxCpu = (Idx * 32);
+    MaxCpu = Idx < CpuCount / 32 ? MaxCpu + 31 : MaxCpu + (CpuCount % 32) - 1;
+
+    UnicodeSPrint (
+      PromptStr,
+      sizeof (PromptStr),
+      L"CPU [%u - %u] Enable/Disable",
+      Idx * 32,
+      MaxCpu
+      );
+
+    Status = DynHiiAddString (Priv->StrPkg, &StrTable, 1, &Prompt);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    MaxValue = (Idx < (CpuCount / 32)) ? MAX_UINT32 : ((1U << (CpuCount % 32)) - 1U);
+
+    Status = DynHiiAddNumeric (
+               FormHandle,
+               mQuestionId++,
+               (EFI_VARSTORE_ID)DYN_HII_ARM_CPU_VARSTORE_ID,
+               (UINT16)(Idx * sizeof (UINT32)),
+               Prompt,
+               STRING_TOKEN (STR_CPU_GEN_QUESTION_HELP),
+               EFI_IFR_FLAG_RESET_REQUIRED,
+               EFI_IFR_DISPLAY_UINT_HEX | EFI_IFR_NUMERIC_SIZE_4,
+               1,
+               MaxValue,
+               1,
+               NULL
+               );
+    if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
+      return Status;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Add the varstore object to the Formset.
+
+  Add the varstore to the given formset.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the varstore was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormsetVarstores (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  CONST CHAR8     VarstoreName[] = "ArmCpuVar";
+  CONST EFI_GUID  VarstoreGuid   = DYN_PLATFORM_CPU_VARSTORE_GUID;
+
+  return DynHiiAddVarstoreBuffer (
+           Priv->FormsetHandle,
+           &VarstoreGuid,
+           (EFI_VARSTORE_ID)DYN_HII_ARM_CPU_VARSTORE_ID,
+           (UINT16)(Priv->QuestionCount * sizeof (UINT32)),
+           VarstoreName
+           );
+}
+
+/** Add the Form object to the Formset
+
+  Add the form to the given formset.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Form was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormsetForms (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  EFI_FORM_ID  TempId;
+
+  return DynHiiAddForm (
+           Priv->FormsetHandle,
+           STRING_TOKEN (STR_CPU_GEN_FORM_TITLE),
+           &TempId
+           );
+}
+
+/** Create the Formset object for the form.
+
+  Add the Formset object for the form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Formset was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormset (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  CONST EFI_GUID  FormsetGuid = DYNAMIC_PLATFORM_CFG_ARM_CPU_GUID;
+
+  return DynHiiCreateFormSet (
+           &FormsetGuid,
+           NULL,
+           STRING_TOKEN (STR_CPU_GEN_FORM_SET_TITLE),
+           STRING_TOKEN (STR_CPU_GEN_FORM_SET_TITLE_HELP),
+           0,
+           &Priv->FormsetHandle
+           );
+}
+
+/** Initialize the string package info structure.
+
+  Initialize the structure that contains information needed for the generation
+  of the string package.
+
+  @param [out]  StrPkg      Pointer to the string package info structure.
+
+  @retval  EFI_SUCCESS  If the structure was successfully initialized or other
+                        failure codes as returned by the string generation
+                        API's.
+
+**/
+static
+EFI_STATUS
+InitStringPkg (
+  OUT DYN_HII_STR_HANDLE  *StrPkg
+  )
+{
+  return DynHiiInitStringPkg (
+           CpuFormGeneratorStrings,
+           StrPkg
+           );
+}
+
+/** Initialize the form's private data structure.
+
+  Allocate and initialize the form's private data structure.
+
+  @param [in]  CpuCount         Number of CPU's on the platform.
+  @param [out] ArmCpuPriv       Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the structure was initialized successfully or other
+                        failure codes as returned by the string generation
+                        API's.
+
+**/
+static
+EFI_STATUS
+InitFormPrivateData (
+  IN      UINT32                CpuCount,
+  OUT     HII_ARM_CPU_GEN_PRIV  **ArmCpuPriv
+  )
+{
+  EFI_STATUS            Status;
+  HII_ARM_CPU_GEN_PRIV  *Priv;
+
+  Priv = AllocateZeroPool (sizeof (*Priv));
+  if (Priv == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  *ArmCpuPriv     = Priv;
+  Priv->Signature = DYN_HII_ARM_CPU_GEN_SIGNATURE;
+
+  Priv->ConfigAccess.ExtractConfig = ExtractConfig;
+  Priv->ConfigAccess.RouteConfig   = RouteConfig;
+  Priv->ConfigAccess.Callback      = DriverCallback;
+
+  Priv->QuestionCount = BASE_DIV_ROUND_UP (CpuCount, 32);
+  Priv->VarstoreCount = 1; // only a single variable store entry needed in the form
+
+  Priv->ArmCpuVar = AllocateZeroPool (Priv->QuestionCount * sizeof (UINT32));
+  if (Priv->ArmCpuVar == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Priv->ArmCpuVarSize = Priv->QuestionCount * sizeof (UINT32);
+
+  Status = InitStringPkg (&Priv->StrPkg);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Setup the EFI variables for storing Question data.
+
+  Set the EFI variables needed for storing the data associated with the
+  Questions on the form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the variables were setup successfully or other
+                        failure codes as returned by the Set/Get variable
+                        API's.
+
+**/
+static
+EFI_STATUS
+SetupEfiVarBackend (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  UINTN           BufferSize;
+  BOOLEAN         ActionFlag;
+  EFI_STATUS      Status;
+  EFI_STRING      ConfigRequestHdr;
+  CONST CHAR16    VariableName[]       = L"ArmCpuVar";
+  CONST EFI_GUID  DynPlatCfgCpuVarGuid = DYN_PLATFORM_CPU_VARSTORE_GUID;
+
+  //
+  // Try to read NV config EFI variable first
+  //
+  ConfigRequestHdr = HiiConstructConfigHdr (
+                       (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                       (CHAR16 *)VariableName,
+                       Priv->DevHandle
+                       );
+  if (ConfigRequestHdr == NULL) {
+    ASSERT (0);
+    Status = EFI_UNSUPPORTED;
+    goto err_out;
+  }
+
+  BufferSize = Priv->ArmCpuVarSize;
+  Status     = gRT->GetVariable (
+                      (CHAR16 *)VariableName,
+                      (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                      NULL,
+                      &BufferSize,
+                      Priv->ArmCpuVar
+                      );
+  if (EFI_ERROR (Status)) {
+    Status = gRT->SetVariable (
+                    (CHAR16 *)VariableName,
+                    (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                    EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                    Priv->ArmCpuVarSize,
+                    Priv->ArmCpuVar
+                    );
+    if (EFI_ERROR (Status)) {
+      ASSERT (!EFI_ERROR (Status));
+      goto err_out;
+    }
+
+    ActionFlag = HiiSetToDefaults (ConfigRequestHdr, EFI_HII_DEFAULT_CLASS_STANDARD);
+    if (!ActionFlag) {
+      Status = EFI_INVALID_PARAMETER;
+      goto err_out;
+    }
+
+    BufferSize = Priv->ArmCpuVarSize;
+    Status     = gRT->GetVariable (
+                        (CHAR16 *)VariableName,
+                        (EFI_GUID *)&DynPlatCfgCpuVarGuid,
+                        NULL,
+                        &BufferSize,
+                        Priv->ArmCpuVar
+                        );
+    if (EFI_ERROR (Status)) {
+      goto err_out;
+    }
+  } else {
+    ActionFlag = HiiValidateSettings (ConfigRequestHdr);
+    if (!ActionFlag) {
+      Status = EFI_INVALID_PARAMETER;
+      goto err_out;
+    }
+  }
+
+  Status = EFI_SUCCESS;
+
+err_out:
+  if (ConfigRequestHdr != NULL) {
+    FreePool (ConfigRequestHdr);
+  }
+
+  return Status;
+}
+
+/** Construct Hii Forms with Cpu based Questions.
+
+  This function invokes the Configuration Manager protocol interface
+  to get the required information for generating the Cpu based
+  Hii Forms. It then calls the HII Form and String Generation API's
+  for building the form and string package, and then adds these
+  packages to the HII database through a call to HiiAddPackages().
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXRes function.
+
+  @param [in]  This            Pointer to the HII forms generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII forms information.
+  @param [in]  CfgMgrProtocol  Pointer to the Configuration Manager
+                               Protocol interface.
+  @param [in]  HiiHandleList   List of all Hii handles to which this
+                               form creates references.
+  @param [out] HiiHandle       Hii handle of this form.
+
+  @retval EFI_SUCCESS            Form generated successfully.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+BuildHiiArmCpuForm (
+  IN        HII_FORMS_GENERATOR                            *This,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                  *CONST  HiiFormsInfo  OPTIONAL,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  IN  CONST LIST_ENTRY                                     *HiiHandleList OPTIONAL,
+  OUT       EFI_HII_HANDLE                                 *HiiHandle
+  )
+{
+  UINT8                 *IfrBuffer;
+  UINT8                 *StrPkgBuf;
+  EFI_STATUS            Status;
+  UINT32                CpuCount;
+  CM_ARM_GICC_INFO      *GicCInfo;
+  HII_ARM_CPU_GEN_PRIV  *Priv;
+  CONST EFI_GUID        FormsetGuid = DYNAMIC_PLATFORM_CFG_ARM_CPU_GUID;
+
+  /// Get the Gicc object first. Rest of the form
+  /// formation would depend upon information
+  /// obtained from that object
+  Status = GetEArmObjGicCInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &GicCInfo,
+             &CpuCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii-ARM: Failed to get GICC Info. Status = %r\n",
+      Status
+      ));
+    return Status;
+  }
+
+  if (CpuCount == 0) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: Hii-ARM: GIC CPU Interface information not provided.\n"
+      ));
+    ASSERT (CpuCount != 0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *HiiHandle = NULL;
+  This->Priv = NULL;
+  StrPkgBuf  = NULL;
+  IfrBuffer  = NULL;
+  Status     = InitFormPrivateData (CpuCount, (HII_ARM_CPU_GEN_PRIV **)&This->Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to Initialise the private data structure for the form."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Priv = This->Priv;
+
+  //
+  // Locate ConfigRouting protocol
+  //
+  Status = gBS->LocateProtocol (&gEfiHiiConfigRoutingProtocolGuid, NULL, (VOID **)&Priv->HiiConfigRouting);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &Priv->DevHandle,
+                  &gEfiDevicePathProtocolGuid,
+                  &mHiiVendorDevicePath0,
+                  &gEfiHiiConfigAccessProtocolGuid,
+                  &Priv->ConfigAccess,
+                  NULL
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = SetupFormset (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Formset Strings."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = SetupFormsetVarstores (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Varstore information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = SetupFormsetForms (Priv);
+  if (EFI_ERROR (Status) && (Status != EFI_ALREADY_STARTED)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Varstore information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = PopulateQuestionObjs (CpuCount, Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Cpu Question information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = DynHiiGenerateFormPackage (
+             Priv->FormsetHandle,
+             &IfrBuffer
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to serialize the IFR Byte Buffer."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    goto out;
+  }
+
+  Status = DynHiiGenerateStringPackage (Priv->StrPkg, &StrPkgBuf);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to serialize the String Package Buffer."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    goto out;
+  }
+
+  /// Add the template data to the Hii Package list
+  *HiiHandle = HiiAddPackages (
+                 &FormsetGuid,
+                 Priv->DevHandle,
+                 IfrBuffer,
+                 StrPkgBuf,
+                 NULL
+                 );
+  if (*HiiHandle == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to add packages to Hii Database\n",
+      __func__
+      ));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto out;
+  }
+
+  Status = SetupEfiVarBackend (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to setup the Efi var backend information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+  }
+
+out:
+  if (IfrBuffer != NULL) {
+    FreePool (IfrBuffer);
+  }
+
+  if (StrPkgBuf != NULL) {
+    FreePool (StrPkgBuf);
+  }
+
+  return Status;
+}
+
+/** Free up all resources associated with this form.
+
+  Free up all resources associated with this form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+**/
+static
+VOID
+DeInitPrivateData (
+  IN HII_ARM_CPU_GEN_PRIV  *Priv
+  )
+{
+  if (Priv->FormsetHandle != NULL) {
+    DynHiiFreeFormSet (Priv->FormsetHandle);
+  }
+
+  if (Priv->StrPkg != NULL) {
+    DynHiiFreeStringPackage (Priv->StrPkg);
+  }
+
+  if (Priv->ArmCpuVar != NULL) {
+    FreePool (Priv->ArmCpuVar);
+  }
+
+  FreePool (Priv);
+}
+
+/** Free up all resources associated with this form.
+
+  Free up all resources associated with this form. In addition remove
+  the Hii Handle from the Hii database.
+
+  @param [in]  This            Pointer to the HII forms generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII forms information.
+  @param [in]  HiiHandle       Hii handle of this form.
+
+  @retval The resources were freed successfully.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+FreeHiiArmCpuForm (
+  IN        HII_FORMS_GENERATOR                            *This,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                  *CONST  HiiFormsInfo,
+  IN  EFI_HII_HANDLE                                       *HiiHandle
+  )
+{
+  HII_ARM_CPU_GEN_PRIV  *Priv;
+
+  ASSERT (This != NULL);
+  ASSERT (This->GeneratorID == HiiFormsInfo->FormGeneratorId);
+
+  if (*HiiHandle != NULL) {
+    HiiRemovePackages (*HiiHandle);
+  }
+
+  if (This->Priv == NULL) {
+    return EFI_SUCCESS;
+  }
+
+  Priv = This->Priv;
+  if (Priv->DevHandle != NULL) {
+    gBS->UninstallMultipleProtocolInterfaces (
+           Priv->DevHandle,
+           &gEfiDevicePathProtocolGuid,
+           &mHiiVendorDevicePath0,
+           &gEfiHiiConfigAccessProtocolGuid,
+           &Priv->ConfigAccess,
+           NULL
+           );
+  }
+
+  DeInitPrivateData (This->Priv);
+
+  return EFI_SUCCESS;
+}
+
+/** The interface for the Cpu Form Generator.
+*/
+static
+HII_FORMS_GENERATOR  HiiCpuFormGenGeneric = {
+  // Generator ID
+  CREATE_HII_FORMS_GEN_ID (EStdHiiFormsIdCpuArm),
+  // Generator Description
+  L"HII.STD.ARM.CPU.FORM.GENERATOR",
+  // Private structure for the Form (to be populated at runtime)
+  NULL,
+  // Build form function.
+  BuildHiiArmCpuForm,
+  // Free form function.
+  FreeHiiArmCpuForm,
+};
+
+/** Register the Generator with the HII Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+HiiCpuFormConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterHiiFormsGenerator (&HiiCpuFormGenGeneric);
+  DEBUG ((
+    DEBUG_INFO,
+    "HII-Cpu: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the HII Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+HiiCpuFormDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterHiiFormsGenerator (&HiiCpuFormGenGeneric);
+  DEBUG ((
+    DEBUG_INFO,
+    "HII-Cpu: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Hii/CpuFormGenerator/ArmCpuFormGenerator.h
+++ b/DynamicTablesPkg/Library/Hii/CpuFormGenerator/ArmCpuFormGenerator.h
@@ -1,0 +1,95 @@
+/** @file
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+**/
+
+#pragma once
+
+#include <Protocol/HiiConfigAccess.h>
+#include <Protocol/HiiConfigRouting.h>
+#include <Protocol/DevicePath.h>
+
+/// Formset GUID
+#define DYNAMIC_PLATFORM_CFG_ARM_CPU_GUID \
+  { \
+    0xe1ab22e8, 0xeabe, 0x4bcb, {0xb0, 0xef, 0x9d, 0x5a, 0x5c, 0xa5, 0x5d, 0x9f} \
+  }
+
+/// Varstore GUID
+#define DYN_PLATFORM_CPU_VARSTORE_GUID \
+  { \
+    0xBC65E462, 0x138D, 0x499B, { 0x9A, 0x97, 0xAF, 0xD1, 0xA9, 0x18, 0x17, 0x9E } \
+  }
+
+/// Varstore ID for the Formset
+#define DYN_HII_ARM_CPU_VARSTORE_ID  0x1234
+
+/// Question ID start value for the Formset
+#define DYN_HII_ARM_CPU_QUESTION_ID_START  0x2000
+
+#define DYN_HII_ARM_CPU_GEN_SIGNATURE  SIGNATURE_64 ('A', 'R', 'M', 'C', 'P', 'U', 0, 0)
+
+/** This structure is used for holding the formset specific
+    private data.
+**/
+typedef struct HiiArmCpuGenPriv {
+  /// Formset Signature
+  UINT64                             Signature;
+
+  /// Question count
+  UINT32                             QuestionCount;
+
+  /// Varstore count
+  UINT32                             VarstoreCount;
+
+  /// Pointer to varstore backend
+  UINT32                             *ArmCpuVar;
+
+  /// Size of the varstore backend
+  UINT32                             ArmCpuVarSize;
+
+  /// Pointer to the generated formset
+  DYN_HII_HANDLE                     FormsetHandle;
+
+  /// Handle to the IFR buffer structure
+  DYN_HII_HANDLE                     IfrBufHandle;
+
+  /// Pointer to the form package data buffer
+  UINT8                              *IfrBuffer;
+
+  /// Pointer to string package handle
+  DYN_HII_STR_HANDLE                 StrPkg;
+
+  /// Pointer to the string package data buffer
+  UINT8                              *StrPkgBuf;
+
+  /// Device handle
+  EFI_HANDLE                         DevHandle;
+
+  /// Config routing protocol instance for the form
+  /// generator
+  EFI_HII_CONFIG_ROUTING_PROTOCOL    *HiiConfigRouting;
+
+  /// Config access protocol instance for the form
+  /// generator
+  EFI_HII_CONFIG_ACCESS_PROTOCOL     ConfigAccess;
+} HII_ARM_CPU_GEN_PRIV;
+
+#define DYN_HII_ARM_CPU_GEN_PRIVATE_FROM_THIS(a)  CR (a, HII_ARM_CPU_GEN_PRIV, ConfigAccess, DYN_HII_ARM_CPU_GEN_SIGNATURE)
+
+#pragma pack(1)
+
+///
+/// HII specific Vendor Device Path definition.
+///
+typedef struct {
+  VENDOR_DEVICE_PATH          VendorDevicePath;
+  EFI_DEVICE_PATH_PROTOCOL    End;
+} HII_VENDOR_DEVICE_PATH;
+
+#pragma pack()

--- a/DynamicTablesPkg/Library/Hii/CpuFormGenerator/ArmCpuFormGenerator.h
+++ b/DynamicTablesPkg/Library/Hii/CpuFormGenerator/ArmCpuFormGenerator.h
@@ -1,0 +1,86 @@
+/** @file
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+**/
+
+#pragma once
+
+#include <Protocol/HiiConfigAccess.h>
+#include <Protocol/HiiConfigRouting.h>
+#include <Protocol/DevicePath.h>
+
+/// Formset GUID
+#define DYNAMIC_PLATFORM_CFG_ARM_CPU_GUID \
+  { \
+    0xe1ab22e8, 0xeabe, 0x4bcb, {0xb0, 0xef, 0x9d, 0x5a, 0x5c, 0xa5, 0x5d, 0x9f} \
+  }
+
+/// Varstore GUID
+#define DYN_PLATFORM_CPU_VARSTORE_GUID \
+  { \
+    0xBC65E462, 0x138D, 0x499B, { 0x9A, 0x97, 0xAF, 0xD1, 0xA9, 0x18, 0x17, 0x9E } \
+  }
+
+/// Varstore ID for the Formset
+#define DYN_HII_ARM_CPU_VARSTORE_ID  0x1234
+
+/// Question ID start value for the Formset
+#define DYN_HII_ARM_CPU_QUESTION_ID_START  0x2000
+
+#define DYN_HII_ARM_CPU_GEN_SIGNATURE  SIGNATURE_64 ('A', 'R', 'M', 'C', 'P', 'U', 0, 0)
+
+/** This structure is used for holding the formset specific
+    private data.
+**/
+typedef struct HiiArmCpuGenPriv {
+  /// Formset Signature
+  UINT64                             Signature;
+
+  /// Question count
+  UINT32                             QuestionCount;
+
+  /// Varstore count
+  UINT32                             VarstoreCount;
+
+  /// Pointer to varstore backend
+  UINT32                             *ArmCpuVar;
+
+  /// Size of the varstore backend
+  UINT32                             ArmCpuVarSize;
+
+  /// Pointer to the generated formset
+  DYN_HII_FORMSET_HANDLE             FormsetHandle;
+
+  /// Pointer to string package handle
+  DYN_HII_STR_HANDLE                 StrPkg;
+
+  /// Device handle
+  EFI_HANDLE                         DevHandle;
+
+  /// Config routing protocol instance for the form
+  /// generator
+  EFI_HII_CONFIG_ROUTING_PROTOCOL    *HiiConfigRouting;
+
+  /// Config access protocol instance for the form
+  /// generator
+  EFI_HII_CONFIG_ACCESS_PROTOCOL     ConfigAccess;
+} HII_ARM_CPU_GEN_PRIV;
+
+#define DYN_HII_ARM_CPU_GEN_PRIVATE_FROM_THIS(a)  CR (a, HII_ARM_CPU_GEN_PRIV, ConfigAccess, DYN_HII_ARM_CPU_GEN_SIGNATURE)
+
+#pragma pack(1)
+
+///
+/// HII specific Vendor Device Path definition.
+///
+typedef struct {
+  VENDOR_DEVICE_PATH          VendorDevicePath;
+  EFI_DEVICE_PATH_PROTOCOL    End;
+} HII_VENDOR_DEVICE_PATH;
+
+#pragma pack()

--- a/DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.inf
+++ b/DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.inf
@@ -1,0 +1,56 @@
+## @file
+#  Dynamic HII Checkbox Question based Form Generator
+#
+#  Copyright (c) 2026, Arm Limited. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = CpuFormGenerator
+  MODULE_UNI_FILE                = CpuFormGenerator.uni
+  FILE_GUID                      = D052BAEB-B149-5E09-A467-5CBA9A86AE3f
+  MODULE_TYPE                    = DXE_DRIVER
+  LIBRARY_CLASS                  = NULL|DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  CONSTRUCTOR                    = HiiCpuFormConstructor
+  DESTRUCTOR                     = HiiCpuFormDestructor
+
+[Sources]
+  ArmCpuFormGenerator.c
+  ArmCpuFormGenerator.h
+  CpuFormGenerator.uni
+
+[Packages]
+  DynamicTablesPkg/DynamicTablesPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  DevicePathLib
+  HiiFormsLib
+  HiiStringsLib
+  HiiLib
+  MemoryAllocationLib
+  PrintLib
+  UefiBootServicesTableLib
+  UefiLib
+  UefiRuntimeServicesTableLib
+
+[Guids]
+  ## SOMETIMES_PRODUCES ## Event
+  ## CONSUMES ## Event
+  gEfiIfrTianoGuid
+  gEfiIfrRefreshIdOpGuid
+
+[Protocols]
+  gEfiDevicePathProtocolGuid
+  gEfiHiiConfigRoutingProtocolGuid              ## CONSUMES
+  gEfiHiiConfigAccessProtocolGuid               ## PRODUCES
+
+[Depex]
+  gEfiVariableArchProtocolGuid AND gEfiVariableWriteArchProtocolGuid

--- a/DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.uni
+++ b/DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.uni
@@ -1,0 +1,16 @@
+// /** @file
+// Dynamic HII CPU Form Generator.
+//
+// Copyright (c) 2026, Arm Limited. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// --*/
+
+#langdef en-US  "English"
+
+#string STR_MODULE_ABSTRACT                    #language en-US "Dynamic HII CPU form generator"
+#string STR_MODULE_DESCRIPTION                 #language en-US "Dynamic HII CPU form generator"
+#string STR_CPU_GEN_FORM_SET_TITLE             #language en-US "Configure CPU's on the platform"
+#string STR_CPU_GEN_FORM_SET_TITLE_HELP        #language en-US "Configure CPU's on the platform"
+#string STR_CPU_GEN_FORM_TITLE                 #language en-US "Enable/Disable CPU's"

--- a/DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.uni
+++ b/DynamicTablesPkg/Library/Hii/CpuFormGenerator/CpuFormGenerator.uni
@@ -1,0 +1,17 @@
+// /** @file
+// Dynamic HII CPU Form Generator.
+//
+// Copyright (c) 2026, Arm Limited. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// --*/
+
+#langdef en-US  "English"
+
+#string STR_MODULE_ABSTRACT                    #language en-US "Dynamic HII CPU form generator"
+#string STR_MODULE_DESCRIPTION                 #language en-US "Dynamic HII CPU form generator"
+#string STR_CPU_GEN_FORM_SET_TITLE             #language en-US "Configure CPU's on the platform"
+#string STR_CPU_GEN_FORM_SET_TITLE_HELP        #language en-US "Configure CPU's on the platform"
+#string STR_CPU_GEN_FORM_TITLE                 #language en-US "Enable/Disable CPU's"
+#string STR_CPU_GEN_QUESTION_HELP              #language en-US "Enable or Disable the CPU's"

--- a/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.c
+++ b/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.c
@@ -1,0 +1,536 @@
+/** @file
+  Dynamic Hii Root Form Generator.
+
+  This is the top level Form that references all other
+  dynamically generated HII forms.
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerHelper.h>
+#include <ConfigurationManagerObject.h>
+#include <HiiFormsGenerator.h>
+#include <Guid/HiiPlatformSetupFormset.h>
+#include <Guid/MdeModuleHii.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/HiiFormsLib.h>
+#include <Library/HiiLib.h>
+#include <Library/HiiStringsLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "RootFormGenerator.h"
+
+static EFI_HANDLE  mDevHandle;
+extern UINT8       RootFormGeneratorStrings[];
+
+/** Add all question objects to the Form
+
+  Add all the question objects, cross-links to other forms in this case,
+  to the form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the questions were added successfully or other
+                        failure codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+PopulateQuestionObjs (
+  IN     HII_ROOT_FORM_GEN_PRIV  *Priv
+  )
+{
+  UINTN             BufferSize;
+  EFI_GUID          FormsetGuid;
+  EFI_STATUS        Status;
+  EFI_STRING        String;
+  EFI_STRING_ID     Prompt;
+  EFI_STRING_ID     Help;
+  EFI_QUESTION_ID   QuestionId;
+  EFI_HII_HANDLE    HiiHandle;
+  DYN_HII_HANDLE    FormHandle;
+  EFI_IFR_FORM_SET  *Buffer;
+  HII_FORM_HANDLE   *Entry;
+
+  Buffer     = NULL;
+  String     = NULL;
+  QuestionId = DYN_HII_ROOT_FORM_QUESTION_ID_START;
+  FormHandle = DynHiiGetForm (Priv->FormsetHandle, 1);
+  Entry      = (HII_FORM_HANDLE *)GetFirstNode (Priv->HiiHandleList);
+  while (!IsNull (Priv->HiiHandleList, &Entry->List)) {
+    HiiHandle = Entry->HiiHandle;
+    Status    = HiiGetFormSetFromHiiHandle (HiiHandle, &Buffer, &BufferSize);
+    if (EFI_ERROR (Status)) {
+      Entry = (HII_FORM_HANDLE *)GetNextNode (Priv->HiiHandleList, &Entry->List);
+      continue;
+    }
+
+    String = HiiGetString (HiiHandle, Buffer->FormSetTitle, NULL);
+    Status = DynHiiAddString (Priv->StrPkg, "en-US", String, &Prompt);
+    if (EFI_ERROR (Status)) {
+      goto out;
+    }
+
+    FreePool (String);
+
+    String = HiiGetString (HiiHandle, Buffer->Help, NULL);
+    Status = DynHiiAddString (Priv->StrPkg, "en-US", String, &Help);
+    if (EFI_ERROR (Status)) {
+      goto out;
+    }
+
+    FreePool (String);
+    CopyMem (&FormsetGuid, &Buffer->Guid, sizeof (EFI_GUID));
+    Status = DynHiiAddRef3 (
+               FormHandle,
+               QuestionId++,
+               Prompt,
+               Help,
+               0,              // QuestionFlags
+               0,              // RefFormId
+               0,              // RefQuestionId
+               &FormsetGuid    // RefFormsetId
+               );
+    if (EFI_ERROR (Status)) {
+      goto out;
+    }
+
+    FreePool (Buffer);
+    Buffer     = NULL;
+    String     = NULL;
+    BufferSize = 0;
+
+    Entry = (HII_FORM_HANDLE *)GetNextNode (Priv->HiiHandleList, &Entry->List);
+  }
+
+  return EFI_SUCCESS;
+
+out:
+  if (Buffer != NULL) {
+    FreePool (Buffer);
+  }
+
+  if (String != NULL) {
+    FreePool (String);
+  }
+
+  return Status;
+}
+
+/** Add the Form object to the Formset
+
+  Add the form to the given formset.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Form was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormsetForms (
+  IN     HII_ROOT_FORM_GEN_PRIV  *Priv
+  )
+{
+  EFI_FORM_ID  TempId;
+
+  return DynHiiAddForm (
+           Priv->FormsetHandle,
+           STRING_TOKEN (STR_PLAT_CFG_FORM_TITLE),
+           &TempId
+           );
+}
+
+/** Create the Formset object for the form.
+
+  Add the Formset object for the form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Formset was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormset (
+  IN     HII_ROOT_FORM_GEN_PRIV  *Priv
+  )
+{
+  CONST EFI_GUID  FormsetGuid = DYNAMIC_HII_ROOT_FORM_GUID;
+  CONST EFI_GUID  ClassGuid   = EFI_HII_PLATFORM_SETUP_FORMSET_GUID;
+
+  return DynHiiCreateFormSet (
+           &FormsetGuid,
+           &ClassGuid,
+           STRING_TOKEN (STR_PLAT_CFG_FORM_SET_TITLE),
+           STRING_TOKEN (STR_PLAT_CFG_FORM_SET_TITLE_HELP),
+           1,
+           &Priv->FormsetHandle
+           );
+}
+
+/** Initialize the string package info structure.
+
+  Initialize the structure that contains information needed for the generation
+  of the string package.
+
+  @param [out]  StrPkg     Pointer to the string package info structure.
+
+  @retval  EFI_SUCCESS  If the structure was successfully initialized or other
+                        failure codes as returned by the string generation
+                        API's.
+
+**/
+static
+EFI_STATUS
+InitStringPkgInfo (
+  OUT DYN_HII_STR_HANDLE  *StrPkg
+  )
+{
+  return DynHiiInitStringPkg (
+           RootFormGeneratorStrings,
+           StrPkg
+           );
+}
+
+/** Initialize the form's private data structure.
+
+  Allocate and initialize the form's private data structure.
+
+  @param [in]  HiiHandleList    Pointer to the list of HII handles.
+  @param [out] PlatCfgPriv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the structure was initialized successfully or other
+                        failure codes as returned by the string generation
+                        API's.
+
+**/
+static
+EFI_STATUS
+InitFormPrivateData (
+  IN     LIST_ENTRY              *HiiHandleList,
+  OUT    HII_ROOT_FORM_GEN_PRIV  **PlatCfgPriv
+  )
+{
+  EFI_STATUS              Status;
+  HII_ROOT_FORM_GEN_PRIV  *Priv;
+
+  Priv = AllocateZeroPool (sizeof (*Priv));
+  if (Priv == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Priv->Signature     = DYN_HII_ROOT_FORM_GEN_SIGNATURE;
+  Priv->HiiHandleList = HiiHandleList;
+
+  Status = InitStringPkgInfo (&Priv->StrPkg);
+  if (EFI_ERROR (Status)) {
+    FreePool (Priv);
+    return Status;
+  }
+
+  *PlatCfgPriv = Priv;
+
+  return EFI_SUCCESS;
+}
+
+/** Construct Dynamic HII Root Form
+
+  This function is invoked for building the dynamic HII root form.
+  In turn, this calls the HII Form and String Generation API's
+  for building the form and string package, and then adds these
+  packages to the HII database through a call to HiiAddPackages().
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXRes function.
+
+  @param [in]  This            Pointer to the HII forms generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII forms information.
+  @param [in]  CfgMgrProtocol  Pointer to the Configuration Manager
+                               Protocol interface.
+  @param [in]  HiiHandleList   List of all Hii handles to which this
+                               form creates references.
+  @param [out] HiiHandle       Hii handle of this form.
+
+  @retval EFI_SUCCESS            Form generated successfully.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+static
+EFI_STATUS
+EFIAPI
+BuildHiiRootForm (
+  IN        HII_FORMS_GENERATOR                            *This,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                  *CONST  HiiFormsInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  IN  CONST LIST_ENTRY                                     *HiiHandleList,
+  OUT       EFI_HII_HANDLE                                 *HiiHandle
+  )
+{
+  EFI_STATUS              Status;
+  HII_ROOT_FORM_GEN_PRIV  *Priv;
+  CONST EFI_GUID          FormsetGuid = DYNAMIC_HII_ROOT_FORM_GUID;
+
+  ASSERT (HiiHandleList != NULL);
+
+  This->Priv = NULL;
+  Status     = InitFormPrivateData (
+                 (LIST_ENTRY *)HiiHandleList,
+                 (HII_ROOT_FORM_GEN_PRIV **)&This->Priv
+                 );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to Initialise the private data structure for the form."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Priv = This->Priv;
+
+  Status = SetupFormset (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to create the Formset."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = SetupFormsetForms (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to add the Form information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = PopulateQuestionObjs (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Question information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = DynHiiGenerateFormPackage (
+             Priv->FormsetHandle,
+             &Priv->IfrBufHandle,
+             &Priv->IfrBuffer
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to serialize the IFR Byte Buffer."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = DynHiiGenerateStringPackage (Priv->StrPkg, &Priv->StrPkgBuf);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to serialize the String Package Buffer."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  /// Add the template data to the Hii Package list
+  *HiiHandle = HiiAddPackages (
+                 &FormsetGuid,
+                 mDevHandle,
+                 Priv->IfrBuffer,
+                 Priv->StrPkgBuf,
+                 NULL
+                 );
+  if (*HiiHandle == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to add packages to Hii Database\n",
+      __func__
+      ));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  return Status;
+}
+
+/** Free up all resources associated with this form.
+
+  Free up all resources associated with this form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+**/
+static
+VOID
+DeInitPrivateData (
+  IN HII_ROOT_FORM_GEN_PRIV  *Priv
+  )
+{
+  if (Priv->FormsetHandle != NULL) {
+    DynHiiFreeFormSet (Priv->FormsetHandle);
+  }
+
+  if (Priv->IfrBuffer != NULL) {
+    DynHiiFreeFormPackage (Priv->IfrBufHandle);
+  }
+
+  if (Priv->StrPkg != NULL) {
+    DynHiiFreeStringPackage (Priv->StrPkg);
+  }
+
+  if (Priv->StrPkgBuf != NULL) {
+    FreePool (Priv->StrPkgBuf);
+  }
+
+  FreePool (Priv);
+}
+
+/** Free up all resources associated with this form.
+
+  Free up all resources associated with this form. In addition remove
+  the Hii Handle from the Hii database.
+
+  @param [in]  This            Pointer to the HII forms generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII forms information.
+  @param [in]  HiiHandle       Hii handle of this form.
+
+  @retval The resources were freed successfully.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+FreeHiiRootForm (
+  IN        HII_FORMS_GENERATOR                            *This,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                  *CONST  HiiFormsInfo,
+  IN  EFI_HII_HANDLE                                       *HiiHandle
+  )
+{
+  ASSERT (This != NULL);
+  ASSERT (This->GeneratorID == HiiFormsInfo->FormGeneratorId);
+
+  if (*HiiHandle != NULL) {
+    HiiRemovePackages (*HiiHandle);
+  }
+
+  if (This->Priv != NULL) {
+    DeInitPrivateData (This->Priv);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** The interface for the Root Form Generator.
+*/
+static
+HII_FORMS_GENERATOR  HiiRootFormGenerator = {
+  // Generator ID
+  CREATE_HII_FORMS_GEN_ID (EStdHiiFormsIdRootForm),
+  // Generator Description
+  L"HII.STD.ROOT.FORM.GENERATOR",
+  // Private structure for the Form (to be populated at runtime)
+  NULL,
+  // Build form function.
+  BuildHiiRootForm,
+  // Free form function.
+  FreeHiiRootForm,
+};
+
+/** Register the Generator with the HII Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+HiiRootFormConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterHiiFormsGenerator (&HiiRootFormGenerator);
+  DEBUG ((
+    DEBUG_INFO,
+    "HII-PlatCfg: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the HII Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+HiiRootFormDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterHiiFormsGenerator (&HiiRootFormGenerator);
+  DEBUG ((
+    DEBUG_INFO,
+    "HII-PlatCfg: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.c
+++ b/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.c
@@ -1,0 +1,555 @@
+/** @file
+  Dynamic Hii Root Form Generator.
+
+  This is the top level Form that references all other
+  dynamically generated HII forms.
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerHelper.h>
+#include <ConfigurationManagerObject.h>
+#include <HiiFormsGenerator.h>
+#include <Guid/HiiPlatformSetupFormset.h>
+#include <Guid/MdeModuleHii.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/HiiFormsLib.h>
+#include <Library/HiiLib.h>
+#include <Library/HiiStringsLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/TableHelperLib.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Uefi/UefiInternalFormRepresentation.h>
+
+#include "RootFormGenerator.h"
+
+static EFI_HANDLE  mDevHandle;
+extern UINT8       RootFormGeneratorStrings[];
+
+/** Add all question objects to the Form
+
+  Add all the question objects, cross-links to other forms in this case,
+  to the form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the questions were added successfully or other
+                        failure codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+PopulateQuestionObjs (
+  IN     HII_ROOT_FORM_GEN_PRIV  *Priv
+  )
+{
+  UINTN                BufferSize;
+  EFI_GUID             FormsetGuid;
+  EFI_STATUS           Status;
+  EFI_STRING_ID        Prompt;
+  EFI_STRING_ID        Help;
+  EFI_QUESTION_ID      QuestionId;
+  EFI_HII_HANDLE       HiiHandle;
+  DYN_HII_FORM_HANDLE  FormHandle;
+  EFI_IFR_FORM_SET     *Buffer;
+  HII_FORM_HANDLE      *Entry;
+  DYN_HII_STR_ENTRY    StrTable = {
+    .LanguageCode = "en-US"
+  };
+
+  Buffer          = NULL;
+  StrTable.String = NULL;
+  QuestionId      = DYN_HII_ROOT_FORM_QUESTION_ID_START;
+  FormHandle      = DynHiiGetForm (Priv->FormsetHandle, 1);
+  Entry           = (HII_FORM_HANDLE *)GetFirstNode (Priv->HiiHandleList);
+  while (!IsNull (Priv->HiiHandleList, &Entry->List)) {
+    HiiHandle = Entry->HiiHandle;
+    Status    = HiiGetFormSetFromHiiHandle (HiiHandle, &Buffer, &BufferSize);
+    if (EFI_ERROR (Status)) {
+      Entry = (HII_FORM_HANDLE *)GetNextNode (Priv->HiiHandleList, &Entry->List);
+      continue;
+    }
+
+    StrTable.String = HiiGetString (HiiHandle, Buffer->FormSetTitle, NULL);
+    if (StrTable.String == NULL) {
+      Status = EFI_NOT_FOUND;
+      goto out;
+    }
+
+    Status = DynHiiAddString (Priv->StrPkg, &StrTable, 1, &Prompt);
+    if (EFI_ERROR (Status)) {
+      goto out;
+    }
+
+    FreePool (StrTable.String);
+
+    StrTable.String = HiiGetString (HiiHandle, Buffer->Help, NULL);
+    if (StrTable.String == NULL) {
+      Status = EFI_NOT_FOUND;
+      goto out;
+    }
+
+    Status = DynHiiAddString (Priv->StrPkg, &StrTable, 1, &Help);
+    if (EFI_ERROR (Status)) {
+      goto out;
+    }
+
+    FreePool (StrTable.String);
+    StrTable.String = NULL;
+    CopyMem (&FormsetGuid, &Buffer->Guid, sizeof (EFI_GUID));
+    Status = DynHiiAddRef3 (
+               FormHandle,
+               QuestionId++,
+               Prompt,
+               Help,
+               0,              // QuestionFlags
+               0,              // RefFormId
+               0,              // RefQuestionId
+               &FormsetGuid,   // RefFormsetId
+               NULL            // StatementHandle
+               );
+    if (EFI_ERROR (Status)) {
+      goto out;
+    }
+
+    FreePool (Buffer);
+    Buffer          = NULL;
+    StrTable.String = NULL;
+    BufferSize      = 0;
+
+    Entry = (HII_FORM_HANDLE *)GetNextNode (Priv->HiiHandleList, &Entry->List);
+  }
+
+  return EFI_SUCCESS;
+
+out:
+  if (Buffer != NULL) {
+    FreePool (Buffer);
+  }
+
+  if (StrTable.String != NULL) {
+    FreePool (StrTable.String);
+  }
+
+  return Status;
+}
+
+/** Add the Form object to the Formset
+
+  Add the form to the given formset.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Form was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormsetForms (
+  IN     HII_ROOT_FORM_GEN_PRIV  *Priv
+  )
+{
+  EFI_FORM_ID  TempId;
+
+  return DynHiiAddForm (
+           Priv->FormsetHandle,
+           STRING_TOKEN (STR_PLAT_CFG_FORM_TITLE),
+           &TempId
+           );
+}
+
+/** Create the Formset object for the form.
+
+  Add the Formset object for the form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the Formset was added successfully or other failure
+                        codes as returned by the form generation API's.
+
+**/
+static
+EFI_STATUS
+SetupFormset (
+  IN     HII_ROOT_FORM_GEN_PRIV  *Priv
+  )
+{
+  CONST EFI_GUID  FormsetGuid = DYNAMIC_HII_ROOT_FORM_GUID;
+  CONST EFI_GUID  ClassGuid   = EFI_HII_PLATFORM_SETUP_FORMSET_GUID;
+
+  return DynHiiCreateFormSet (
+           &FormsetGuid,
+           &ClassGuid,
+           STRING_TOKEN (STR_PLAT_CFG_FORM_SET_TITLE),
+           STRING_TOKEN (STR_PLAT_CFG_FORM_SET_TITLE_HELP),
+           1,
+           &Priv->FormsetHandle
+           );
+}
+
+/** Initialize the string package info structure.
+
+  Initialize the structure that contains information needed for the generation
+  of the string package.
+
+  @param [out]  StrPkg     Pointer to the string package info structure.
+
+  @retval  EFI_SUCCESS  If the structure was successfully initialized or other
+                        failure codes as returned by the string generation
+                        API's.
+
+**/
+static
+EFI_STATUS
+InitStringPkgInfo (
+  OUT DYN_HII_STR_HANDLE  *StrPkg
+  )
+{
+  return DynHiiInitStringPkg (
+           RootFormGeneratorStrings,
+           StrPkg
+           );
+}
+
+/** Initialize the form's private data structure.
+
+  Allocate and initialize the form's private data structure.
+
+  @param [in]  HiiHandleList    Pointer to the list of HII handles.
+  @param [out] PlatCfgPriv      Pointer to the private structure of the form.
+
+  @retval  EFI_SUCCESS  If the structure was initialized successfully or other
+                        failure codes as returned by the string generation
+                        API's.
+
+**/
+static
+EFI_STATUS
+InitFormPrivateData (
+  IN     LIST_ENTRY              *HiiHandleList,
+  OUT    HII_ROOT_FORM_GEN_PRIV  **PlatCfgPriv
+  )
+{
+  EFI_STATUS              Status;
+  HII_ROOT_FORM_GEN_PRIV  *Priv;
+
+  Priv = AllocateZeroPool (sizeof (*Priv));
+  if (Priv == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Priv->Signature     = DYN_HII_ROOT_FORM_GEN_SIGNATURE;
+  Priv->HiiHandleList = HiiHandleList;
+
+  Status = InitStringPkgInfo (&Priv->StrPkg);
+  if (EFI_ERROR (Status)) {
+    FreePool (Priv);
+    return Status;
+  }
+
+  *PlatCfgPriv = Priv;
+
+  return EFI_SUCCESS;
+}
+
+/** Construct Dynamic HII Root Form
+
+  This function is invoked for building the dynamic HII root form.
+  In turn, this calls the HII Form and String Generation API's
+  for building the form and string package, and then adds these
+  packages to the HII database through a call to HiiAddPackages().
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXRes function.
+
+  @param [in]  This            Pointer to the HII forms generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII forms information.
+  @param [in]  CfgMgrProtocol  Pointer to the Configuration Manager
+                               Protocol interface.
+  @param [in]  HiiHandleList   List of all Hii handles to which this
+                               form creates references.
+  @param [out] HiiHandle       Hii handle of this form.
+
+  @retval EFI_SUCCESS            Form generated successfully.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+static
+EFI_STATUS
+EFIAPI
+BuildHiiRootForm (
+  IN        HII_FORMS_GENERATOR                            *This,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                  *CONST  HiiFormsInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  IN  CONST LIST_ENTRY                                     *HiiHandleList,
+  OUT       EFI_HII_HANDLE                                 *HiiHandle
+  )
+{
+  UINT8                   *IfrBuf;
+  UINT8                   *StrPkgBuf;
+  EFI_STATUS              Status;
+  HII_ROOT_FORM_GEN_PRIV  *Priv;
+  CONST EFI_GUID          FormsetGuid = DYNAMIC_HII_ROOT_FORM_GUID;
+
+  ASSERT (HiiHandleList != NULL);
+
+  This->Priv = NULL;
+  Status     = InitFormPrivateData (
+                 (LIST_ENTRY *)HiiHandleList,
+                 (HII_ROOT_FORM_GEN_PRIV **)&This->Priv
+                 );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to Initialise the private data structure for the form."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Priv      = This->Priv;
+  IfrBuf    = NULL;
+  StrPkgBuf = NULL;
+
+  Status = SetupFormset (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to create the Formset."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = SetupFormsetForms (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to add the Form information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = PopulateQuestionObjs (Priv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to populate the Question information."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    return Status;
+  }
+
+  Status = DynHiiGenerateFormPackage (
+             Priv->FormsetHandle,
+             &IfrBuf
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to serialize the IFR Byte Buffer."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    goto out;
+  }
+
+  Status = DynHiiGenerateStringPackage (Priv->StrPkg, &StrPkgBuf);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to serialize the String Package Buffer."
+      " Status = %r\n",
+      __func__,
+      Status
+      ));
+
+    goto out;
+  }
+
+  /// Add the template data to the Hii Package list
+  *HiiHandle = HiiAddPackages (
+                 &FormsetGuid,
+                 mDevHandle,
+                 IfrBuf,
+                 StrPkgBuf,
+                 NULL
+                 );
+  if (*HiiHandle == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a: Failed to add packages to Hii Database\n",
+      __func__
+      ));
+
+    Status = EFI_OUT_OF_RESOURCES;
+  }
+
+out:
+  if (IfrBuf != NULL) {
+    FreePool (IfrBuf);
+  }
+
+  if (StrPkgBuf != NULL) {
+    FreePool (StrPkgBuf);
+  }
+
+  return Status;
+}
+
+/** Free up all resources associated with this form.
+
+  Free up all resources associated with this form.
+
+  @param [in]  Priv      Pointer to the private structure of the form.
+
+**/
+static
+VOID
+DeInitPrivateData (
+  IN HII_ROOT_FORM_GEN_PRIV  *Priv
+  )
+{
+  if (Priv->FormsetHandle != NULL) {
+    DynHiiFreeFormSet (Priv->FormsetHandle);
+  }
+
+  if (Priv->StrPkg != NULL) {
+    DynHiiFreeStringPackage (Priv->StrPkg);
+  }
+
+  FreePool (Priv);
+}
+
+/** Free up all resources associated with this form.
+
+  Free up all resources associated with this form. In addition remove
+  the Hii Handle from the Hii database.
+
+  @param [in]  This            Pointer to the HII forms generator.
+  @param [in]  HiiFormsInfo    Pointer to the HII forms information.
+  @param [in]  HiiHandle       Hii handle of this form.
+
+  @retval The resources were freed successfully.
+
+**/
+static
+EFI_STATUS
+EFIAPI
+FreeHiiRootForm (
+  IN        HII_FORMS_GENERATOR                            *This,
+  IN  CONST CM_HII_FORMS_OBJ_INFO                  *CONST  HiiFormsInfo,
+  IN  EFI_HII_HANDLE                                       *HiiHandle
+  )
+{
+  ASSERT (This != NULL);
+  ASSERT (This->GeneratorID == HiiFormsInfo->FormGeneratorId);
+
+  if (*HiiHandle != NULL) {
+    HiiRemovePackages (*HiiHandle);
+  }
+
+  if (This->Priv != NULL) {
+    DeInitPrivateData (This->Priv);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** The interface for the Root Form Generator.
+*/
+static
+HII_FORMS_GENERATOR  HiiRootFormGenerator = {
+  // Generator ID
+  CREATE_HII_FORMS_GEN_ID (EStdHiiFormsIdRootForm),
+  // Generator Description
+  L"HII.STD.ROOT.FORM.GENERATOR",
+  // Private structure for the Form (to be populated at runtime)
+  NULL,
+  // Build form function.
+  BuildHiiRootForm,
+  // Free form function.
+  FreeHiiRootForm,
+};
+
+/** Register the Generator with the HII Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+HiiRootFormConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterHiiFormsGenerator (&HiiRootFormGenerator);
+  DEBUG ((
+    DEBUG_INFO,
+    "HII-PlatCfg: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/** Deregister the Generator from the HII Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+HiiRootFormDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterHiiFormsGenerator (&HiiRootFormGenerator);
+  DEBUG ((
+    DEBUG_INFO,
+    "HII-PlatCfg: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.h
+++ b/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.h
@@ -1,0 +1,53 @@
+/** @file
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+**/
+
+#pragma once
+
+/** Dynamic HII root formset GUID.
+*/
+#define DYNAMIC_HII_ROOT_FORM_GUID \
+  { \
+    0x1806F55C, 0x0DC5, 0x468B, { 0x80, 0x45, 0xD2, 0x91, 0x6E, 0xF2, 0xF4, 0x55 } \
+  }
+
+/** Dynamic HII root form generator signature.
+*/
+#define DYN_HII_ROOT_FORM_GEN_SIGNATURE  SIGNATURE_64 ('R', 'O', 'O', 'T', 'F', 'O', 'R', 'M')
+
+/** Question ID start value for the formset
+*/
+#define DYN_HII_ROOT_FORM_QUESTION_ID_START  0x1000
+
+/** Structure for holding private data for the Form generator.
+*/
+typedef struct HiiPlatCfgGenPriv {
+  /// Form generator signature
+  UINT64                Signature;
+
+  /// Pointer to the Form's formset
+  DYN_HII_HANDLE        FormsetHandle;
+
+  /// Handle to the IFR buffer structure
+  DYN_HII_HANDLE        IfrBufHandle;
+
+  /// Form package buffer pointer
+  UINT8                 *IfrBuffer;
+
+  /// String package information for the
+  /// generator
+  DYN_HII_STR_HANDLE    StrPkg;
+
+  /// String package data buffer pointer
+  UINT8                 *StrPkgBuf;
+
+  /// List of HII Handles that are to be added under
+  /// this Form
+  LIST_ENTRY            *HiiHandleList;
+} HII_ROOT_FORM_GEN_PRIV;

--- a/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.h
+++ b/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.h
@@ -1,0 +1,44 @@
+/** @file
+
+  Copyright (c) 2026, ARM Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - HII        - Human Interface Infrastructure
+**/
+
+#pragma once
+
+/** Dynamic HII root formset GUID.
+*/
+#define DYNAMIC_HII_ROOT_FORM_GUID \
+  { \
+    0x1806F55C, 0x0DC5, 0x468B, { 0x80, 0x45, 0xD2, 0x91, 0x6E, 0xF2, 0xF4, 0x55 } \
+  }
+
+/** Dynamic HII root form generator signature.
+*/
+#define DYN_HII_ROOT_FORM_GEN_SIGNATURE  SIGNATURE_64 ('R', 'O', 'O', 'T', 'F', 'O', 'R', 'M')
+
+/** Question ID start value for the formset
+*/
+#define DYN_HII_ROOT_FORM_QUESTION_ID_START  0x1000
+
+/** Structure for holding private data for the Form generator.
+*/
+typedef struct HiiPlatCfgGenPriv {
+  /// Form generator signature
+  UINT64                    Signature;
+
+  /// Pointer to the Form's formset
+  DYN_HII_FORMSET_HANDLE    FormsetHandle;
+
+  /// String package information for the
+  /// generator
+  DYN_HII_STR_HANDLE        StrPkg;
+
+  /// List of HII Handles that are to be added under
+  /// this Form
+  LIST_ENTRY                *HiiHandleList;
+} HII_ROOT_FORM_GEN_PRIV;

--- a/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
+++ b/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.inf
@@ -1,0 +1,46 @@
+## @file
+#  Dynamic HII Platform Configuration Form Generator
+#
+#  Copyright (c) 2026, Arm Limited. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = RootFormGenerator
+  MODULE_UNI_FILE                = RootFormGenerator.uni
+  FILE_GUID                      = 967D421F-9AC0-4E9F-B272-8A94F5ED6A25
+  MODULE_TYPE                    = DXE_DRIVER
+  LIBRARY_CLASS                  = NULL|DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  CONSTRUCTOR                    = HiiRootFormConstructor
+  DESTRUCTOR                     = HiiRootFormDestructor
+
+[Sources]
+  RootFormGenerator.c
+  RootFormGenerator.h
+  RootFormGenerator.uni
+
+[Packages]
+  DynamicTablesPkg/DynamicTablesPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  DevicePathLib
+  HiiFormsLib
+  HiiStringsLib
+  HiiLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+  UefiLib
+
+[Guids]
+  ## SOMETIMES_PRODUCES ## Event
+  ## CONSUMES ## Event
+  gEfiIfrTianoGuid
+  gEfiIfrRefreshIdOpGuid

--- a/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.uni
+++ b/DynamicTablesPkg/Library/Hii/RootFormGenerator/RootFormGenerator.uni
@@ -1,0 +1,19 @@
+// /** @file
+// Dynamic HII Root Form Generator.
+//
+// Top level form that references all other dynamically
+// generated forms.
+//
+// Copyright (c) 2026, Arm Limited. All rights reserved.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// --*/
+
+#langdef en-US  "English"
+
+#string STR_MODULE_ABSTRACT                     #language en-US "Root form generator"
+#string STR_MODULE_DESCRIPTION                  #language en-US "Top level form for referencing all other generated forms."
+#string STR_PLAT_CFG_FORM_SET_TITLE             #language en-US "Dynamic Platform Configuration"
+#string STR_PLAT_CFG_FORM_SET_TITLE_HELP        #language en-US "Dynamic Platform Configuration"
+#string STR_PLAT_CFG_FORM_TITLE                 #language en-US "Dynamic Platform Configuration"

--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -732,6 +732,22 @@ typedef UINTN *BASE_LIST;
 #define _BASE_INT_SIZE_OF(TYPE)  ((sizeof (TYPE) + sizeof (UINTN) - 1) / sizeof (UINTN))
 
 /**
+  Macro that performs integer division of Dividend by Divisor, rounding up to the
+  nearest integer.
+
+  This macro is intended for positive integer operands.
+
+  @param  X   The Dividend number
+  @param  Y   The Divisor number
+
+  @return The Quotient, rounded up to the nearest integer
+
+**/
+#ifndef BASE_DIV_ROUND_UP
+#define BASE_DIV_ROUND_UP(X, Y)  (((X) + (Y) - 1) / (Y))
+#endif
+
+/**
   Returns an argument of a specified type from a variable argument list and updates
   the pointer to the variable argument list to point to the next argument.
 


### PR DESCRIPTION
# Description

These patches add a runtime HII Form generation framework to the DynamicTablesPkg, which is similar to the existing Dynamic-Tables ACPI/SMBIOS table generation architecture, and plugs it into the package's Factory/Manager flow.

There are two primary components that are involved.
1. Libraries which provide set of API's which can be used for runtime generation of the HII Form and String packages.  
2. HII Form generators which can be invoked by the platform. The Form generators would then build the HII Form by invoking the API's mentioned above.

Why this is needed:
 1. Allows for HII Form generation at runtime, instead of build time generation through vfr/uni files.
 2. This would be useful in scenarios where the structure of the Form could be changed at runtime based on some inputs received from an earlier stage boot image.
 3. Provides a generic/architecture agnostic framework for generating the Form and String packages dynamically, which can be added to the HII database through HiiAddPackages(). 

 What this series adds:
1. Core public interfaces and namespace objects for HII form generators in DynamicTablesPkg.
2. HII Forms Factory integration (register/deregister/get generator interfaces).
3. DynamicTableManager integration to fetch configured HII generators and invoke build/free paths.
4. New HiiFormsLib implementation:
      - runtime object model/builders for formset/form/statement/varstore/defaults/options
      - IFR form package serializer
 5. New HiiStringsLib implementation
      - runtime string package modifier and generator
6. Two runtime form generators:
      - top-level root form generator
      - ARM CPU form generator (CPU info from CM, variable backend setup, CPU enable/disable bitfield control)
6. Supporting base/protocol updates:
      - BASE_DIV_ROUND_UP() helper macro for integer sizing/count calculations

Things to be added:
1. Primarily, support for expressions, allowing for conditional disabling/graying out of Form content
 
Other design considered:
Dynamically adding HII Form content through the existing 'label' based mechanism was also explored. However, that approach has certain limitations.
1. Still need to provide a template vfr/uni file per form generator.
5. The dynamic content would have to be confined within the contours provided by the template vfr file.
6. The design has certain limitations where the dynamic content cannot span across forms, or does not allow for adding types like varstores etc.

Changes since version 1:
* Carve out the string manipulation and form generation functionality into a separate HiiStringsLib library.
* Add multiple language support in the HiiStringsLib implementation
* Incorporate a hybrid model for the HiiStringsLib implementation, where some of the fixed strings are included into the uni file, and the string library works on the string package array generated at build-time to add dynamic strings.
* Change the string addition API's to allow for multi-language support.
* Change the form generation API's to work with opaque handles instead of the actual data-types.
* Add separate API's per question type, instead of the earlier generic API to add any question type.
* The first two patches to change variable sized members of the EFI_IFR_* opcodes to flexible array type, have been   dropped. This is done to keep the structure definitions similar to the ones used by VfrCompiler tool.

Changes since version 2:
* Pulled in the library class declaration for HiiFormsLib and HiiStringsLib in the respective patches that add the library.
* Added references to the corresponding UEFI section for the Forms package and Strings package in the new files being added in HiiFormsLib and HiiStringsLib.
* Use node type specific handles, e.g. DYN_HII_FORMSET_HANDLE, instead of a generic DYN_HII_HANDLE that was being used earlier.
* Changed the prototype of the question addition API's under DynamicTablesPkg/Library/Common/HiiFormsLib/HiiFormGenerator.c to have an `optional` StatementHandle parameter which can be used to return a handle to the created statement(question).
* Added checks in individual question addition functions, like DynHiiAddCheckbox() for the respective flags being populated under the question header and the actual question opcode.
* Added a check in DynHiiAddOneOf() function that the numeric size passed in the OneOfFlags parameter matches the ValueType parameter.
* Used a boolean MinMaxSet to determine if the minimum/maximum value has not being set.
* For all union based opcodes being serialized, compute the size of the opcode based on the size that has been requested, instead of using the size of the largest data-type. This matches with the logic being used by the VfrCompile tool for serializing union based opcodes.
* Added table driver serialization logic for some of the functions which are re-using the same function prototype. Certain higher level functions have been left as-is for sake of code clarity.
* Changed the prototype of DynHiiGenerateFormPackage() to only output the generated serialized IFR buffer.
* Changed DYN_HII_IFR_BUFFER variable BufInfo to a local variable in DynHiiGenerateFormPackage() instead of allocating it. 
* Removed the now superfluous DynHiiFreeFormPackage().
* Handled some of the misc review comments from Pierre about moving related functions closer, and adding comments for certain sections, removing superfluous variable assignments etc.
* Renamed DynHiiGenStringList() to DynHiiBuildStrBlocks().
* Changed the prototype of DynHiiAddString() to allow for adding strings for multiple supported languages in the same function call.
*  Changed the data-type of certain variables from UINTN to UINT64. These variables were being used to check for UINT32 overflow.
* Used a local variable of type DYN_HII_STR_PKG_BUFFER in DynHiiGenerateStringPackage() for bookkeeping of the current position of the string package buffer that will be written to.
* Fixed the entry removal logic in DynHiiFreeStringPackage().
* Made DynHiiFreeStrings() a static function.
* Added a macro CREATE_OEM_HII_FORMS_GEN_ID() for OEM HII form generator support.
* Removed the unused FormsetToken member from CM_HII_FORMS_OBJ_INFO.
* Added FormVariantId member to the CM_HII_FORMS_OBJ_INFO structure.
* Added support for OEM form generators in the HII factory DXE module.
* Made changes in the root form generarator and CPU form generators corresponding to the changes made in the HIIFormsLib and HiiStringsLib.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was unit tested on the Arm VExpress(FVP) platform with the CPU Form generator that is being added in the patch-series.

## Integration Instructions

N/A
