### PR TITLE
ShellPkg: Add null pointer checks before dereference

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/Compress.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/Compress.c
@@ -184,13 +184,40 @@ AllocateMemory (
   VOID
   )
 {
-  mText       = AllocateZeroPool (WNDSIZ * 2 + MAXMATCH);
-  mLevel      = AllocateZeroPool ((WNDSIZ + UINT8_MAX + 1) * sizeof (*mLevel));
+  mText = AllocateZeroPool (WNDSIZ * 2 + MAXMATCH);
+  if (mText == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mLevel = AllocateZeroPool ((WNDSIZ + UINT8_MAX + 1) * sizeof (*mLevel));
+  if (mLevel == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   mChildCount = AllocateZeroPool ((WNDSIZ + UINT8_MAX + 1) * sizeof (*mChildCount));
-  mPosition   = AllocateZeroPool ((WNDSIZ + UINT8_MAX + 1) * sizeof (*mPosition));
-  mParent     = AllocateZeroPool (WNDSIZ * 2 * sizeof (*mParent));
-  mPrev       = AllocateZeroPool (WNDSIZ * 2 * sizeof (*mPrev));
-  mNext       = AllocateZeroPool ((MAX_HASH_VAL + 1) * sizeof (*mNext));
+  if (mChildCount == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mPosition = AllocateZeroPool ((WNDSIZ + UINT8_MAX + 1) * sizeof (*mPosition));
+  if (mPosition == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mParent = AllocateZeroPool (WNDSIZ * 2 * sizeof (*mParent));
+  if (mParent == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mPrev = AllocateZeroPool (WNDSIZ * 2 * sizeof (*mPrev));
+  if (mPrev == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mNext = AllocateZeroPool ((MAX_HASH_VAL + 1) * sizeof (*mNext));
+  if (mNext == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   mBufSiz = BLKSIZ;
   mBuf    = AllocateZeroPool (mBufSiz);


### PR DESCRIPTION
# Description

In AllocateMemory(), several pointers are used without prior null checks. This may lead to unexpected behavior or system crashes if any of these pointers are NULL.

Add explicit null checks for these pointers to ensure safe access and prevent potential null pointer dereferences.

## How This Was Tested



## Integration Instructions

N/A
