### PR TITLE
FatPkg: Fix FAT32 mount on small 4K-sector ESP partitions

### DIFF
--- a/FatPkg/EnhancedFatDxe/Init.c
+++ b/FatPkg/EnhancedFatDxe/Init.c
@@ -390,7 +390,12 @@ FatOpenDevice (
     Volume->FatEntrySize = sizeof (UINT16);
     DirtyMask            = FAT16_DIRTY_MASK;
   } else {
-    if (Volume->MaxCluster < FAT_MAX_FAT16_CLUSTER) {
+    //
+    // FAT32 layout comes from the BPB (32-bit FAT).  Small volumes such as a
+    // ~200 MiB ESP with 4 KB sectors can be valid FAT32 while MaxCluster is
+    // still below FAT_MAX_FAT16_CLUSTER; mkfs.fat and Linux use this layout.
+    //
+    if (Volume->MaxCluster < FAT_MAX_FAT12_CLUSTER) {
       return EFI_VOLUME_CORRUPTED;
     }
 


### PR DESCRIPTION
# Description

Trust the FAT32 BPB instead of requiring MaxCluster >= 65525, which rejected valid UFS EFS volumes and blocked internal boot.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?
 
## How This Was Tested

TEST=build/boot google/joxer with 200MB EFS (51024 clusters)

## Integration Instructions

N/A