### PR TITLE
MdeModulePkg/UfsPassThruDxe: Fix v2 protocol backward compatibility

### DIFF
--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -1866,6 +1866,7 @@ UfsEnableHostController (
   }
 
   if ((mUfsHcPlatform == NULL) ||
+      (mUfsHcPlatform->Version < 3) ||
       ((mUfsHcPlatform->Version >= 3) && !mUfsHcPlatform->SkipHceReenable))
   {
     //


### PR DESCRIPTION
# Description

Commit b58ce4c226 broke backward compatibility with v2 platform protocols by incorrectly skipping HCE re-enable for v2 implementations.

When used with a UfsPlatform.efi binary that was compiled against an older stable tag, (where EDKII_UFS_HC_PLATFORM_PROTOCOL_VERSION is defined as 2), the code attempted to read the v3-only SkipHceReenable/SkipLinkStartup fields beyond the v2 struct boundary, reading garbage memory and potentially skipping initialization.

Add explicit version check to ensure v2 protocols follow normal initialization path, preventing out-of-bounds struct access.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?
 
## How This Was Tested

TEST=build/boot google/yaviks with UFS storage

## Integration Instructions

N/A