### PR TITLE
MdeModulePkg/ScsiDiskDxe: Don't fail media detection on FUA query error

### DIFF
--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -2541,10 +2541,9 @@ ScsiDiskDetectMedia (
   //
   // Get FUA Mode
   //
-  for (Retry = 0; Retry < MaxRetry; Retry++) {
-    if (ScsiDiskDevice->DeviceType == EFI_SCSI_TYPE_DISK) {
-      Status = ScsiDiskFuaMode (ScsiDiskDevice);
-      if (!EFI_ERROR (Status)) {
+  if (ScsiDiskDevice->DeviceType == EFI_SCSI_TYPE_DISK) {
+    for (Retry = 0; Retry < MaxRetry; Retry++) {
+      if (!EFI_ERROR (ScsiDiskFuaMode (ScsiDiskDevice))) {
         break;
       }
     }


### PR DESCRIPTION
# Description

Commit ee58614bbb ("MdeModulePkg/ScsiDiskDxe: Check Write Caching and FUA support") added a best-effort FUA-support query to ScsiDiskDetectMedia(). It issues a MODE SENSE(10) for the Caching mode page via ScsiDiskFuaMode() and assigns the result to the function's shared Status variable.

When the device rejects that command, Status is left as EFI_DEVICE_ERROR and falls through to the function's return, even though the media was already detected successfully (capacity read, media present). Callers treat this as fatal:
ScsiDiskDriverBindingStart() skips installing Block I/O, and ScsiDiskReadBlocks()/WriteBlocks() return EFI_DEVICE_ERROR. For non-fixed devices DetectMedia() re-runs on every access, so the disk is never usable.

This is observed on UFS: the LUN answers the MODE SENSE with a Target Failure ("UfsExecScsiCmds() fails with Target Failure"), which previously worked (edk2-stable202602) now breaks UFS drive detection (edk2-stable202605).

The FUA query is only used to refine ScsiDiskDevice->FuaMode, which already defaults to TRUE (the prior always-set-FUA behavior). Its failure must not affect media detection, so stop assigning its result to Status and hoist the device-type check out of the retry loop.

Fixes: ee58614bbb ("MdeModulePkg/ScsiDiskDxe: Check Write Caching and FUA support")

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

TEST=build/boot google/yaviks Chromebook with UFS, drive is detected and bootable.

## Integration Instructions

N/A
