### PR TITLE
ShellPkg: Fix smbiosview Type 26 location/status decode

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -3246,33 +3246,6 @@ TABLE_ITEM  VPLocationTable[] = {
   },
   {
     0x03,
-    L" OK "
-  },
-  {
-    0x04,
-    L" Non-critical "
-  },
-  {
-    0x05,
-    L" Critical "
-  },
-  {
-    0x06,
-    L" Non-recoverable "
-  },
-};
-
-TABLE_ITEM  VPStatusTable[] = {
-  {
-    0x01,
-    L" Other "
-  },
-  {
-    0x02,
-    L" Unknown "
-  },
-  {
-    0x03,
     L" Processor "
   },
   {
@@ -3306,6 +3279,33 @@ TABLE_ITEM  VPStatusTable[] = {
   {
     0x0B,
     L" Add-in Card "
+  },
+};
+
+TABLE_ITEM  VPStatusTable[] = {
+  {
+    0x01,
+    L" Other "
+  },
+  {
+    0x02,
+    L" Unknown "
+  },
+  {
+    0x03,
+    L" OK "
+  },
+  {
+    0x04,
+    L" Non-critical "
+  },
+  {
+    0x05,
+    L" Critical "
+  },
+  {
+    0x06,
+    L" Non-recoverable "
   },
 };
 

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -3455,6 +3455,22 @@ TABLE_ITEM  TemperatureProbeLocTable[] = {
     0x0B,
     L" Add-in Card "
   },
+  {
+    0x0C,
+    L" Front Panel Board "
+  },
+  {
+    0x0D,
+    L" Back Panel Board "
+  },
+  {
+    0x0E,
+    L" Power System Board "
+  },
+  {
+    0x0F,
+    L" Drive Back Plane "
+  },
 };
 
 TABLE_ITEM  ECPStatusTable[] = {


### PR DESCRIPTION
## Description

Fix the SMBIOS shell viewer decode for Type 26 Voltage Probe
LocationAndStatus and add missing Type 28 Temperature Probe location
decode values.

smbiosview extracts Type 26 location from bits 4:0 and status from
bits 7:5, matching the SMBIOS structure definition. However, the lookup
tables used for those decoded values were swapped: VPLocationTable
contained status strings and VPStatusTable contained location strings.

As a result, a valid Type 26 record could be displayed as:

  Voltage Probe - Location: OK
  Voltage Probe - Status: Processor

Swap the table contents so the decoded output correctly reports:

  Voltage Probe - Location: Processor
  Voltage Probe - Status: OK

Also extend the Type 28 Temperature Probe location table with the SMBIOS
defined values 0x0C through 0x0F:

  0x0C Front Panel Board
  0x0D Back Panel Board
  0x0E Power System Board
  0x0F Drive Back Plane