### PR TITLE
OvmfPkg/PlatformInitLib: restore below-4G low memory detection for TDVF

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -164,6 +164,10 @@ PlatformGetFirstNonAddressCB (
   there are multiple memory blocks below 4G though, because SVSM caves out a
   chunk of memory for itself.  Only the first of these blocks is considered
   low memory.
+
+  Multiple blocks without gap inbetween are grouped together.
+  This is required for TDX which has two low memory descriptors
+  (accepted and unaccepted).
 **/
 STATIC
 VOID
@@ -176,12 +180,12 @@ PlatformGetLowMemoryCB (
     return;
   }
 
-  if (E820Entry->BaseAddr != 0) {
+  if (E820Entry->BaseAddr != PlatformInfoHob->LowMemory) {
     return;
   }
 
-  DEBUG ((DEBUG_INFO, "%a: LowMemory=0x%Lx\n", __func__, E820Entry->Length));
-  PlatformInfoHob->LowMemory = (UINT32)E820Entry->Length;
+  PlatformInfoHob->LowMemory += (UINT32)E820Entry->Length;
+  DEBUG ((DEBUG_INFO, "%a: LowMemory=0x%Lx\n", __func__, PlatformInfoHob->LowMemory));
 }
 
 /**


### PR DESCRIPTION
# Description

Fix TDVF regression introduced by 0a0919607c.
Commit 0a0919607c ("OvmfPkg/PlatformInitLib: redefine low memory") narrowed PlatformGetLowMemoryCB() to consider only the first below-4G memory block whose base address is zero. The change was intended to fix SVSM guests, where SVSM caves a chunk out of below-4G RAM and OVMF must not stray into that hole.

TDVF, however, reports its below-4G RAM through the TdHob as two adjacent resource descriptors:

  [0, 0x800000)              EFI_RESOURCE_SYSTEM_MEMORY   (pre-accepted)
  [0x800000, ~4G)            EFI_RESOURCE_MEMORY_UNACCEPTED

PlatformScanE820Tdx() surfaces both as EfiAcpiAddressRangeMemory E820 entries.  After 0a0919607c only the first, tiny 8 MiB block is picked up, so PlatformInfoHob->LowMemory becomes 0x800000.  In OvmfPkg/PlatformPei/MemDetect.c PublishPeiMemory() this drives:

  LowerMemorySize = 0x00800000            // LowMemory
  PeiMemoryCap    = 0x04F82000            // ~81 MiB
  MemoryBase      = LowerMemorySize - PeiMemoryCap   // UINT32 underflow
                  = 0xFB87E000

Permanent PEI memory is then published at 0xFB87E000, which is not backed by RAM.  TemporaryRamMigration()'s first CopyMem into that phantom range (observed as 0xFB898000 in the failing log) faults, tearing down the TD.

SEC's TdxHelperProcessTdHob() -> AcceptMemory() already accepts the entire below-4G unaccepted range before PEI runs, so under TDVF all below-4G RAM is usable and the pre-0a0919607c "top of highest below-4G RAM block" rule is correct.  Gate on CcProbe() == CcGuestTypeIntelTdx so SVSM keeps the first-block-only semantics that 0a0919607c introduced.

PlatformScanE820Tdx() also surfaces above-4G RAM (as unaccepted memory) via the same callback; filter those out explicitly before extending LowMemory, and clamp the candidate to MAX_UINT32 so the UINT32 store is always safe.

- [ ] Breaking change?
  - No
- [ ] Impacts security?
  - No
- [ ] Includes tests?
  - No

## How This Was Tested
Tested TDVF with TDX enabled, 2 GB / 4 GB / 8 GB Guest RAM sizes on qemu v10.1.50, CentOS 10 with 6.18 kernel.

## Integration Instructions
N/A