### PR TITLE
RedfishPkg/RedfishHttpDxe: report Redfish communication time

### DIFF
--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.h
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.h
@@ -1,7 +1,7 @@
 /** @file
   Definitions of RedfishHttpDxe
 
-  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -25,17 +25,19 @@
 #include <Library/RedfishDebugLib.h>
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/PrintLib.h>
+#include <Library/TimerLib.h>
 
 #include <Protocol/Http.h>
 #include <Protocol/EdkIIRedfishHttpProtocol.h>
 #include <Protocol/EdkIIRedfishCredential2.h>
 #include <Protocol/RestEx.h>
 
-#define REDFISH_HTTP_CACHE_LIST_SIZE      0x80
-#define REDFISH_ERROR_MSG_MAX             128
-#define REDFISH_DEBUG_STRING_LENGTH       200
-#define REDFISH_HOST_NAME_MAX             64   // IPv6 maximum length (39) + "https://" (8) + port number (maximum 5)
-#define REDFISH_HTTP_ERROR_REPORT         "Redfish HTTP %a failure(0x%x): %s"
-#define REDFISH_HTTP_CACHE_DEBUG          DEBUG_MANAGEABILITY
-#define REDFISH_HTTP_CACHE_DEBUG_DUMP     DEBUG_MANAGEABILITY
-#define REDFISH_HTTP_CACHE_DEBUG_REQUEST  DEBUG_MANAGEABILITY
+#define REDFISH_HTTP_CACHE_LIST_SIZE              0x80
+#define REDFISH_ERROR_MSG_MAX                     128
+#define REDFISH_DEBUG_STRING_LENGTH               200
+#define REDFISH_HOST_NAME_MAX                     64  // IPv6 maximum length (39) + "https://" (8) + port number (maximum 5)
+#define REDFISH_HTTP_ERROR_REPORT                 "Redfish HTTP %a failure(0x%x): %s"
+#define REDFISH_HTTP_CACHE_DEBUG                  DEBUG_MANAGEABILITY
+#define REDFISH_HTTP_CACHE_DEBUG_DUMP             DEBUG_MANAGEABILITY
+#define REDFISH_HTTP_CACHE_DEBUG_REQUEST          DEBUG_MANAGEABILITY
+#define REDFISH_HTTP_RESPONSE_TIME_DEBUG_ENABLED  0x0

--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.inf
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpDxe.inf
@@ -3,7 +3,7 @@
 #  EdkIIRedfishHttpProtocol to EDK2 Redfish Feature
 #  drivers for HTTP operation.
 #
-#  Copyright (c) 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -47,6 +47,7 @@
   PrintLib
   RedfishDebugLib
   ReportStatusCodeLib
+  TimerLib
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   UefiLib

--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
@@ -11,6 +11,19 @@
 #include "RedfishHttpData.h"
 
 /**
+  Return HTTP method in ASCII string. Caller does not need
+  to free returned string buffer.
+
+  @param[in]  Method         HTTP method.
+
+  @retval CHAR8 *   Method in string.
+**/
+CHAR8 *
+HttpMethodToString (
+  IN  EFI_HTTP_METHOD  Method
+  );
+
+/**
   This function copies all headers in SrcHeaders to DstHeaders.
   It's call responsibility to release returned DstHeaders.
 
@@ -640,6 +653,13 @@ HttpSendReceive (
   EFI_HTTP_HEADER          *XAuthTokenHeader;
   CHAR8                    *HttpContentEncoding;
 
+ #if REDFISH_HTTP_RESPONSE_TIME_DEBUG_ENABLED
+  UINT64  StartNs;
+  UINT64  EndNs;
+  UINT64  ElapsedNs;
+
+ #endif
+
   if ((Service == NULL) || IS_EMPTY_STRING (Uri) || (Response == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
@@ -661,6 +681,10 @@ HttpSendReceive (
     return EFI_PROTOCOL_ERROR;
   }
 
+ #if REDFISH_HTTP_RESPONSE_TIME_DEBUG_ENABLED
+  StartNs = GetTimeInNanoSecond (GetPerformanceCounter ());
+ #endif
+
   //
   // call RESTEx to get response from REST service.
   //
@@ -668,6 +692,12 @@ HttpSendReceive (
   if (EFI_ERROR (RestExStatus)) {
     DEBUG ((DEBUG_ERROR, "%a: %s SendReceive failure: %r\n", __func__, Uri, RestExStatus));
   }
+
+ #if REDFISH_HTTP_RESPONSE_TIME_DEBUG_ENABLED
+  EndNs     = GetTimeInNanoSecond (GetPerformanceCounter ());
+  ElapsedNs = EndNs - StartNs;
+  DEBUG ((DEBUG_ERROR, "%a: %a %s takes: %ld us\n", __func__, HttpMethodToString (Method), Uri, (ElapsedNs / 1000)));
+ #endif
 
   //
   // Return status code, headers and payload to caller as much as possible even when RestEx returns failure.

--- a/RedfishPkg/RedfishPkg.dsc
+++ b/RedfishPkg/RedfishPkg.dsc
@@ -4,7 +4,7 @@
 # Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2021 Hewlett-Packard Enterprise Development LP.
 # Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
-# Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -48,6 +48,7 @@
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
   SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
   RedfishPlatformWantedDeviceLib|RedfishPkg/Library/RedfishPlatformWantedDeviceLibNull/RedfishPlatformWantedDeviceLibNull.inf
+  TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
 
   # NULL instance of IPMI related library.
   IpmiLib|MdeModulePkg/Library/BaseIpmiLibNull/BaseIpmiLibNull.inf


### PR DESCRIPTION
# Description

Add the support of reporting Redfish communication time between BIOS and BMC. This helps to debug the issue of long boot time. This debug function is default disabled, so it won't add extra time during Redfish communication on regular boot.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on Arm base server.

## Integration Instructions

N/A
