### PR TITLE
OvmfPkg/LoongArchVirt: Fix ResetSystemLibConstructor signature and header

### DIFF
--- a/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
+++ b/OvmfPkg/LoongArchVirt/Library/ResetSystemAcpiLib/BaseResetSystemAcpiGed.c
@@ -10,6 +10,7 @@
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/QemuFwCfgLib.h>
+#include <IndustryStandard/Acpi.h>
 #include "ResetSystemAcpiGed.h"
 
 /**
@@ -130,10 +131,9 @@ Done:
   @retval EFI_NOT_FOUND   Failed to initialize mPowerManager.
 **/
 EFI_STATUS
-EFI_API
+EFIAPI
 ResetSystemLibConstructor (
-  IN EFI_HANDLE        ImageHandle,
-  IN EFI_SYSTEM_TABLE  *SystemTable
+  VOID
   )
 {
   EFI_STATUS  Status;


### PR DESCRIPTION
# Description

The ResetSystemLibConstructor was incorrectly declared with EFI_API and
    a UEFI driver entry point signature (ImageHandle, SystemTable), but it
    is actually a library constructor that should use EFIAPI and take no
    arguments (VOID) as per EDK2 library constructor conventions.
    
    This mismatch caused compilation errors when enabling TPM2 support
    for LoongArchVirt.
    
    - Add missing <IndustryStandard/Acpi.h> include
    - Replace EFI_API with EFIAPI
    - Change constructor signature from
      (IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
      to (VOID)

## How This Was Tested
After cherry-pick commit https://github.com/tianocore/edk2/pull/12746/changes/8061ca159500de1503af8a785e9a5fbda80dad67 , use following command to compile
build -b DEBUG -t GCC -a LOONGARCH64 -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc -D TPM2_ENABLE=TRUE -D TPM2_CONFIG_ENABLE=TURE

## Integration Instructions

N/A
