### PR TITLE
ShellPkg: Fix smbiosview probe table display

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -5101,7 +5101,7 @@ DisplayTemperatureProbeStatus (
   UINT8  Status;
 
   Status = (UINT8)((Key & 0xE0) >> 5);
-  ShellPrintHiiDefaultEx (STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_TEMP_PROBE), gShellDebug1HiiHandle);
+  ShellPrintHiiDefaultEx (STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_TEMP_PROBE_STATUS), gShellDebug1HiiHandle);
   PRINT_INFO_OPTION (Status, Option);
   PRINT_TABLE_ITEM (TemperatureProbeStatusTable, Status);
 }
@@ -5121,7 +5121,7 @@ DisplayTemperatureProbeLoc (
   UINT8  Loc;
 
   Loc = (UINT8)(Key & 0x1F);
-  ShellPrintHiiDefaultEx (STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_VOLTAGE_PROBE_LOC), gShellDebug1HiiHandle);
+  ShellPrintHiiDefaultEx (STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_TEMP_PROBE_LOC), gShellDebug1HiiHandle);
   PRINT_INFO_OPTION (Loc, Option);
   PRINT_TABLE_ITEM (TemperatureProbeLocTable, Loc);
 }

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -6,7 +6,7 @@
   Copyright (c) 2005 - 2024, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2016-2019 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-  Copyright (c) 2023, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2023-2026, Arm Limited. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -5020,7 +5020,7 @@ DisplayVPLocation (
 {
   UINT8  Loc;
 
-  Loc = (UINT8)((Key & 0xE0) >> 5);
+  Loc = (UINT8)(Key & 0x1F);
   ShellPrintHiiDefaultEx (STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_VOLTAGE_PROBE_LOC), gShellDebug1HiiHandle);
   PRINT_INFO_OPTION (Loc, Option);
   PRINT_TABLE_ITEM (VPLocationTable, Loc);
@@ -5040,7 +5040,7 @@ DisplayVPStatus (
 {
   UINT8  Status;
 
-  Status = (UINT8)(Key & 0x1F);
+  Status = (UINT8)((Key & 0xE0) >> 5);
   ShellPrintHiiDefaultEx (STRING_TOKEN (STR_SMBIOSVIEW_QUERYTABLE_VOLTAGE_PROBE_STATUS), gShellDebug1HiiHandle);
   PRINT_INFO_OPTION (Status, Option);
   PRINT_TABLE_ITEM (VPStatusTable, Status);

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/SmbiosViewStrings.uni
@@ -6,6 +6,7 @@
 // (C) Copyright 2015-2019 Hewlett Packard Enterprise Development LP<BR>
 // Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Arm Limited. All rights reserved.<BR>
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Module Name:
@@ -452,7 +453,8 @@
 #string STR_SMBIOSVIEW_QUERYTABLE_VOLTAGE_PROBE_STATUS          #language en-US "Voltage Probe - Status:"
 #string STR_SMBIOSVIEW_QUERYTABLE_COOLING_DEV_STATUS            #language en-US "Cooling Device - Status: "
 #string STR_SMBIOSVIEW_QUERYTABLE_COOLING_DEV_TYPE              #language en-US "Cooling Device - Type: "
-#string STR_SMBIOSVIEW_QUERYTABLE_TEMP_PROBE                    #language en-US "Temperature Probe - Status:"
+#string STR_SMBIOSVIEW_QUERYTABLE_TEMP_PROBE_STATUS             #language en-US "Temperature Probe - Status:"
+#string STR_SMBIOSVIEW_QUERYTABLE_TEMP_PROBE_LOC                #language en-US "Temperature Probe - Location:"
 #string STR_SMBIOSVIEW_QUERYTABLE_ELEC_PROBE_STATUS             #language en-US "Electrical Current Probe - Status:"
 #string STR_SMBIOSVIEW_QUERYTABLE_ELEC_PROBE_LOC                #language en-US "Electrical Current Probe - Location:"
 #string STR_SMBIOSVIEW_QUERYTABLE_MANAGEMENT_DEV_TYPE           #language en-US "Management Device Type:"


### PR DESCRIPTION
Fix two smbiosview display issues for SMBIOS probe tables.

The Type 26 Voltage Probe decoder was interpreting the Location and Status
fields in the wrong bit order. Per SMBIOS 3.9.0, section 7.27, Table 95,
bits 4:0 are Location and bits 7:5 are Status.

The Type 28 Temperature Probe decoder was displaying the Location field
with the Voltage Probe label. Add and use a Temperature Probe specific
Location label instead.