### PR TITLE
MdeModulePkg: Print HOB memory type names

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -232,6 +232,7 @@ DEFINE FD_SIZE_IN_MB    = 3
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   PeiCoreEntryPoint|MdePkg/Library/PeiCoreEntryPoint/PeiCoreEntryPoint.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   PerformanceLib|MdeModulePkg/Library/PeiPerformanceLib/PeiPerformanceLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
@@ -274,6 +275,7 @@ DEFINE FD_SIZE_IN_MB    = 3
   MemoryAllocationLib|MdeModulePkg/Library/DxeCoreMemoryAllocationLib/DxeCoreMemoryAllocationLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/DxeExtractGuidedSectionLib/DxeExtractGuidedSectionLib.inf
   PerformanceLib|MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_DRIVER]
   SecurityManagementLib|MdeModulePkg/Library/DxeSecurityManagementLib/DxeSecurityManagementLib.inf

--- a/EmulatorPkg/EmulatorPkg.dsc
+++ b/EmulatorPkg/EmulatorPkg.dsc
@@ -205,6 +205,7 @@
 
 [LibraryClasses.common.PEI_CORE]
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.PEIM]
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
@@ -218,6 +219,7 @@
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   TimerLib|EmulatorPkg/Library/DxeCoreTimerLib/DxeCoreTimerLib.inf
   EmuThunkLib|EmulatorPkg/Library/DxeEmuLib/DxeEmuLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
 !if $(SECURE_BOOT_ENABLE) == TRUE

--- a/IntelFsp2Pkg/Tools/Tests/QemuFspPkg.dsc
+++ b/IntelFsp2Pkg/Tools/Tests/QemuFspPkg.dsc
@@ -87,6 +87,7 @@
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -85,6 +85,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugAgentLib.h>
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/OrderedCollectionLib.h>
+#include <Library/HobPrintLib.h>
 
 #include <MemoryBin.h>
 

--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -97,6 +97,7 @@
   PcdLib
   ImagePropertiesRecordLib
   OrderedCollectionLib
+  HobPrintLib
 
 [Guids]
   gEfiEventMemoryMapChangeGuid                  ## PRODUCES             ## Event

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -404,10 +404,11 @@ DxeMain (
     if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_MEMORY_ALLOCATION) {
       DEBUG ((
         DEBUG_INFO | DEBUG_LOAD,
-        "Memory Allocation 0x%08x 0x%0lx - 0x%0lx\n", \
-        Hob.MemoryAllocation->AllocDescriptor.MemoryType,                      \
-        Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress,               \
-        Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress + Hob.MemoryAllocation->AllocDescriptor.MemoryLength - 1
+        "Memory Allocation 0x%08x 0x%0lx - 0x%0lx (%a)\n",
+        Hob.MemoryAllocation->AllocDescriptor.MemoryType,
+        Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress,
+        Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress + Hob.MemoryAllocation->AllocDescriptor.MemoryLength - 1,
+        GetMemoryTypeName (Hob.MemoryAllocation->AllocDescriptor.MemoryType)
         ));
     }
   }

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -397,65 +397,9 @@ DxeMain (
 
   DEBUG ((DEBUG_INFO | DEBUG_LOAD, "HOBLIST address in DXE = 0x%p\n", HobStart));
 
-  DEBUG_CODE_BEGIN ();
-  EFI_PEI_HOB_POINTERS  Hob;
-
-  for (Hob.Raw = HobStart; !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
-    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_MEMORY_ALLOCATION) {
-      DEBUG ((
-        DEBUG_INFO | DEBUG_LOAD,
-        "Memory Allocation 0x%08x 0x%0lx - 0x%0lx (%a)\n",
-        Hob.MemoryAllocation->AllocDescriptor.MemoryType,
-        Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress,
-        Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress + Hob.MemoryAllocation->AllocDescriptor.MemoryLength - 1,
-        GetMemoryTypeName (Hob.MemoryAllocation->AllocDescriptor.MemoryType)
-        ));
-    }
-  }
-
-  for (Hob.Raw = HobStart; !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
-    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV) {
-      DEBUG ((
-        DEBUG_INFO | DEBUG_LOAD,
-        "FV Hob            0x%0lx - 0x%0lx\n",
-        Hob.FirmwareVolume->BaseAddress,
-        Hob.FirmwareVolume->BaseAddress + Hob.FirmwareVolume->Length - 1
-        ));
-    } else if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV2) {
-      DEBUG ((
-        DEBUG_INFO | DEBUG_LOAD,
-        "FV2 Hob           0x%0lx - 0x%0lx\n",
-        Hob.FirmwareVolume2->BaseAddress,
-        Hob.FirmwareVolume2->BaseAddress + Hob.FirmwareVolume2->Length - 1
-        ));
-      DEBUG ((
-        DEBUG_INFO | DEBUG_LOAD,
-        "                  %g - %g\n",
-        &Hob.FirmwareVolume2->FvName,
-        &Hob.FirmwareVolume2->FileName
-        ));
-    } else if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV3) {
-      DEBUG ((
-        DEBUG_INFO | DEBUG_LOAD,
-        "FV3 Hob           0x%0lx - 0x%0lx - 0x%x - 0x%x\n",
-        Hob.FirmwareVolume3->BaseAddress,
-        Hob.FirmwareVolume3->BaseAddress + Hob.FirmwareVolume3->Length - 1,
-        Hob.FirmwareVolume3->AuthenticationStatus,
-        Hob.FirmwareVolume3->ExtractedFv
-        ));
-      if (Hob.FirmwareVolume3->ExtractedFv) {
-        DEBUG ((
-          DEBUG_INFO | DEBUG_LOAD,
-          "                  %g - %g\n",
-          &Hob.FirmwareVolume3->FvName,
-          &Hob.FirmwareVolume3->FileName
-          ));
-      }
-    }
-  }
-
-  DEBUG_CODE_END ();
-
+  DEBUG_CODE ( 
+    PrintHobList (HobStart, NULL); 
+  ); 
   //
   // Initialize the Event Services
   //

--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -1094,7 +1094,6 @@ PeiCheckAndSwitchStack (
     //
     DEBUG_CODE_BEGIN ();
     UINT32                *StackPointer;
-    EFI_PEI_HOB_POINTERS  Hob;
 
     for (  StackPointer = (UINT32 *)SecCoreData->StackBase;
            (StackPointer < (UINT32 *)((UINTN)SecCoreData->StackBase + SecCoreData->StackSize)) \
@@ -1121,18 +1120,7 @@ PeiCheckAndSwitchStack (
       "  temporary memory heap occupied by memory pages: %d bytes.\n",
       (UINT32)(UINTN)(Private->HobList.HandoffInformationTable->EfiMemoryTop - Private->HobList.HandoffInformationTable->EfiFreeMemoryTop)
       ));
-    for (Hob.Raw = Private->HobList.Raw; !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
-      if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_MEMORY_ALLOCATION) {
-        DEBUG ((
-          DEBUG_INFO,
-          "Memory Allocation 0x%08x 0x%0lx - 0x%0lx (%a)\n",
-          Hob.MemoryAllocation->AllocDescriptor.MemoryType,
-          Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress,
-          Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress + Hob.MemoryAllocation->AllocDescriptor.MemoryLength - 1,
-          GetMemoryTypeName (Hob.MemoryAllocation->AllocDescriptor.MemoryType)
-          ));
-      }
-    }
+    PrintHobList (Private->HobList.Raw, NULL);
 
     DEBUG_CODE_END ();
 

--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -1125,10 +1125,11 @@ PeiCheckAndSwitchStack (
       if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_MEMORY_ALLOCATION) {
         DEBUG ((
           DEBUG_INFO,
-          "Memory Allocation 0x%08x 0x%0lx - 0x%0lx\n", \
-          Hob.MemoryAllocation->AllocDescriptor.MemoryType,               \
-          Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress,        \
-          Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress + Hob.MemoryAllocation->AllocDescriptor.MemoryLength - 1
+          "Memory Allocation 0x%08x 0x%0lx - 0x%0lx (%a)\n",
+          Hob.MemoryAllocation->AllocDescriptor.MemoryType,
+          Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress,
+          Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress + Hob.MemoryAllocation->AllocDescriptor.MemoryLength - 1,
+          GetMemoryTypeName (Hob.MemoryAllocation->AllocDescriptor.MemoryType)
           ));
       }
     }

--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -45,6 +45,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
 #include <Library/SafeIntLib.h>
+#include <Library/HobPrintLib.h>
 #include <Guid/FirmwareFileSystem2.h>
 #include <Guid/FirmwareFileSystem3.h>
 #include <Guid/AprioriFileName.h>

--- a/MdeModulePkg/Core/Pei/PeiMain.inf
+++ b/MdeModulePkg/Core/Pei/PeiMain.inf
@@ -69,6 +69,7 @@
   PcdLib
   TimerLib
   SafeIntLib
+  HobPrintLib
 
 [Guids]
   gPeiAprioriFileNameGuid       ## SOMETIMES_CONSUMES   ## File

--- a/MdeModulePkg/Include/Library/HobPrintLib.h
+++ b/MdeModulePkg/Include/Library/HobPrintLib.h
@@ -41,18 +41,3 @@ PrintHobList (
   IN CONST VOID         *HobStart,
   IN HOB_PRINT_HANDLER  PrintHandler OPTIONAL
   );
-
-/**
-  Return the human-readable name string for the given EFI_MEMORY_TYPE.
-
-  @param[in] MemoryType   The memory type value.
-
-  @return A pointer to a null-terminated ASCII string describing the memory type,
-          or "Unknown" if the type is not recognized.
-
-**/
-CONST CHAR8 *
-EFIAPI
-GetMemoryTypeName (
-  IN EFI_MEMORY_TYPE  MemoryType
-  );

--- a/MdeModulePkg/Include/Library/HobPrintLib.h
+++ b/MdeModulePkg/Include/Library/HobPrintLib.h
@@ -41,3 +41,18 @@ PrintHobList (
   IN CONST VOID         *HobStart,
   IN HOB_PRINT_HANDLER  PrintHandler OPTIONAL
   );
+
+/**
+  Return the human-readable name string for the given EFI_MEMORY_TYPE.
+
+  @param[in] MemoryType   The memory type value.
+
+  @return A pointer to a null-terminated ASCII string describing the memory type,
+          or "Unknown" if the type is not recognized.
+
+**/
+CONST CHAR8 *
+EFIAPI
+GetMemoryTypeName (
+  IN EFI_MEMORY_TYPE  MemoryType
+  );

--- a/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
+++ b/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
@@ -39,7 +39,7 @@ CHAR8  *mMemoryTypeStr[] = {
   "EfiMemoryMappedIOPortSpace",
   "EfiPalCode",
   "EfiPersistentMemory",
-  "EfiMaxMemoryType"
+  "EfiUnacceptedMemoryType"
 };
 
 CHAR8  *mResource_Type_List[] = {

--- a/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
+++ b/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
@@ -382,28 +382,6 @@ PrintFv3Hob (
   return EFI_SUCCESS;
 }
 
-/**
-  Return the human-readable name string for the given EFI_MEMORY_TYPE.
-
-  @param[in] MemoryType   The memory type value.
-
-  @return A pointer to a null-terminated ASCII string describing the memory type,
-          or "Unknown" if the type is not recognized.
-
-**/
-CONST CHAR8 *
-EFIAPI
-GetMemoryTypeName (
-  IN EFI_MEMORY_TYPE  MemoryType
-  )
-{
-  if ((UINTN)MemoryType < ARRAY_SIZE (mMemoryTypeStr)) {
-    return mMemoryTypeStr[MemoryType];
-  }
-
-  return "Unknown";
-}
-
 //
 // Mapping table from Hob type to Hob print function.
 //
@@ -422,7 +400,11 @@ HOB_PRINT_HANDLER_TABLE  mHobHandles[] = {
 };
 
 /**
-  Print all HOBs info from the HOB list.
+  Print memory allocation HOB information from the HOB list.
+
+  If a custom PrintHandler is provided, it is called first. If it returns
+  EFI_SUCCESS, the default handling for the HOB is skipped. Otherwise, only
+  EFI_HOB_TYPE_MEMORY_ALLOCATION HOBs are printed.
 
   @param[in] HobStart       A pointer to the HOB list.
   @param[in] PrintHandler   A custom handler to print HOB info.
@@ -437,58 +419,51 @@ PrintHobList (
 {
   EFI_STATUS            Status;
   EFI_PEI_HOB_POINTERS  Hob;
-  UINTN                 Count;
-  UINTN                 Index;
+  EFI_PHYSICAL_ADDRESS  End;
+  CONST CHAR8           *MemoryTypeName;
 
   ASSERT (HobStart != NULL);
 
   Hob.Raw = (UINT8 *)HobStart;
-  DEBUG ((DEBUG_INFO, "Print all Hob information from Hob 0x%p\n", Hob.Raw));
 
-  Status = EFI_SUCCESS;
-  Count  = 0;
-  //
-  // Parse the HOB list to see which type it is, and print the information.
-  //
   while (!END_OF_HOB_LIST (Hob)) {
-    //
-    // Print HOB generic information
-    //
-    for (Index = 0; Index < ARRAY_SIZE (mHobHandles); Index++) {
-      if (Hob.Header->HobType == mHobHandles[Index].Type) {
-        DEBUG ((DEBUG_INFO, "HOB[%d]: Type = %a, Offset = 0x%p, Length = 0x%x\n", Count, mHobHandles[Index].Name, (Hob.Raw - (UINT8 *)HobStart), Hob.Header->HobLength));
-        break;
-      }
-    }
-
-    if (Index == ARRAY_SIZE (mHobHandles)) {
-      DEBUG ((DEBUG_INFO, "HOB[%d]: Type = %d, Offset = 0x%p, Length = 0x%x\n", Count, Hob.Header->HobType, (Hob.Raw - (UINT8 *)HobStart), Hob.Header->HobLength));
-    }
-
     //
     // Process custom HOB print handler first
     //
+    Status = EFI_SUCCESS;
     if (PrintHandler != NULL) {
       Status = PrintHandler (Hob.Raw, Hob.Header->HobLength);
     }
 
     //
-    // Process internal HOB print handler
+    // Print concise memory allocation information when the custom handler
+    // does not handle this HOB.
     //
     if ((PrintHandler == NULL) || EFI_ERROR (Status)) {
-      if (Index < ARRAY_SIZE (mHobHandles)) {
-        if (mHobHandles[Index].PrintHandler != NULL) {
-          mHobHandles[Index].PrintHandler (Hob.Raw, Hob.Header->HobLength);
+      if (Hob.Header->HobType == EFI_HOB_TYPE_MEMORY_ALLOCATION) {
+        if (Hob.MemoryAllocation->AllocDescriptor.MemoryLength == 0) {
+          End = Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress;
+        } else {
+          End = Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress + Hob.MemoryAllocation->AllocDescriptor.MemoryLength - 1;
         }
-      } else {
-        DEBUG ((DEBUG_INFO, "   Unknown Hob type, full hex dump in below:\n"));
-        PrintHex (DEBUG_INFO, Hob.Raw, Hob.Header->HobLength);
+
+        if ((UINTN)Hob.MemoryAllocation->AllocDescriptor.MemoryType < ARRAY_SIZE (mMemoryTypeStr)) {
+          MemoryTypeName = mMemoryTypeStr[Hob.MemoryAllocation->AllocDescriptor.MemoryType];
+        } else {
+          MemoryTypeName = "Unknown";
+        }
+
+        DEBUG ((
+          DEBUG_INFO,
+          "Memory Allocation 0x%08x 0x%0lx - 0x%0lx (%a)\n",
+          Hob.MemoryAllocation->AllocDescriptor.MemoryType,
+          Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress,
+          End,
+          MemoryTypeName
+          ));
       }
     }
 
-    Count++;
     Hob.Raw = GET_NEXT_HOB (Hob);
   }
-
-  DEBUG ((DEBUG_INFO, "There are totally %d Hobs, the End Hob address is %p\n", Count, Hob.Raw));
 }

--- a/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
+++ b/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
@@ -382,6 +382,28 @@ PrintFv3Hob (
   return EFI_SUCCESS;
 }
 
+/**
+  Return the human-readable name string for the given EFI_MEMORY_TYPE.
+
+  @param[in] MemoryType   The memory type value.
+
+  @return A pointer to a null-terminated ASCII string describing the memory type,
+          or "Unknown" if the type is not recognized.
+
+**/
+CONST CHAR8 *
+EFIAPI
+GetMemoryTypeName (
+  IN EFI_MEMORY_TYPE  MemoryType
+  )
+{
+  if ((UINTN)MemoryType < ARRAY_SIZE (mMemoryTypeStr)) {
+    return mMemoryTypeStr[MemoryType];
+  }
+
+  return "Unknown";
+}
+
 //
 // Mapping table from Hob type to Hob print function.
 //

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -115,6 +115,7 @@
 [LibraryClasses.common.PEI_CORE]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -127,6 +128,7 @@
   HobLib|MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
   MemoryAllocationLib|MdeModulePkg/Library/DxeCoreMemoryAllocationLib/DxeCoreMemoryAllocationLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/DxeExtractGuidedSectionLib/DxeExtractGuidedSectionLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -260,6 +260,7 @@
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -311,6 +312,7 @@
 !endif
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -290,6 +290,7 @@
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -342,6 +343,7 @@
 !endif
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -295,6 +295,7 @@
 !endif
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -342,6 +343,7 @@
 !endif
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -246,6 +246,7 @@
   HobLib|MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
   DxeCoreEntryPoint|MdePkg/Library/DxeCoreEntryPoint/DxeCoreEntryPoint.inf
   MemoryAllocationLib|MdeModulePkg/Library/DxeCoreMemoryAllocationLib/DxeCoreMemoryAllocationLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -253,6 +253,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
 !endif
+  HobPrintLib                      | MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib                           | MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -285,6 +286,7 @@
   PciPcdProducerLib                | OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   CpuExceptionHandlerLib           | UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   PerformanceLib                   | MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.inf
+  HobPrintLib                      | MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   PcdLib                           | MdePkg/Library/DxePcdLib/DxePcdLib.inf

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -300,6 +300,7 @@
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -350,6 +351,7 @@
 !endif
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -285,6 +285,7 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   PeiCoreEntryPoint|MdePkg/Library/PeiCoreEntryPoint/PeiCoreEntryPoint.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
@@ -334,6 +335,7 @@
   HobLib|MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
   DxeCoreEntryPoint|MdePkg/Library/DxeCoreEntryPoint/DxeCoreEntryPoint.inf
   MemoryAllocationLib|MdeModulePkg/Library/DxeCoreMemoryAllocationLib/DxeCoreMemoryAllocationLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
 !ifdef $(DEBUG_ON_SERIAL_PORT)
   DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -316,6 +316,7 @@
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   PeiCoreEntryPoint|MdePkg/Library/PeiCoreEntryPoint/PeiCoreEntryPoint.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
@@ -387,6 +388,7 @@
 !endif
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -265,6 +265,7 @@
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
   PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -294,6 +295,7 @@
   MemoryAllocationLib|MdeModulePkg/Library/DxeCoreMemoryAllocationLib/DxeCoreMemoryAllocationLib.inf
   ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/DxeExtractGuidedSectionLib/DxeExtractGuidedSectionLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 !if $(SOURCE_DEBUG_ENABLE) == TRUE
   DebugAgentLib|SourceLevelDebugPkg/Library/DebugAgent/DxeDebugAgentLib.inf
 !endif

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -161,6 +161,7 @@
 
 [LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM]
   TimerLib|UefiCpuPkg/Library/RiscV64CpuTimerLib/RiscV64CpuTimerSecLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 !if $(TPM2_ENABLE) == TRUE
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
@@ -171,6 +172,7 @@
 
 [LibraryClasses.common.DXE_CORE]
   TimerLib|UefiCpuPkg/Library/RiscV64CpuTimerLib/RiscV64CpuTimerDxeLib.inf
+  HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
 
 [LibraryClasses.common.DXE_DRIVER]
   TimerLib|UefiCpuPkg/Library/RiscV64CpuTimerLib/RiscV64CpuTimerDxeLib.inf


### PR DESCRIPTION
…ug log

When iterating EFI_HOB_TYPE_MEMORY_ALLOCATION entries, the existing
DEBUG output only prints the numeric MemoryType value in hexadecimal.
This makes it necessary to manually cross-reference the EFI_MEMORY_TYPE
enum to understand which memory region belongs to which memory type.

Add a new GetMemoryTypeName() API to HobPrintLib that returns the
human-readable string for a given EFI_MEMORY_TYPE value. Use this
function in the DEBUG_CODE_BEGIN() blocks of both DxeMain and PeiCore
dispatcher to append the type name to the existing format string:

Also fix the existing mMemoryTypeStr array in HobPrintLib.c which
incorrectly mapped index 15 to "EfiMaxMemoryType" instead of
"EfiUnacceptedMemoryType".

Before:
```
Memory Allocation 0x00000006 0x812000 - 0x812FFF
Memory Allocation 0x0000000A 0x7EF78000 - 0x7EFFFFFF
Memory Allocation 0x0000000A 0x814000 - 0x81FFFF
```

After:
```
Memory Allocation 0x00000006 0x812000 - 0x812FFF (EfiRuntimeServicesData)
Memory Allocation 0x0000000A 0x7FF78000 - 0x7FFFFFFF (EfiACPIMemoryNVS)
Memory Allocation 0x0000000A 0x814000 - 0x81FFFF (EfiACPIMemoryNVS)
```

# Description

- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build OvmfX64.dsc with GCC and test in QEMU x86-64 system

## Integration Instructions

N/A
