### PR TITLE
NetworkPkg/SnpDxe: Fix MAC address passthrough by reading station address after init

### DIFF
--- a/NetworkPkg/SnpDxe/Initialize.c
+++ b/NetworkPkg/SnpDxe/Initialize.c
@@ -188,6 +188,7 @@ SnpUndi32Initialize (
   )
 {
   EFI_STATUS  EfiStatus;
+  EFI_STATUS  StnAddrStatus;
   SNP_DRIVER  *Snp;
   EFI_TPL     OldTpl;
 
@@ -253,6 +254,11 @@ SnpUndi32Initialize (
   //
   if (Snp->CableDetectSupported) {
     if (PxeInit (Snp, PXE_OPFLAGS_INITIALIZE_DETECT_CABLE) == EFI_SUCCESS) {
+      StnAddrStatus = PxeGetStnAddr (Snp);
+      if (EFI_ERROR (StnAddrStatus)) {
+        DEBUG ((DEBUG_WARN, "%a: failed to refresh station address (%r)\n", __func__, StnAddrStatus));
+      }
+
       goto ON_EXIT;
     }
   }
@@ -271,6 +277,11 @@ SnpUndi32Initialize (
   //
   if (Snp->MediaStatusSupported) {
     PxeGetStatus (Snp, NULL, FALSE);
+  }
+
+  StnAddrStatus = PxeGetStnAddr (Snp);
+  if (EFI_ERROR (StnAddrStatus)) {
+    DEBUG ((DEBUG_WARN, "%a: failed to refresh station address (%r)\n", __func__, StnAddrStatus));
   }
 
 ON_EXIT:


### PR DESCRIPTION
During SnpUndi32Initialize(), CurrentAddress is unconditionally
overwritten with PermanentAddress before UNDI initialization. This
causes MAC address passthrough (MacPassthru) to fail, as the NIC's
actual current address which may differ from its permanent address
is lost.

After UNDI initialization completes, call PxeGetStnAddr() to read the
NIC's station address via the UNDI interface and update CurrentAddress,
PermanentAddress, and BroadcastAddress in the mode structure with the
values reported by the hardware.

The call is added to both initialization paths: the cable-detect
success path and the fallback no-cable-detect path.

Signed-off-by: Jared Pan <jared.pan@dell.com>

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions

