### PR TITLE
BaseTools/GenFv: Update reset vector for rebased non-top FVs

### DIFF
--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.c
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.c
@@ -2840,7 +2840,12 @@ Returns:
       // If the PEI Core is found, the VTF file will probably get
       // corrupted by updating the entry point.
       //
+      // The FV is rebased when ForceRebase == 1 or, on the legacy path, when
+      // ForceRebase is unset and the FV has a non-zero base address. In both
+      // cases the reset vector must be updated to match the rebased modules.
+      //
       if (mFvDataInfo.ForceRebase == 1 ||
+          (mFvDataInfo.ForceRebase == -1 && mFvDataInfo.BaseAddress != 0) ||
           (mFvDataInfo.BaseAddress + mFvDataInfo.Size) == FV_IMAGES_TOP_ADDRESS) {
         Status = UpdateResetVector (&FvImageMemoryFile, &mFvDataInfo, VtfFileImage);
         if (EFI_ERROR(Status)) {


### PR DESCRIPTION
## Description

GenFv relocates the PE/COFF images in a firmware volume in two situations:

- when `FvForceRebase = TRUE` is set (`ForceRebase == 1`), and
- on the legacy path, when `ForceRebase` is unset and the FV has a non-zero
  base address (`ForceRebase == -1 && BaseAddress != 0`).

In both situations the module image bases are relocated to the FV run-time
address.

`UpdateResetVector()` patches the SEC -> PEI hand-off data stored in the
Volume Top File: the PEI Core entry point and the boot FV base address. It is
currently invoked only when `ForceRebase == 1` or when the FV ends at 4 GB
(`BaseAddress + Size == FV_IMAGES_TOP_ADDRESS`).

As a result, a boot FV that is rebased via the legacy path to a base address
that does not end at 4 GB gets its module bodies relocated, but its
reset-vector hand-off pointers are left at their build-time placeholder
values. At reset, SEC reads the placeholder PEI Core entry and transfers to
an invalid address, faulting before any PEI code executes.

## Change

Also invoke `UpdateResetVector()` on the legacy rebase path so that any boot
FV rebased to a fixed base has its reset-vector hand-off data updated to match
the rebased modules. `UpdateResetVector()` already returns early when the FV
contains no VTF or SEC core, so non-boot FVs are unaffected.

## Verification

Built GenFv with and without this change and ran both on the same boot-FV
input produced for the legacy path (`ForceRebase` unset, non-zero base):

- Without the change, the SEC -> PEI hand-off pointers (PEI Core entry and
  boot FV base) in the generated FV remained at their build-time placeholders.
- With the change, those pointers were written with the correct rebased
  PEI Core entry and boot FV base, matching the values `UpdateResetVector()`
  produces on the `ForceRebase == 1` path.
