### PR TITLE
LoongArchVirt: Add TPM support

### DIFF
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -149,7 +149,16 @@
   SerializeVariablesLib            | OvmfPkg/Library/SerializeVariablesLib/SerializeVariablesLib.inf
   CustomizedDisplayLib             | MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
   DebugPrintErrorLevelLib          | MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
-  TpmMeasurementLib                | MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
+!if $(TPM2_ENABLE) == TRUE
+  Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
+  Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
+  TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
+  TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
+!else
+  TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
+  TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
+!endif
 !if $(SECURE_BOOT_ENABLE) == TRUE
   PlatformSecureLib                | OvmfPkg/Library/PlatformSecureLib/PlatformSecureLib.inf
   AuthVariableLib                  | SecurityPkg/Library/AuthVariableLib/AuthVariableLib.inf
@@ -240,6 +249,10 @@
   QemuFwCfgLib                     | OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioPeiLib.inf
   PlatformHookLib                  | OvmfPkg/LoongArchVirt/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf
   PerformanceLib                   | MdeModulePkg/Library/PeiPerformanceLib/PeiPerformanceLib.inf
+!if $(TPM2_ENABLE) == TRUE
+  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+!endif
 
 [LibraryClasses.common.PEIM]
   HobLib                           | MdePkg/Library/PeiHobLib/PeiHobLib.inf
@@ -259,6 +272,10 @@
   CpuMmuInitLib                    | OvmfPkg/LoongArchVirt/Library/CpuMmuInitLib/CpuMmuInitLib.inf
   MpInitLib                        | UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf
   PlatformHookLib                  | OvmfPkg/LoongArchVirt/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf
+!if $(TPM2_ENABLE) == TRUE
+  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
+  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
+!endif
 
 [LibraryClasses.common.DXE_CORE]
   HobLib                           | MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
@@ -315,6 +332,9 @@
   PciPcdProducerLib                | OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   AcpiPlatformLib                  | OvmfPkg/Library/AcpiPlatformLib/DxeAcpiPlatformLib.inf
   MpInitLib                        | UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+!if $(TPM2_ENABLE) == TRUE
+  Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.inf
+!endif
 
 [LibraryClasses.common.UEFI_APPLICATION]
   PcdLib                           | MdePkg/Library/DxePcdLib/DxePcdLib.inf
@@ -487,12 +507,28 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosVersion|0x0300
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosDocRev|0x0
   gUefiOvmfPkgTokenSpaceGuid.PcdQemuSmbiosValidated|TRUE
+  #
+  # TPM2 support
+  #
+!if $(TPM2_ENABLE) == TRUE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0x0
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask|0
+!endif
 
 [PcdsDynamicHii]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut|L"Timeout"|gEfiGlobalVariableGuid|0x0|3
-
+!if $(TPM2_CONFIG_ENABLE) == TRUE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x0|"1.3"|NV,BS
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableRev|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x8|3|NV,BS
+!endif
 [PcdsPatchableInModule.common]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x0
+!if $(TPM2_ENABLE) == FALSE
+  # make this PCD patchable instead of dynamic when TPM support is not enabled
+  # this permits setting the PCD in unreachable code without pulling in dynamic PCD support
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0x0
+!endif
 
 [Components]
 
@@ -500,6 +536,24 @@
   # SEC Phase modules
   #
   OvmfPkg/LoongArchVirt/Sec/SecMain.inf
+!if $(TPM2_ENABLE) == TRUE
+  SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf {
+    <LibraryClasses>
+      Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.inf
+      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
+      HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+  }
+  SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf {
+    <LibraryClasses>
+      TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
+  }
+  OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+!endif
 
   #
   # PEI Phase modules
@@ -747,3 +801,23 @@
     <PcdsFixedAtBuild>
       gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE
   }
+
+  #
+  # TPM2 support
+  #
+!if $(TPM2_ENABLE) == TRUE
+  SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf {
+    <LibraryClasses>
+      HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
+      Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
+      NULL|SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
+      NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+  }
+!if $(TPM2_CONFIG_ENABLE) == TRUE
+  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
+!endif
+!endif

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
@@ -210,6 +210,15 @@ INF ShellPkg/Application/Shell/Shell.inf
 INF MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.inf
 INF ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf
 
+#
+# TPM support
+#
+!if $(TPM2_ENABLE) == TRUE
+  INF SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+!if $(TPM2_CONFIG_ENABLE) == TRUE
+  INF SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
+!endif
+!endif
 #####################################################################################################
 [FV.FVMAIN_COMPACT]
 FvNameGuid         = af8c3fe8-9ce8-4548-884a-e3f4dd91f040
@@ -249,6 +258,12 @@ INF  OvmfPkg/LoongArchVirt/Sec/SecMain.inf
 INF  MdeModulePkg/Core/Pei/PeiMain.inf
 INF  MdeModulePkg/Universal/PCD/Pei/Pcd.inf
 INF  OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
+
+!if $(TPM2_ENABLE) == TRUE
+  INF  SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
+  INF  SecurityPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
+  INF  OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+!endif
 INF  MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
 INF  MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTablePei/FirmwarePerformancePei.inf
 

--- a/OvmfPkg/LoongArchVirt/PlatformPei/Platform.c
+++ b/OvmfPkg/LoongArchVirt/PlatformPei/Platform.c
@@ -58,6 +58,12 @@ CONST EFI_PEI_PPI_DESCRIPTOR  mPpiListBootMode = {
 
 STATIC EFI_BOOT_MODE  mBootMode = BOOT_WITH_FULL_CONFIGURATION;
 
+CONST EFI_PEI_PPI_DESCRIPTOR  mTpm2DiscoveredPpi = {
+  (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gOvmfTpmDiscoveredPpiGuid,
+  NULL
+};
+
 /**
   Create system type  memory range hand off block.
 
@@ -312,6 +318,185 @@ ReportSystemMemorySize (
 }
 
 /**
+  Set up TPM resources from FDT.
+
+  @param  FdtBase       Fdt base address
+
+**/
+STATIC
+VOID
+SetupTPMResources (
+  VOID  *FdtBase
+  )
+{
+  INT32         Node, Prev;
+  INT32         Parent, Depth;
+  CONST CHAR8   *Compatible;
+  CONST CHAR8   *CompItem;
+  INT32         Len;
+  INT32         RangesLen;
+  CONST UINT8   *RegProp;
+  CONST UINT32  *RangesProp;
+  UINT64        TpmBase;
+  UINT64        TpmBaseSize;
+
+  //
+  // Empty TpmBaseSize indicates no TPM found.
+  //
+  TpmBase     = 0;
+  TpmBaseSize = 0;
+
+  //
+  // Set Parent to suppress incorrect compiler/analyzer warnings.
+  //
+  Parent = 0;
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: FdtBase=%p, FdtCheckHeader=%d\n",
+    __func__,
+    FdtBase,
+    FdtCheckHeader (FdtBase)
+    ));
+
+  for (Prev = Depth = 0; ; Prev = Node) {
+    Node = FdtNextNode (FdtBase, Prev, &Depth);
+    if (Node < 0) {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a: FdtNextNode returned %d, stopping\n",
+        __func__,
+        Node
+        ));
+      break;
+    }
+
+    if (Depth == 1) {
+      Parent = Node;
+    }
+
+    Compatible = FdtGetProp (FdtBase, Node, "compatible", &Len);
+    if (Compatible != NULL) {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a: depth=%d node=%d compat=%a (len=%d)\n",
+        __func__,
+        Depth,
+        Node,
+        Compatible,
+        Len
+        ));
+    } else {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a: depth=%d node=%d (no compatible)\n",
+        __func__,
+        Depth,
+        Node
+        ));
+    }
+
+    //
+    // Iterate over the NULL-separated items in the compatible string
+    //
+    for (CompItem = Compatible; CompItem != NULL && CompItem < Compatible + Len;
+         CompItem += 1 + AsciiStrLen (CompItem))
+    {
+      if (AsciiStrCmp (CompItem, "tcg,tpm-tis-mmio") == 0) {
+        DEBUG ((
+          DEBUG_INFO,
+          "%a: found tpm node at depth %d\n",
+          __func__,
+          Depth
+          ));
+        RegProp = FdtGetProp (FdtBase, Node, "reg", &Len);
+        DEBUG ((
+          DEBUG_INFO,
+          "%a: reg len=%d\n",
+          __func__,
+          Len
+          ));
+        ASSERT (Len == 8 || Len == 16);
+        if (Len == 8) {
+          TpmBase     = Fdt32ToCpu (*(UINT32 *)RegProp);
+          TpmBaseSize = Fdt32ToCpu (*(UINT32 *)((UINT8 *)RegProp + 4));
+        } else if (Len == 16) {
+          TpmBase     = Fdt64ToCpu (ReadUnaligned64 ((UINT64 *)RegProp));
+          TpmBaseSize = Fdt64ToCpu (ReadUnaligned64 ((UINT64 *)((UINT8 *)RegProp + 8)));
+        }
+
+        if (Depth > 1) {
+          //
+          // QEMU/mach-virt may put the TPM on the platform bus, in which case
+          // we have to take its 'ranges' property into account to translate the
+          // MMIO address. This consists of a <child base, parent base, size>
+          // tuple, where the child base and the size use the same number of
+          // cells as the 'reg' property above, and the parent base uses 2 cells
+          //
+          RangesProp = FdtGetProp (FdtBase, Parent, "ranges", &RangesLen);
+          ASSERT (RangesProp != NULL);
+
+          //
+          // a plain 'ranges' attribute without a value implies a 1:1 mapping
+          //
+          if (RangesLen != 0) {
+            //
+            // assume a single translated range with 2 cells for the parent base
+            //
+            if (RangesLen != Len + 2 * sizeof (UINT32)) {
+              DEBUG ((
+                DEBUG_WARN,
+                "%a: 'ranges' property has unexpected size %d\n",
+                __func__,
+                RangesLen
+                ));
+              break;
+            }
+
+            if (Len == 8) {
+              TpmBase -= Fdt32ToCpu (RangesProp[0]);
+            } else {
+              TpmBase -= Fdt64ToCpu (ReadUnaligned64 ((UINT64 *)RangesProp));
+            }
+
+            //
+            // advance RangesProp to the parent bus address
+            //
+            RangesProp = (UINT32 *)((UINT8 *)RangesProp + Len / 2);
+            TpmBase   += Fdt64ToCpu (ReadUnaligned64 ((UINT64 *)RangesProp));
+          }
+        }
+
+        break;
+      }
+    }
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: TpmBase=0x%lx TpmBaseSize=0x%lx\n",
+    __func__,
+    TpmBase,
+    TpmBaseSize
+    ));
+
+  if (TpmBaseSize > 0) {
+    BuildResourceDescriptorHob (
+      EFI_RESOURCE_MEMORY_MAPPED_IO,
+      EFI_RESOURCE_ATTRIBUTE_PRESENT     |
+      EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+      EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+      EFI_RESOURCE_ATTRIBUTE_TESTED,
+      TpmBase,
+      ALIGN_VALUE (TpmBaseSize, EFI_PAGE_SIZE)
+      );
+
+    ASSERT_EFI_ERROR ((EFI_STATUS)PcdSet64S (PcdTpmBaseAddress, TpmBase));
+    PeiServicesInstallPpi (&mTpm2DiscoveredPpi);
+  }
+}
+
+/**
   Perform Platform PEI initialization.
 
   @param  FileHandle      Handle of the file being invoked.
@@ -351,7 +536,7 @@ InitializePlatform (
   MiscInitialization ();
 
   AddFdtHob ();
-
+  SetupTPMResources ((VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress));
   //
   // Initialization MMU
   //

--- a/OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
@@ -30,9 +30,11 @@
   MdeModulePkg/MdeModulePkg.dec
   OvmfPkg/OvmfPkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
+  SecurityPkg/SecurityPkg.dec
 
 [Ppis]
   gEfiPeiMasterBootModePpiGuid
+  gOvmfTpmDiscoveredPpiGuid
 
 [Guids]
   gEfiMemoryTypeInformationGuid
@@ -58,6 +60,7 @@
   gUefiOvmfPkgTokenSpaceGuid.PcdDeviceTreeInitialBaseAddress
   gUefiOvmfPkgTokenSpaceGuid.PcdDeviceTreeAllocationPadding
   gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress
 
 [FixedPcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdOvmfSecPeiTempRamBase

--- a/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
+++ b/OvmfPkg/Tcg/Tcg2Config/Tcg2ConfigPei.inf
@@ -50,8 +50,5 @@
 [Depex.IA32, Depex.X64]
   gOvmfTpmMmioAccessiblePpiGuid
 
-[Depex.AARCH64]
-  gOvmfTpmDiscoveredPpiGuid
-
-[Depex.RISCV64]
+[Depex.AARCH64, Depex.RISCV64, Depex.LOONGARCH64]
   gOvmfTpmDiscoveredPpiGuid


### PR DESCRIPTION
# Description

    Add TPM 2.0 support to the LoongArchVirtQemu platform, following the
    same pattern used by ARM and RISC-V virt platforms:
    
    - LoongArchVirtQemu.dsc: Add library class mappings, PCDs, and component
      entries for Tcg2Pei, Tcg2ConfigPei, Tcg2PlatformPei, Tcg2Dxe, and
      Tcg2CongigDxe when TPM2_ENABLE is TRUE.
    - LoongArchVirtQemu.fdf: Include TPM PEIM and DXE drivers in firmware
      volumes.
    - PlatformPei/Platform.c: Add SetupTPMResources() to parse the QEMU
      FDT for a "tcg,tpm-tis-mmio" node, translate the MMIO address via the
      platform-bus ranges property,create an MMIO resource HOB, set
      PcdTpmBaseAddress, and install gOvmfTpmDiscoveredPpi to trigger
      Tcg2ConfigPei dispatch.
    - PlatformPei/PlatformPei.inf: Add SecurityPkg.dec dependency and
      required PPI/PCD references.
    - Tcg2Config/Tcg2ConfigPei.inf: Add LOONGARCH64 depex for
      gOvmfTpmDiscoveredPpi.


## How This Was Tested

build -b DEBUG -t GCC -a LOONGARCH64 -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc -D TPM2_ENABLE=TRUE -D TPM2_CONFIG_ENABLE=TURE

swtpm socket --tpm2 --tpmstate dir=/home/zyf/tpm-vm/swtpm-state --ctrl type=unixio,path=/home/zyf/tpm-vm/swtpm.sock --log level=20 --daemon 2>&1; sleep 1;/usr/bin/qemu-system-loongarch64 -M virt -cpu max -m 4G -smp 4 -bios /home/zyf/edk2/Build/LoongArchVirtQemu/DEBUG_GCC/FV/QEMU_EFI.fd -chardev socket,id=chrtpm,path=/home/zyf/tpm-vm/swtpm.sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis-device,tpmdev=tpm0 -drive if=virtio,file=/home/vmdata/zyf-test.qcow2,format=qcow2 --serial mon:stdio

## Integration Instructions
N/A 
