### PR TITLE
OvmfPkg: Add PcdEfiShellAutoboot to optionally restore shell autoboot

### DIFF
--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -1693,7 +1693,9 @@ PlatformBootManagerAfterConsole (
   PlatformRegisterFvBootOption (
     &gUefiShellFileGuid,
     L"EFI Internal Shell",
-    LOAD_OPTION_ACTIVE | LOAD_OPTION_CATEGORY_APP,
+    FeaturePcdGet (PcdEfiShellAutoboot)
+      ? LOAD_OPTION_ACTIVE
+      : LOAD_OPTION_ACTIVE | LOAD_OPTION_CATEGORY_APP,
     ShellEnabled
     );
 

--- a/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -59,6 +59,9 @@
   QemuFwCfgSimpleParserLib
   PlatformBootManagerCommonLib
 
+[FeaturePcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdEfiShellAutoboot
+
 [Pcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdEmuVariableEvent
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfFlashVariablesEnable

--- a/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBm.c
+++ b/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBm.c
@@ -1046,7 +1046,9 @@ PlatformBootManagerAfterConsole (
   PlatformRegisterFvBootOption (
     &gUefiShellFileGuid,
     L"EFI Internal Shell",
-    LOAD_OPTION_ACTIVE | LOAD_OPTION_CATEGORY_APP,
+    FeaturePcdGet (PcdEfiShellAutoboot)
+      ? LOAD_OPTION_ACTIVE
+      : LOAD_OPTION_ACTIVE | LOAD_OPTION_CATEGORY_APP,
     ShellEnabled
     );
 

--- a/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBootManagerLib.inf
+++ b/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBootManagerLib.inf
@@ -55,6 +55,9 @@
   UefiRuntimeServicesTableLib
   PlatformBootManagerCommonLib
 
+[FeaturePcd]
+  gUefiOvmfPkgTokenSpaceGuid.PcdEfiShellAutoboot
+
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultDataBits

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -499,6 +499,9 @@
   ## This feature flag indicates the firmware build needs the qemu variable service.
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuVarsRequire|FALSE|BOOLEAN|0x77
 
+  ## This feature flag enables EFI Shell autoboot.
+  gUefiOvmfPkgTokenSpaceGuid.PcdEfiShellAutoboot|FALSE|BOOLEAN|0x81
+
   ## Informs modules whether the platform firmware supports Standalone MM.
   #
   gUefiOvmfPkgTokenSpaceGuid.PcdStandaloneMmEnable|FALSE|BOOLEAN|0x100065


### PR DESCRIPTION
# Description

Commits 896907b53b and ca278f14c2 set LOAD_OPTION_CATEGORY_APP on the EFI Shell boot option, preventing it from being used as a fallback boot target. This is desirable for interactive use but breaks automated testing frameworks like edk2-sct that rely on the shell starting automatically after each VM reboot.

Add a new FeaturePcd PcdEfiShellAutoboot (default FALSE) that enables or disables autoboot on the shell.
Users who need autoboot can enable it at build time via:

  build --pcd PcdEfiShellAutoboot=TRUE

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build edk2 with `--pcd PcdEfiShellAutoboot=TRUE`
Run VM without any disk attached and check if shell autoboots 

## Integration Instructions

N/A
