### PR TITLE
Maintainers.txt: Add Myself as MdeModulePkg/Core Maintainer

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -217,7 +217,6 @@ M: Abner Chang <abner.chang@amd.com> [changab]
 EmulatorPkg
 F: EmulatorPkg/
 W: https://www.tianocore.org/tianocore-wiki.github.io/platforms-packages/platform-ports/emulator_pkg.html
-M: Oliver Smith-Denny <osde@microsoft.com> [os-d]
 M: Andrew Fish <afish@apple.com> [ajfish]
 M: Michael Kubacki <mikuback@linux.microsoft.com> [makubacki]
 S: Maintained
@@ -312,6 +311,7 @@ F: MdeModulePkg/Library/DxeSecurityManagementLib/
 F: MdeModulePkg/Universal/PCD/
 F: MdeModulePkg/Universal/PlatformDriOverrideDxe/
 F: MdeModulePkg/Universal/SecurityStubDxe/SecurityStub.c
+M: Oliver Smith-Denny <osde@microsoft.com> [os-d]
 R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
 R: Khalid Ali <khaliidcaliy@gmail.com> [khaliid2040]
 R: Mike Beaton <mjsbeaton@gmail.com> [mikebeaton]
@@ -379,6 +379,7 @@ R: Khalid Ali <khaliidcaliy@gmail.com> [khaliid2040]
 
 MdeModulePkg: Pei Core
 F: MdeModulePkg/Core/Pei/
+M: Oliver Smith-Denny <osde@microsoft.com> [os-d]
 R: Liming Gao <gaoliming@byosoft.com.cn> [lgao4]
 R: Khalid Ali <khaliidcaliy@gmail.com> [khaliid2040]
 


### PR DESCRIPTION
# Description

Add myself as a maintainer of DXE and PEI Core modules. I've made some large changes there to date and I plan on more, so I figure it is only fair to sign up to help maintain it.

As I am taking on a larger maintenance set, drop my EmulatorPkg maintainership to focus on the new one. @makubacki is already an EmulatorPkg maintainer and has agreed to take sole active maintenance there.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A.

## Integration Instructions

N/A.
