### PR TITLE
Smbios type1 system info

### DIFF
--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -53,6 +53,7 @@
 
   # SMBIOS Generators (Common)
   DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Lib.inf
+  DynamicTablesPkg/Library/Smbios/SmbiosType1Lib/SmbiosType1Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf
@@ -171,6 +172,7 @@
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtPcieLib/SsdtPcieLib.inf
 
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType0Lib/SmbiosType0Lib.inf
+      NULL|DynamicTablesPkg/Library/Smbios/SmbiosType1Lib/SmbiosType1Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType16Lib/SmbiosType16Lib.inf

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -93,6 +93,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjMemoryChannelInfo,              ///< 64 - Memory Channel Info
   EArchCommonObjMemoryChannelDevice,            ///< 65 - Memory Channel Device Info
   EArchCommonObjProcessorSpecificBlockInfo,     ///< 66 - Processor specific data Info
+  EArchCommonObjSystemInfo,                     ///< 67 - System Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -1726,5 +1727,32 @@ typedef struct CmArchCommonProcessorSpecificBlockInfo {
   /// Token array for architecture specific Processor Data.
   CM_OBJECT_TOKEN                       ArchProcessorSpecificDataToken;
 } CM_ARCH_COMMON_PROCESSOR_SPECIFIC_BLOCK_INFO;
+
+/** A structure that describes System Information.
+
+  SMBIOS Specification v3.9.0 Type 1
+
+  ID: EArchCommonObjSystemInfo
+**/
+typedef struct CmArchCommonSystemInfo {
+  /// CM Object Token uniquely identifying this System Information entry.
+  CM_OBJECT_TOKEN    SystemInfoToken;
+  /// Manufacturer of the system.
+  CHAR8              Manufacturer[SMBIOS_MAX_STRING_SIZE];
+  /// Product name of the system.
+  CHAR8              ProductName[SMBIOS_MAX_STRING_SIZE];
+  /// Version of the system.
+  CHAR8              Version[SMBIOS_MAX_STRING_SIZE];
+  /// Serial number of the system.
+  CHAR8              SerialNum[SMBIOS_MAX_STRING_SIZE];
+  /// Universal unique ID of the system.
+  GUID               Uuid;
+  /// Identifies the event that caused the system to power up.
+  UINT8              WakeUpType;
+  /// SKU number of the system.
+  CHAR8              SkuNum[SMBIOS_MAX_STRING_SIZE];
+  /// Family that the system belongs to.
+  CHAR8              Family[SMBIOS_MAX_STRING_SIZE];
+} CM_ARCH_COMMON_SYSTEM_INFO;
 
 #pragma pack()

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -44,6 +44,15 @@ PrintChars (
 STATIC
 VOID
 EFIAPI
+PrintGuid (
+  CONST CHAR8  *Format,
+  UINT8        *Ptr,
+  UINT32       Length
+  );
+
+STATIC
+VOID
+EFIAPI
 HexDump (
   CONST CHAR8  *Format,
   UINT8        *Ptr,
@@ -1320,76 +1329,92 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonSystemResetInfoParser[] = {
   { "Timeout",          sizeof (UINT16),          "0x%x", NULL },
 };
 
+/** A parser for EArchCommonObjSystemInfo.
+*/
+STATIC CONST CM_OBJ_PARSER  CmArchCommonSystemInfoParser[] = {
+  { "SystemInfoToken", sizeof (CM_OBJECT_TOKEN), "0x%p", NULL        },
+  { "Manufacturer",    SMBIOS_MAX_STRING_SIZE,   NULL,   PrintString },
+  { "ProductName",     SMBIOS_MAX_STRING_SIZE,   NULL,   PrintString },
+  { "Version",         SMBIOS_MAX_STRING_SIZE,   NULL,   PrintString },
+  { "SerialNum",       SMBIOS_MAX_STRING_SIZE,   NULL,   PrintString },
+  { "Uuid",            sizeof (GUID),            NULL,   PrintGuid   },
+  { "WakeUpType",      sizeof (UINT8),           "0x%x", NULL        },
+  { "SkuNum",          SMBIOS_MAX_STRING_SIZE,   NULL,   PrintString },
+  { "Family",          SMBIOS_MAX_STRING_SIZE,   NULL,   PrintString },
+};
+
 /** A parser for Arch Common namespace objects.
 */
 STATIC CONST CM_OBJ_PARSER_ARRAY  ArchCommonNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjReserved),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPowerManagementProfileInfo,   CmArchCommonPowerManagementProfileInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjSerialPortInfo,               CmArchCommonSerialPortInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjConsolePortInfo,              CmArchCommonSerialPortInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjSerialDebugPortInfo,          CmArchCommonSerialPortInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjHypervisorVendorIdentity,     CmArchCommonHypervisorVendorIdentityParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjFixedFeatureFlags,            CmArchCommonFixedFeatureFlagsParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjCmRef,                        CmArchCommonObjRefParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPciConfigSpaceInfo,           CmArchCommonPciConfigSpaceInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPciAddressMapInfo,            CmArchCommonPciAddressMapInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPciInterruptMapInfo,          CmArchCommonPciInterruptMapInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryAffinityInfo,           CmArchCommonMemoryAffinityInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjDeviceHandleAcpi,             CmArchCommonDeviceHandleAcpiParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjDeviceHandlePci,              CmArchCommonDeviceHandlePciParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjGenericInitiatorAffinityInfo, CmArchCommonGenericInitiatorAffinityInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjLpiInfo,                      CmArchCommonLpiInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjProcHierarchyInfo,            CmArchCommonProcHierarchyInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjCacheInfo,                    CmArchCommonCacheInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjCpcInfo,                      CmArchCommonCpcInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType0Info,         CmArchCommonPccSubspaceType0InfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType1Info,         CmArchCommonPccSubspaceType1InfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType2Info,         CmArchCommonPccSubspaceType2InfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType3Info,         CmArchCommonPccSubspaceType34InfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType4Info,         CmArchCommonPccSubspaceType34InfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType5Info,         CmArchCommonPccSubspaceType5InfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPsdInfo,                      CmArchCommonPsdInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjTpm2InterfaceInfo,            CmArchCommonTpm2InterfaceInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjSpmiInterfaceInfo,            CmArchCommonSpmiInterfaceInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjSpmiInterruptDeviceInfo,      CmArchCommonSpmiInterruptDeviceInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjCstInfo,                      CmArchCommonCstInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjCsdInfo,                      CmArchCommonCsdInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPctInfo,                      CmArchCommonPctInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPssInfo,                      CmArchCommonPssInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPpcInfo,                      CmArchCommonPpcInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjStaInfo,                      CmArchCommonStaInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryRangeDescriptor,        CmArchCommonObjMemoryRangeDescriptor),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjGenericDbg2DeviceInfo,        CmArchCommonObjDbg2DeviceInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjCxlHostBridgeInfo,            CmArchCommonObjCxlHostBridgeInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjCxlFixedMemoryWindowInfo,     CmArchCommonObjCxlFixedMemoryWindowInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjProximityDomainInfo,          CmArchCommonProximityDomainInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjProximityDomainRelationInfo,  CmArchCommonProximityDomainRelationInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjSystemLocalityInfo,           CmArchCommonSystemLocalityInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryProximityDomainAttrInfo,CmArchCommonMemoryProximityDomainAttrInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryLatBwInfo,              CmArchCommonMemoryLatBwInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryCacheInfo,              CmArchCommonMemoryCacheInfo),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjSpcrInfo,                     CmArchCommonObjSpcrInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjTpm2DeviceInfo,               CmArchCommonObjTpm2DeviceInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMcfgPciConfigSpaceInfo,       CmArchCommonPciConfigSpaceInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPciRootPortInfo,              CmArchCommonObjPciRootPortInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourcePciRootPortInfo,     CmArchCommonObjErrSourcePciRootPortInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourcePciDeviceInfo,       CmArchCommonObjErrSourcePciDeviceInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourcePciBridgeInfo,       CmArchCommonObjErrSourcePciBridgeInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwInfo,       CmArchCommonObjErrSourceGenericHwInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwVer2Info,   CmArchCommonObjErrSourceGenericHwVer2InfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjEinjInstructionsInfo,         CmArchCommonObjEinjInstructionsInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPlatformFwInfo,               CmArchCommonPlatformFwInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjPhysicalMemoryArray,          CmArchCommonPhysicalMemoryArrayParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryDeviceInfo,             CmArchCommonMemoryDeviceInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryArrayMappedAddress,     CmArchCommonMemoryArrayMappedAddressParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjCoolingDeviceInfo,            CmArchCommonCoolingDeviceInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjTemperatureProbeInfo,         CmArchCommonTemperatureProbeInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjVoltageProbeInfo,             CmArchCommonVoltageProbeInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjElectricalCurrentProbeInfo,   CmArchCommonElectricalCurrentProbeInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjSystemResetInfo,              CmArchCommonSystemResetInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryDeviceMappedAddress,    CmArchCommonMemoryDeviceMappedAddressParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryChannelInfo,            CmArchCommonMemoryChannelInfoParser),
-  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryChannelDevice,          CmArchCommonMemoryChannelDeviceParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPowerManagementProfileInfo,          CmArchCommonPowerManagementProfileInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSerialPortInfo,                      CmArchCommonSerialPortInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjConsolePortInfo,                     CmArchCommonSerialPortInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSerialDebugPortInfo,                 CmArchCommonSerialPortInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjHypervisorVendorIdentity,            CmArchCommonHypervisorVendorIdentityParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjFixedFeatureFlags,                   CmArchCommonFixedFeatureFlagsParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCmRef,                               CmArchCommonObjRefParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPciConfigSpaceInfo,                  CmArchCommonPciConfigSpaceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPciAddressMapInfo,                   CmArchCommonPciAddressMapInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPciInterruptMapInfo,                 CmArchCommonPciInterruptMapInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryAffinityInfo,                  CmArchCommonMemoryAffinityInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjDeviceHandleAcpi,                    CmArchCommonDeviceHandleAcpiParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjDeviceHandlePci,                     CmArchCommonDeviceHandlePciParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjGenericInitiatorAffinityInfo,        CmArchCommonGenericInitiatorAffinityInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjLpiInfo,                             CmArchCommonLpiInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjProcHierarchyInfo,                   CmArchCommonProcHierarchyInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCacheInfo,                           CmArchCommonCacheInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCpcInfo,                             CmArchCommonCpcInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType0Info,                CmArchCommonPccSubspaceType0InfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType1Info,                CmArchCommonPccSubspaceType1InfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType2Info,                CmArchCommonPccSubspaceType2InfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType3Info,                CmArchCommonPccSubspaceType34InfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType4Info,                CmArchCommonPccSubspaceType34InfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPccSubspaceType5Info,                CmArchCommonPccSubspaceType5InfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPsdInfo,                             CmArchCommonPsdInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjTpm2InterfaceInfo,                   CmArchCommonTpm2InterfaceInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSpmiInterfaceInfo,                   CmArchCommonSpmiInterfaceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSpmiInterruptDeviceInfo,             CmArchCommonSpmiInterruptDeviceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCstInfo,                             CmArchCommonCstInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCsdInfo,                             CmArchCommonCsdInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPctInfo,                             CmArchCommonPctInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPssInfo,                             CmArchCommonPssInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPpcInfo,                             CmArchCommonPpcInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjStaInfo,                             CmArchCommonStaInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryRangeDescriptor,               CmArchCommonObjMemoryRangeDescriptor),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjGenericDbg2DeviceInfo,               CmArchCommonObjDbg2DeviceInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCxlHostBridgeInfo,                   CmArchCommonObjCxlHostBridgeInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCxlFixedMemoryWindowInfo,            CmArchCommonObjCxlFixedMemoryWindowInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjProximityDomainInfo,                 CmArchCommonProximityDomainInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjProximityDomainRelationInfo,         CmArchCommonProximityDomainRelationInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSystemLocalityInfo,                  CmArchCommonSystemLocalityInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryProximityDomainAttrInfo,       CmArchCommonMemoryProximityDomainAttrInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryLatBwInfo,                     CmArchCommonMemoryLatBwInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryCacheInfo,                     CmArchCommonMemoryCacheInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSpcrInfo,                            CmArchCommonObjSpcrInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjTpm2DeviceInfo,                      CmArchCommonObjTpm2DeviceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMcfgPciConfigSpaceInfo,              CmArchCommonPciConfigSpaceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPciRootPortInfo,                     CmArchCommonObjPciRootPortInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourcePciRootPortInfo,            CmArchCommonObjErrSourcePciRootPortInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourcePciDeviceInfo,              CmArchCommonObjErrSourcePciDeviceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourcePciBridgeInfo,              CmArchCommonObjErrSourcePciBridgeInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwInfo,              CmArchCommonObjErrSourceGenericHwInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjErrSourceGenericHwVer2Info,          CmArchCommonObjErrSourceGenericHwVer2InfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjEinjInstructionsInfo,                CmArchCommonObjEinjInstructionsInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPlatformFwInfo,                      CmArchCommonPlatformFwInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjPhysicalMemoryArray,                 CmArchCommonPhysicalMemoryArrayParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryDeviceInfo,                    CmArchCommonMemoryDeviceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryArrayMappedAddress,            CmArchCommonMemoryArrayMappedAddressParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjCoolingDeviceInfo,                   CmArchCommonCoolingDeviceInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjTemperatureProbeInfo,                CmArchCommonTemperatureProbeInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjVoltageProbeInfo,                    CmArchCommonVoltageProbeInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjElectricalCurrentProbeInfo,          CmArchCommonElectricalCurrentProbeInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSystemResetInfo,                     CmArchCommonSystemResetInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryDeviceMappedAddress,           CmArchCommonMemoryDeviceMappedAddressParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryChannelInfo,                   CmArchCommonMemoryChannelInfoParser),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjMemoryChannelDevice,                 CmArchCommonMemoryChannelDeviceParser),
+  CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjProcessorSpecificBlockInfo),
+  CM_PARSER_ADD_OBJECT (EArchCommonObjSystemInfo,                          CmArchCommonSystemInfoParser),
   CM_PARSER_ADD_OBJECT_RESERVED (EArchCommonObjMax)
 };
 
@@ -1784,6 +1809,29 @@ PrintString (
   }
 
   DEBUG ((DEBUG_INFO, "%a", Ptr));
+}
+
+/** Print GUID data.
+
+  @param [in]  Format  Format to print the Ptr.
+  @param [in]  Ptr     Pointer to the GUID.
+  @param [in]  Length  Length of the field.
+**/
+STATIC
+VOID
+EFIAPI
+PrintGuid (
+  IN CONST CHAR8  *Format,
+  IN UINT8        *Ptr,
+  IN UINT32       Length
+  )
+{
+  if ((Ptr == NULL) || (Length != sizeof (GUID))) {
+    ASSERT (0);
+    return;
+  }
+
+  DEBUG ((DEBUG_INFO, "%g", (GUID *)Ptr));
 }
 
 /** Print string from pointer.

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType1Lib/SmbiosType1Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType1Lib/SmbiosType1Generator.c
@@ -1,0 +1,428 @@
+/** @file
+  SMBIOS Type 1 Table Generator.
+
+  Copyright (c) 2024 - 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2020 - 2021, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/SmbiosStringTableLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include <Protocol/Smbios.h>
+#include <IndustryStandard/SmBios.h>
+
+#define SMBIOS_TYPE1_MAX_STRINGS  (6)
+
+#define ALL_ONES_GUID  \
+  { 0xFFFFFFFF, 0xFFFF, 0xFFFF, { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } }
+
+/** This macro expands to a function that retrieves the System
+    information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjSystemInfo,
+  CM_ARCH_COMMON_SYSTEM_INFO
+  )
+
+/**
+  Validate an SMBIOS Type 1 Wake-up Type field value.
+
+  @param [in]  WakeUpType  Wake-up Type value provided by the Configuration
+                           Manager.
+
+  @retval EFI_SUCCESS            The Wake-up Type is valid.
+  @retval EFI_INVALID_PARAMETER  The Wake-up Type is invalid.
+**/
+STATIC
+EFI_STATUS
+CheckWakeUpType (
+  IN  UINT8  WakeUpType
+  )
+{
+  if ((WakeUpType == SystemWakeupTypeReserved) ||
+      (WakeUpType == SystemWakeupTypeUnknown) ||
+      (WakeUpType > SystemWakeupTypeAcPowerRestored))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Invalid WakeUpType 0x%x\n",
+      __func__,
+      WakeUpType
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Validate SMBIOS Type 1 System Information.
+
+  Validation follows SMBIOS Specification v3.9.0, Annex A,
+  Section 4.2 (informative).
+
+  @param [in]  SystemInfo  System Information provided by the Configuration
+                           Manager.
+
+  @retval EFI_SUCCESS            The System Information is valid.
+  @retval EFI_INVALID_PARAMETER  The System Information is invalid.
+**/
+STATIC
+EFI_STATUS
+ValidateSystemInfo (
+  IN CONST CM_ARCH_COMMON_SYSTEM_INFO  *SystemInfo
+  )
+{
+  CONST GUID  AllOnesGuid = ALL_ONES_GUID;
+
+  if ((SystemInfo->Manufacturer[0] == '\0') ||
+      (SystemInfo->ProductName[0] == '\0'))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Manufacturer and ProductName must be non-empty\n",
+      __func__
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (IsZeroGuid (&SystemInfo->Uuid) || CompareGuid (&SystemInfo->Uuid, &AllOnesGuid)) {
+    DEBUG ((DEBUG_ERROR, "%a: UUID must not be all-zero or all-ones\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return CheckWakeUpType (SystemInfo->WakeUpType);
+}
+
+/**
+  Free any resources allocated when installing SMBIOS Type 1 table.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [in]  Table                Pointer to the SMBIOS table.
+
+  @retval EFI_SUCCESS  Table freed successfully.
+**/
+STATIC
+EFI_STATUS
+FreeSmbiosType1Table (
+  IN  CONST SMBIOS_TABLE_GENERATOR                        *This,
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST  TableFactoryProtocol,
+  IN  CONST CM_STD_OBJ_SMBIOS_TABLE_INFO          *CONST  SmbiosTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN        SMBIOS_STRUCTURE                              **Table
+  )
+{
+  if (*Table != NULL) {
+    FreePool (*Table);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Construct SMBIOS Type 1 Table describing system information.
+
+  If this function allocates any resources then they must be freed
+  in the FreeSmbiosType1Table function.
+
+  @param [in]  This                 Pointer to the SMBIOS table generator.
+  @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                    Protocol interface.
+  @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+  @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                    Protocol interface.
+  @param [out] Table                Pointer to the SMBIOS table.
+  @param [out] CmObjToken           Pointer to the CM Object Token.
+
+  @retval EFI_SUCCESS            Table generated successfully.
+  @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+  @retval EFI_NOT_FOUND          Could not find information.
+  @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+**/
+STATIC
+EFI_STATUS
+BuildSmbiosType1Table (
+  IN  CONST SMBIOS_TABLE_GENERATOR                        *This,
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL  *CONST  TableFactoryProtocol,
+  IN        CM_STD_OBJ_SMBIOS_TABLE_INFO          *CONST  SmbiosTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  OUT       SMBIOS_STRUCTURE                              **Table,
+  OUT       CM_OBJECT_TOKEN                               *CmObjToken
+  )
+{
+  EFI_STATUS                  Status;
+  CM_ARCH_COMMON_SYSTEM_INFO  *SystemInfo;
+  UINT32                      SystemInfoCount;
+  UINT8                       ManufacturerRef;
+  UINT8                       ProductNameRef;
+  UINT8                       VersionRef;
+  UINT8                       SerialNumRef;
+  UINT8                       SkuNumRef;
+  UINT8                       FamilyRef;
+  CHAR8                       *OptionalStrings;
+  SMBIOS_TABLE_TYPE1          *SmbiosRecord;
+  UINTN                       SmbiosRecordSize;
+  STRING_TABLE                StrTable;
+
+  SmbiosRecord = NULL;
+
+  ASSERT (This != NULL);
+  ASSERT (SmbiosTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (CmObjToken != NULL);
+  ASSERT (SmbiosTableInfo->TableGeneratorId == This->GeneratorID);
+
+  if ((This == NULL) ||
+      (SmbiosTableInfo == NULL) ||
+      (CfgMgrProtocol == NULL) ||
+      (Table == NULL) ||
+      (CmObjToken == NULL) ||
+      (SmbiosTableInfo->TableGeneratorId != This->GeneratorID))
+  {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid Parameter\n", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Retrieve system info from CM object
+  //
+  *Table = NULL;
+  Status = GetEArchCommonObjSystemInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &SystemInfo,
+             &SystemInfoCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get System CM Object %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  if (SystemInfoCount != 1) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Expected one System Information object, got %u\n",
+      __func__,
+      SystemInfoCount
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = ValidateSystemInfo (SystemInfo);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Copy strings to SMBIOS table
+  //
+  Status = StringTableInitialize (&StrTable, SMBIOS_TYPE1_MAX_STRINGS);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to initialize string table %r\n", __func__, Status));
+    return Status;
+  }
+
+  ManufacturerRef = 0;
+  ProductNameRef  = 0;
+  VersionRef      = 0;
+  SerialNumRef    = 0;
+  SkuNumRef       = 0;
+  FamilyRef       = 0;
+
+  if (SystemInfo->Manufacturer[0] != '\0') {
+    Status = StringTableAddString (&StrTable, SystemInfo->Manufacturer, &ManufacturerRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add Manufacturer string %r\n", __func__, Status));
+      goto ErrorExit;
+    }
+  }
+
+  if (SystemInfo->ProductName[0] != '\0') {
+    Status = StringTableAddString (&StrTable, SystemInfo->ProductName, &ProductNameRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add ProductName string %r\n", __func__, Status));
+      goto ErrorExit;
+    }
+  }
+
+  if (SystemInfo->Version[0] != '\0') {
+    Status = StringTableAddString (&StrTable, SystemInfo->Version, &VersionRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add Version string %r\n", __func__, Status));
+      goto ErrorExit;
+    }
+  }
+
+  if (SystemInfo->SerialNum[0] != '\0') {
+    Status = StringTableAddString (&StrTable, SystemInfo->SerialNum, &SerialNumRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add SerialNum string %r\n", __func__, Status));
+      goto ErrorExit;
+    }
+  }
+
+  if (SystemInfo->SkuNum[0] != '\0') {
+    Status = StringTableAddString (&StrTable, SystemInfo->SkuNum, &SkuNumRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add SkuNum string %r\n", __func__, Status));
+      goto ErrorExit;
+    }
+  }
+
+  if (SystemInfo->Family[0] != '\0') {
+    Status = StringTableAddString (&StrTable, SystemInfo->Family, &FamilyRef);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to add Family string %r\n", __func__, Status));
+      goto ErrorExit;
+    }
+  }
+
+  SmbiosRecordSize = sizeof (SMBIOS_TABLE_TYPE1) +
+                     StringTableGetStringSetSize (&StrTable);
+  SmbiosRecord = (SMBIOS_TABLE_TYPE1 *)AllocateZeroPool (SmbiosRecordSize);
+  if (SmbiosRecord == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ErrorExit;
+  }
+
+  SmbiosRecord->Manufacturer = ManufacturerRef;
+  SmbiosRecord->ProductName  = ProductNameRef;
+  SmbiosRecord->Version      = VersionRef;
+  SmbiosRecord->SerialNumber = SerialNumRef;
+  SmbiosRecord->SKUNumber    = SkuNumRef;
+  SmbiosRecord->Family       = FamilyRef;
+
+  OptionalStrings = (CHAR8 *)(SmbiosRecord + 1);
+  // publish the string set
+  Status = StringTablePublishStringSet (
+             &StrTable,
+             OptionalStrings,
+             (SmbiosRecordSize - sizeof (SMBIOS_TABLE_TYPE1))
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to publish string set %r\n", __func__, Status));
+    goto ErrorExit;
+  }
+
+  //
+  // Fill in other fields of SMBIOS table
+  //
+  CopyGuid (&SmbiosRecord->Uuid, &SystemInfo->Uuid);
+  SmbiosRecord->WakeUpType = SystemInfo->WakeUpType;
+
+  //
+  // Setup SMBIOS header
+  //
+  SmbiosRecord->Hdr.Type   = EFI_SMBIOS_TYPE_SYSTEM_INFORMATION;
+  SmbiosRecord->Hdr.Length = sizeof (SMBIOS_TABLE_TYPE1);
+
+  *Table      = (SMBIOS_STRUCTURE *)SmbiosRecord;
+  *CmObjToken = SystemInfo->SystemInfoToken;
+  Status      = EFI_SUCCESS;
+
+ErrorExit:
+  if (EFI_ERROR (Status) && (SmbiosRecord != NULL)) {
+    FreePool (SmbiosRecord);
+  }
+
+  // free string table
+  StringTableFree (&StrTable);
+  return Status;
+}
+
+/** The interface for the SMBIOS Type 1 Table Generator.
+*/
+STATIC
+CONST
+SMBIOS_TABLE_GENERATOR  SmbiosType1Generator = {
+  // Generator ID
+  CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType01),
+  // Generator Description
+  L"SMBIOS.TYPE1.GENERATOR",
+  // SMBIOS Table Type
+  EFI_SMBIOS_TYPE_SYSTEM_INFORMATION,
+  // Build table function
+  BuildSmbiosType1Table,
+  // Free function
+  FreeSmbiosType1Table,
+  NULL,
+  NULL
+};
+
+/** Register the Generator with the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType1LibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterSmbiosTableGenerator (&SmbiosType1Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type 1: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+/** Deregister the Generator from the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType1LibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterSmbiosTableGenerator (&SmbiosType1Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type1: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType1Lib/SmbiosType1Lib.inf
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType1Lib/SmbiosType1Lib.inf
@@ -1,0 +1,37 @@
+## @file
+#  SMBIOS Type 1 Table Generator
+#
+#  Copyright (c) 2024 - 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  Copyright (c) 2019 - 2021, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = SmbiosType1LibArm
+  FILE_GUID      = c4b1cb30-5652-11ed-9d3f-7fb5379f6d11
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = SmbiosType1LibConstructor
+  DESTRUCTOR     = SmbiosType1LibDestructor
+
+[Sources]
+  SmbiosType1Generator.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                        # PROTOCOL ALWAYS_CONSUMED
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  SmbiosStringTableLib
+  MemoryAllocationLib


### PR DESCRIPTION
# Description

 Add DynamicTablesPkg support for SMBIOS System Information (Type 1).

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Check that Type 1 SMBIOS table was installed on an NVIDIA reference platform.

## Integration Instructions

NA