### PR TITLE
DynamicTablesPkg: add support of SMBIOS Type 44 record

### DIFF
--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -123,6 +123,7 @@
   DynamicTablesPkg/Library/Smbios/SmbiosType28Lib/SmbiosType28Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType29Lib/SmbiosType29Lib.inf
   DynamicTablesPkg/Library/Smbios/SmbiosType37Lib/SmbiosType37Lib.inf
+  DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Lib.inf
 
   # AML Fixup (Arm specific)
   DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCmn600LibArm/SsdtCmn600LibArm.inf
@@ -181,6 +182,7 @@
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType28Lib/SmbiosType28Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType29Lib/SmbiosType29Lib.inf
       NULL|DynamicTablesPkg/Library/Smbios/SmbiosType37Lib/SmbiosType37Lib.inf
+      NULL|DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Lib.inf
   }
 
 [Components.RISCV64]

--- a/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArchCommonNameSpaceObjects.h
@@ -19,6 +19,7 @@
 
 #include <IndustryStandard/AcpiAml.h>
 #include <IndustryStandard/Tpm2Acpi.h>
+#include <IndustryStandard/SmBios.h>
 
 /** The EARCH_COMMON_OBJECT_ID enum describes the Object IDs
     in the Arch Common Namespace
@@ -91,6 +92,7 @@ typedef enum ArchCommonObjectID {
   EArchCommonObjMemoryDeviceMappedAddress,      ///< 63 - Memory Device Mapped Address Info
   EArchCommonObjMemoryChannelInfo,              ///< 64 - Memory Channel Info
   EArchCommonObjMemoryChannelDevice,            ///< 65 - Memory Channel Device Info
+  EArchCommonObjProcessorSpecificBlockInfo,     ///< 66 - Processor specific data Info
   EArchCommonObjMax
 } EARCH_COMMON_OBJECT_ID;
 
@@ -1704,5 +1706,25 @@ typedef struct CmArchCommonSystemResetInfo {
   /// Timeout value used by the watchdog timer.
   UINT16             Timeout;
 } CM_ARCH_COMMON_SYSTEM_RESET_INFO;
+
+/** A structure that describes processor specific data.
+
+  SMBIOS Specification v3.9.0 Type 44
+
+  ID: EArchCommonObjProcessorSpecificBlockInfo
+**/
+typedef struct CmArchCommonProcessorSpecificBlockInfo {
+  /// CM Object Token uniquely identifying this processor specific block info.
+  CM_OBJECT_TOKEN                       Token;
+
+  /// Relevant Process Hierarchy Socket Token.
+  CM_OBJECT_TOKEN                       ProcSocketToken;
+
+  /// Processor Architecture Type.
+  PROCESSOR_SPECIFIC_BLOCK_ARCH_TYPE    ProcArchType;
+
+  /// Token array for architecture specific Processor Data.
+  CM_OBJECT_TOKEN                       ArchProcessorSpecificDataToken;
+} CM_ARCH_COMMON_PROCESSOR_SPECIFIC_BLOCK_INFO;
 
 #pragma pack()

--- a/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
@@ -53,6 +53,8 @@ typedef enum ArmObjectID {
   EArmObjEtInfo,                                               ///< 23 - Embedded Trace Extension/Module Info
   EArmObjDmc620PmuSocketInfo,                                  ///< 24 - DMC620 Socket Info
   EArmObjDmc620PmuRegInfo,                                     ///< 25 - DMC620 PMU Reg Info
+  EArmObjProcessorSpecificBlockInfo,                           ///< 26 - Processor Specific Block.
+  EArmObjProcessorSpecificSubDataArchInfo,                     ///< 27 - Processor Specific Sub Data (ArchData)
   EArmObjMax
 } EARM_OBJECT_ID;
 
@@ -776,5 +778,99 @@ typedef enum ArmEtType {
 typedef struct CmArmEtInfo {
   ARM_ET_TYPE    EtType;
 } CM_ARM_ET_INFO;
+
+typedef enum ArmProcessorSpecifcDataSubType {
+  ArmProcessorSpecificDataSubTypeArch,
+  /// Define vendor type from here.
+  ArmProcessorSpecificDataSubTypeMax,
+} ARM_PROCESSOR_SPECIFIC_DATA_SUB_TYPE;
+
+/** A structure that describes the processor specific data.
+
+    ID: EArmObjProcessorSpecificBlockInfo
+*/
+typedef struct CmArmProcessorSpecificBlockInfo {
+  /// Revision for processor specific block
+  UINT16                                  Revision;
+
+  /// Vendor ID.
+  UINT16                                  VendorId;
+
+  /// Sub type of Processor specific block.
+  ARM_PROCESSOR_SPECIFIC_DATA_SUB_TYPE    SubType;
+
+  /// Sub data token relevant to SubType.
+  CM_OBJECT_TOKEN                         SubDataToken;
+} CM_ARM_PROCESSOR_SPECIFIC_BLOCK_INFO;
+
+/** A structure that describes the processor specific sub data
+    (Architecture Data).
+
+    ID: EArmObjProcessorSpecificSubDataArchInfo
+*/
+typedef struct CmArmProcessorSpecificSubDataArchInfo {
+  /// Version for Processor Specific Sub Data (Arch Data).
+  UINT16    Version;
+
+  /// Value of ID_AA64AFR0_EL1.
+  UINT64    IdAA64Afr0;
+
+  /// Value of ID_AA64AFR1_EL1.
+  UINT64    IdAA64Afr1;
+
+  /// Value of ID_AA64DFR0_EL1.
+  UINT64    IdAA64Dfr0;
+
+  /// Value of ID_AA64DFR1_EL1.
+  UINT64    IdAA64Dfr1;
+
+  /// Value of ID_AA64DFR2_EL1.
+  UINT64    IdAA64Dfr2;
+
+  /// Value of ID_AA64FPFR0_EL1.
+  UINT64    IdAA64Fpfr0;
+
+  /// Value of ID_AA64ISAR0_EL1.
+  UINT64    IdAA64Isar0;
+
+  /// Value of ID_AA64ISAR1_EL1.
+  UINT64    IdAA64Isar1;
+
+  /// Value of ID_AA64ISAR2_EL1.
+  UINT64    IdAA64Isar2;
+
+  /// Value of ID_AA64ISAR3_EL1.
+  UINT64    IdAA64Isar3;
+
+  /// Value of ID_AA64MMFR0_EL1.
+  UINT64    IdAA64Mmfr0;
+
+  /// Value of ID_AA64MMFR1_EL1.
+  UINT64    IdAA64Mmfr1;
+
+  /// Value of ID_AA64MMFR2_EL1.
+  UINT64    IdAA64Mmfr2;
+
+  /// Value of ID_AA64MMFR3_EL1.
+  UINT64    IdAA64Mmfr3;
+
+  /// Value of ID_AA64MMFR4_EL1.
+  UINT64    IdAA64Mmfr4;
+
+  /// Value of ID_AA64PFR0_EL1.
+  UINT64    IdAA64Pfr0;
+
+  /// Value of ID_AA64PFR1_EL1.
+  UINT64    IdAA64Pfr1;
+
+  /// Value of ID_AA64PFR2_EL1.
+  UINT64    IdAA64Pfr2;
+
+  /// Value of ID_AA64SMFR0_EL1.
+  UINT64    IdAA64Smfr0;
+
+  /// Value of ID_AA64ZFR0_EL1.
+  UINT64    IdAA64Zfr0;
+} CM_ARM_PROCESSOR_SPECIFIC_SUB_DATA_ARCH_INFO;
 
 #pragma pack()

--- a/DynamicTablesPkg/Include/RiscVNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/RiscVNameSpaceObjects.h
@@ -39,6 +39,7 @@ typedef enum RiscVObjectID {
   ERiscVObjCmoInfo,                                              ///< 6 - RISC-V CMO Info
   ERiscVObjMmuInfo,                                              ///< 7 - RISC-V MMU Type Info
   ERiscVObjTimerInfo,                                            ///< 8 - RISC-V Timer Type Info
+  ERiscVObjProcessorSpecificBlockInfo,                           ///< 9 - RISC-V Processor Specific Block Info
   ERiscVObjMax
 } ERISCV_OBJECT_ID;
 
@@ -261,5 +262,27 @@ typedef struct CmRiscVTimerInfo {
   /// Time Base Frequency
   UINT64    TimeBaseFrequency;
 } CM_RISCV_TIMER_INFO;
+
+/** A structure that describes the
+    Processor Specific Block for Smbios type 44 record.
+
+    ID: ERiscVObjProcessorSpecificBlockInfo
+*/
+typedef struct CmRiscVProcessorSpecificBlockInfo {
+  /// Revision
+  UINT16    Revision;
+
+  /// The ID of this RISC-V hart.
+  UINT64    HartId;
+
+  /// Vendor ID.
+  UINT64    VendorId;
+
+  /// Machine Architecture ID.
+  UINT64    ArchId;
+
+  /// Machine Implementation ID.
+  UINT64    ImplId;
+} CM_RISCV_PROCESSOR_SPECIFIC_BLOCK_INFO;
 
 #pragma pack()

--- a/DynamicTablesPkg/Include/SmbiosTableGenerator.h
+++ b/DynamicTablesPkg/Include/SmbiosTableGenerator.h
@@ -70,9 +70,9 @@ typedef enum StdSmbiosTableGeneratorId {
   EStdSmbiosTableIdType40,
   EStdSmbiosTableIdType41,
   EStdSmbiosTableIdType42,
-
-  // IDs 43 - 125 are reserved
-
+  // IDs 43 are reserved
+  EStdSmbiosTableIdType44 = (EStdSmbiosTableIdType00 + 44),
+  // IDs 45 - 125 are reserved
   EStdSmbiosTableIdType126 = (EStdSmbiosTableIdType00 + 126),
   EStdSmbiosTableIdType127,
   EStdSmbiosTableIdMax

--- a/DynamicTablesPkg/Include/X64NameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/X64NameSpaceObjects.h
@@ -58,7 +58,8 @@ typedef enum X64ObjectID {
   EX64ObjErrSourceIa32CorrectedMachineCheckInfo, ///< 21 - IA-32 Architecture Corrected Machine Check Error Source info
   EX64ObjErrSourceIa32DeferredMachineCheckInfo,  ///< 22 - IA-32 Architecture Deferred Machine Check Error Source info
   EX64ObjErrSourceIa32NmiInfo,                   ///< 23 - IA-32 Architecture Non-Maskable Interrupt
-  EX64ObjMax                                     ///< 24 - Maximum Object ID
+  EX64ObjProcessorSpecificBlockInfo,             ///< 24 - X86 (X64) Processor Specific Block info
+  EX64ObjMax                                     ///< 25 - Maximum Object ID
 } EX64_OBJECT_ID;
 
 /** A structure that describes the
@@ -433,5 +434,21 @@ typedef struct CmX64Ia32ErrSourceNmiInfo {
   /// The size in bytes of the NMI error data.
   UINT32                      MaxRawDataLength;
 } CM_X64_ERROR_SOURCE_IA32_NMI_INFO;
+
+/**
+  A structure that describes X86 (X64) Processor Specific Block Information.
+
+  ID: EX64ObjProcessorSpecificBlockInfo
+ */
+typedef struct CmX64ProcessorSpecificBlockInfo {
+  /// Identifier.
+  UINT8     BlockIdentifier;
+
+  /// Revision
+  UINT16    Revision;
+
+  /// Use Condition Attributes
+  UINT32    UseConditionAttributes;
+} CM_X64_PROCESSOR_SPECIFIC_BLOCK_INFO;
 
 #pragma pack()

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.c
@@ -1,0 +1,826 @@
+/** @file
+  SMBIOS Type44 Table Generator.
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PrintLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/SmbiosStringTableLib.h>
+
+// Module specific include files.
+#include <ConfigurationManagerObject.h>
+#include <ConfigurationManagerHelper.h>
+#include <Protocol/ConfigurationManagerProtocol.h>
+#include <Protocol/DynamicTableFactoryProtocol.h>
+#include <IndustryStandard/SmBios.h>
+
+#include "SmbiosType44Generator.h"
+
+/**
+  SMBIOS Type 44 Generator
+
+  Requirements:
+    The following Configuration Manager Object(s) are used by this Generator:
+     - EArchCommonObjProcessorSpecificBlockInfo
+     - EArmObjProcessorSpecificBlockInfo,
+     - EArmObjProcessorSpecificSubDataArchInfo,
+*/
+
+/**
+  This macro expands to a function that retrieves the Error source infomation
+  information from the Configuration Manager.
+*/
+GET_OBJECT_LIST (
+  EObjNameSpaceArchCommon,
+  EArchCommonObjProcessorSpecificBlockInfo,
+  CM_ARCH_COMMON_PROCESSOR_SPECIFIC_BLOCK_INFO
+  );
+
+GET_OBJECT_LIST (
+  EObjNameSpaceArm,
+  EArmObjProcessorSpecificBlockInfo,
+  CM_ARM_PROCESSOR_SPECIFIC_BLOCK_INFO
+  );
+
+GET_OBJECT_LIST (
+  EObjNameSpaceArm,
+  EArmObjProcessorSpecificSubDataArchInfo,
+  CM_ARM_PROCESSOR_SPECIFIC_SUB_DATA_ARCH_INFO
+  );
+
+/** Get Arm Processor Specific sub-data CM objects.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       Token                Arm Sub Data Token.
+  @param [out]      ArmSubDataOps        Arm Sub Data Operation.
+
+  @retval EFI_SUCCESS
+  @retval Others                         Failed to initialise
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetArmSubDataArchCmObj (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN            CM_OBJECT_TOKEN                               Token,
+  OUT           ARM_PROCESSOR_SUB_DATA_OPS                    *ArmSubDataOps
+  )
+{
+  EFI_STATUS                                    Status;
+  CM_ARM_PROCESSOR_SPECIFIC_SUB_DATA_ARCH_INFO  *Data;
+  UINT32                                        DataCount;
+
+  Status = GetEArmObjProcessorSpecificSubDataArchInfo (
+             CfgMgrProtocol,
+             Token,
+             &Data,
+             &DataCount
+             );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get Arm processor sub-data arch info. Status = %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  if (DataCount != 1) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: SubData Token (%lx) should be unique. Count = %d\n",
+      __func__,
+      Token,
+      DataCount
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ArmSubDataOps->CmObject = Data;
+
+  return EFI_SUCCESS;
+}
+
+/** Get size of Arm processor arch sub-data.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Data.
+  @param [out]      Size                 Size of Processor Specific sub-data.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetSizeofArmSubDataArch (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN      CONST VOID                                          *CmObject,
+  OUT     UINT32                                              *Size
+  )
+{
+  CONST CM_ARM_PROCESSOR_SPECIFIC_SUB_DATA_ARCH_INFO  *SubData;
+
+  SubData = CmObject;
+
+  switch (SubData->Version) {
+    case 1:
+      *Size = sizeof (AARCH64_PROCESSOR_SPECIFIC_SUB_DATA_ARCH);
+      break;
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Add Arm Processor Specific sub-data arch into ARM_PROCESSOR_SPECIFIC_BLOCK.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Data.
+  @param [out]      ProcBlock             Arm Processor Specific Block.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+AddArmSubDataArch (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN      CONST VOID                                          *CmObject,
+  OUT     ARM_PROCESSOR_SPECIFIC_BLOCK                        *ProcBlock
+  )
+{
+  CONST CM_ARM_PROCESSOR_SPECIFIC_SUB_DATA_ARCH_INFO  *SubData;
+  AARCH64_PROCESSOR_SPECIFIC_SUB_DATA_ARCH            *ArchData;
+
+  SubData  = CmObject;
+  ArchData = (AARCH64_PROCESSOR_SPECIFIC_SUB_DATA_ARCH *)(ProcBlock + 1);
+
+  ArchData->Version = SubData->Version;
+
+  switch (SubData->Version) {
+    case 1:
+      ArchData->Length      = sizeof (AARCH64_PROCESSOR_SPECIFIC_SUB_DATA_ARCH);
+      ArchData->IdAA64Afr0  = SubData->IdAA64Afr0;
+      ArchData->IdAA64Afr1  = SubData->IdAA64Afr1;
+      ArchData->IdAA64Dfr0  = SubData->IdAA64Dfr0;
+      ArchData->IdAA64Dfr1  = SubData->IdAA64Dfr1;
+      ArchData->IdAA64Dfr2  = SubData->IdAA64Dfr2;
+      ArchData->IdAA64Fpfr0 = SubData->IdAA64Fpfr0;
+      ArchData->IdAA64Isar0 = SubData->IdAA64Isar0;
+      ArchData->IdAA64Isar1 = SubData->IdAA64Isar1;
+      ArchData->IdAA64Isar2 = SubData->IdAA64Isar2;
+      ArchData->IdAA64Isar3 = SubData->IdAA64Isar3;
+      ArchData->IdAA64Mmfr0 = SubData->IdAA64Mmfr0;
+      ArchData->IdAA64Mmfr1 = SubData->IdAA64Mmfr1;
+      ArchData->IdAA64Mmfr2 = SubData->IdAA64Mmfr2;
+      ArchData->IdAA64Mmfr3 = SubData->IdAA64Mmfr3;
+      ArchData->IdAA64Mmfr4 = SubData->IdAA64Mmfr4;
+      ArchData->IdAA64Pfr0  = SubData->IdAA64Pfr0;
+      ArchData->IdAA64Pfr1  = SubData->IdAA64Pfr1;
+      ArchData->IdAA64Pfr2  = SubData->IdAA64Pfr2;
+      ArchData->IdAA64Smfr0 = SubData->IdAA64Smfr0;
+      ArchData->IdAA64Zfr0  = SubData->IdAA64Zfr0;
+      break;
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Operation table to handle Arm Processor specific sub data.
+**/
+STATIC ARM_PROCESSOR_SUB_DATA_OPS  mArmProcSubDataOps[] = {
+  {
+    ArmProcessorSpecificDataSubTypeArch,
+    GetArmSubDataArchCmObj,
+    GetSizeofArmSubDataArch,
+    AddArmSubDataArch,
+  },
+};
+
+/** Get Arm Processor Specific Block CM objects.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       Token                Processor Specific Block Token.
+  @param [out]      ProcBlockOps         Process Specific Block Operation.
+
+  @retval EFI_SUCCESS
+  @retval Others                         Failed to initialise
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetArmProcBlockCmObj (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN            CM_OBJECT_TOKEN                               Token,
+  OUT           PROCESSOR_SPECIFIC_BLOCK_OPS                  *ProcBlockOps
+  )
+{
+  EFI_STATUS                            Status;
+  CM_ARM_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+  UINT32                                BlockCount;
+
+  Status = GetEArmObjProcessorSpecificBlockInfo (
+             CfgMgrProtocol,
+             Token,
+             &Block,
+             &BlockCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get Arm processor data info. Status = %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  ProcBlockOps->CmObject = Block;
+
+  return EFI_SUCCESS;
+}
+
+/** Get size of Arm Processor Specific Block.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Block.
+  @param [out]      Size                 Size of Processor Specific Block.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetSizeofArmProcBlock (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN      CONST VOID                                          *CmObject,
+  OUT     UINT32                                              *Size
+  )
+{
+  EFI_STATUS                                  Status;
+  CONST CM_ARM_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+  UINT32                                      BlockSize;
+  ARM_PROCESSOR_SUB_DATA_OPS                  *SubDataOps;
+  UINT32                                      SubDataSize;
+
+  Block     = CmObject;
+  *Size     = 0;
+  BlockSize = 0;
+
+  if (Block->SubType >= ArmProcessorSpecificDataSubTypeMax) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Invalid sub-data type\n",
+      __func__
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (Block->Revision) {
+    case PROCESSOR_SPECIFIC_VERSION_INFO (1, 0):
+      BlockSize += sizeof (ARM_PROCESSOR_SPECIFIC_BLOCK);
+      break;
+    default:
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Invalid revision for ARM_PROCESSOR_SPECIFIC_BLOCK: 0x%x\n",
+        __func__,
+        Block->Revision
+        ));
+      return EFI_INVALID_PARAMETER;
+  }
+
+  SubDataOps = &mArmProcSubDataOps[Block->SubType];
+
+  Status = SubDataOps->GetProcSubDataCmObj (
+                         CfgMgrProtocol,
+                         Block->SubDataToken,
+                         SubDataOps
+                         );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to Get sub-data cm object: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  Status = SubDataOps->GetSizeofProcSubData (
+                         CfgMgrProtocol,
+                         SubDataOps->CmObject,
+                         &SubDataSize
+                         );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to Get sub-data size: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  BlockSize += SubDataSize;
+  *Size      = BlockSize;
+
+  return EFI_SUCCESS;
+}
+
+/** Add Arm Processor Specific Block into SMBIOS record.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Block.
+  @param [out]      SmbiosRecord         Type 44 Smbios Record.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+AddArmProcBlock (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN      CONST VOID                                          *CmObject,
+  OUT     SMBIOS_TABLE_TYPE44                                 *SmbiosRecord
+  )
+{
+  EFI_STATUS                                  Status;
+  ARM_PROCESSOR_SPECIFIC_BLOCK                *ProcBlock;
+  CONST CM_ARM_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+  ARM_PROCESSOR_SUB_DATA_OPS                  *SubDataOps;
+  UINT32                                      SubDataSize;
+
+  Block      = CmObject;
+  SubDataOps = &mArmProcSubDataOps[Block->SubType];
+  ProcBlock  = (ARM_PROCESSOR_SPECIFIC_BLOCK *)(SmbiosRecord + 1);
+
+  Status = SubDataOps->GetSizeofProcSubData (
+                         CfgMgrProtocol,
+                         SubDataOps->CmObject,
+                         &SubDataSize
+                         );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to Get sub-data size: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  ProcBlock->Revision = Block->Revision;
+  ProcBlock->Length   = sizeof (ARM_PROCESSOR_SPECIFIC_BLOCK) + SubDataSize;
+  ProcBlock->VendorId = Block->VendorId;
+  ProcBlock->SubType  = Block->SubType;
+
+  return SubDataOps->AddProcSubData (
+                       CfgMgrProtocol,
+                       SubDataOps->CmObject,
+                       ProcBlock
+                       );
+}
+
+/** Operation table to handle Processor Specific Block to generate
+    Smbios Type 44 record.
+**/
+STATIC PROCESSOR_SPECIFIC_BLOCK_OPS  mProcSpecificBlockOps[] = {
+  {
+    ProcessorSpecificBlockArchTypeReserved,
+    NULL,
+    NULL,
+    NULL,
+    TRUE,
+  },
+  {
+    ProcessorSpecificBlockArchTypeIa32,
+    NULL,
+    NULL,
+    NULL,
+    TRUE,
+  },
+  {
+    ProcessorSpecificBlockArchTypeX64,
+    NULL,
+    NULL,
+    NULL,
+    TRUE,
+  },
+  {
+    ProcessorSpecificBlockArchTypeItanium,
+    NULL,
+    NULL,
+    NULL,
+    TRUE,
+  },
+  {
+    ProcessorSpecificBlockArchTypeAarch32,
+    GetArmProcBlockCmObj,
+    GetSizeofArmProcBlock,
+    AddArmProcBlock,
+    ARM_SMBIOS_TYPE44_RECORD_UNSUPPORTED,
+  },
+  {
+    ProcessorSpecificBlockArchTypeAarch64,
+    GetArmProcBlockCmObj,
+    GetSizeofArmProcBlock,
+    AddArmProcBlock,
+    ARM_SMBIOS_TYPE44_RECORD_UNSUPPORTED,
+  },
+  {
+    ProcessorSpecificBlockArchTypeRiscVRV32,
+    NULL,
+    NULL,
+    NULL,
+    TRUE,
+  },
+  {
+    ProcessorSpecificBlockArchTypeRiscVRV64,
+    NULL,
+    NULL,
+    NULL,
+    TRUE,
+  },
+  {
+    ProcessorSpecificBlockArchTypeRiscVRV128,
+    NULL,
+    NULL,
+    NULL,
+    TRUE,
+  },
+};
+
+/** Free any resources allocated when installing SMBIOS Type44 table.
+
+ @param [in]  This                 Pointer to the SMBIOS table generator.
+ @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                   Protocol interface.
+ @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+ @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                   Protocol interface.
+ @param [in]  Table                Pointer to the SMBIOS table.
+ @param [in]  CmObjectToken        Pointer to the CM ObjectToken Array.
+ @param [in]  TableCount           Number of SMBIOS tables.
+
+ @retval EFI_SUCCESS            Table generated successfully.
+ @retval EFI_BAD_BUFFER_SIZE    The size returned by the Configuration
+                                Manager is less than the Object size for
+                                the requested object.
+ @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+ @retval EFI_NOT_FOUND          Could not find information.
+ @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+ @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+STATIC
+EFI_STATUS
+FreeSmbiosType44TableEx (
+  IN      CONST SMBIOS_TABLE_GENERATOR                    *CONST   This,
+  IN      CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL      *CONST   TableFactoryProtocol,
+  IN      CONST CM_STD_OBJ_SMBIOS_TABLE_INFO              *CONST   SmbiosTableInfo,
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL      *CONST   CfgMgrProtocol,
+  IN      SMBIOS_STRUCTURE                               ***CONST  Table,
+  IN      CM_OBJECT_TOKEN                                          **CmObjectToken,
+  IN      CONST UINTN                                              TableCount
+  )
+{
+  UINTN             Index;
+  SMBIOS_STRUCTURE  **TableList;
+
+  TableList = *Table;
+  for (Index = 0; Index < TableCount; Index++) {
+    if (TableList[Index] != NULL) {
+      FreePool (TableList[Index]);
+    }
+  }
+
+  if (TableList != NULL) {
+    FreePool (TableList);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/** Construct SMBIOS Type 44 Table describing Processor Specific Block.
+
+  If this function allocates any resources then they must be freed
+  in the FreeXXXXTableResources function.
+
+ @param [in]  This                 Pointer to the SMBIOS table generator.
+ @param [in]  TableFactoryProtocol Pointer to the SMBIOS Table Factory
+                                   Protocol interface.
+ @param [in]  SmbiosTableInfo      Pointer to the SMBIOS table information.
+ @param [in]  CfgMgrProtocol       Pointer to the Configuration Manager
+                                   Protocol interface.
+ @param [out] Table                Pointer to the SMBIOS table.
+ @param [out] CmObjectToken        Pointer to the CM Object Token Array.
+ @param [out] TableCount           Number of tables installed.
+
+ @retval EFI_SUCCESS            Table generated successfully.
+ @retval EFI_BAD_BUFFER_SIZE    The size returned by the Configuration
+                                Manager is less than the Object size for
+                                the requested object.
+ @retval EFI_INVALID_PARAMETER  A parameter is invalid.
+ @retval EFI_NOT_FOUND          Could not find information.
+ @retval EFI_OUT_OF_RESOURCES   Could not allocate memory.
+ @retval EFI_UNSUPPORTED        Unsupported configuration.
+**/
+STATIC
+EFI_STATUS
+BuildSmbiosType44TableEx (
+  IN  CONST SMBIOS_TABLE_GENERATOR                         *This,
+  IN  CONST EDKII_DYNAMIC_TABLE_FACTORY_PROTOCOL   *CONST  TableFactoryProtocol,
+  IN        CM_STD_OBJ_SMBIOS_TABLE_INFO           *CONST  SmbiosTableInfo,
+  IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
+  OUT       SMBIOS_STRUCTURE                               ***Table,
+  OUT       CM_OBJECT_TOKEN                                **CmObjectToken,
+  OUT       UINTN                                  *CONST  TableCount
+  )
+{
+  EFI_STATUS                                    Status;
+  SMBIOS_STRUCTURE                              **TableList;
+  SMBIOS_TABLE_TYPE44                           *SmbiosRecord;
+  UINTN                                         SmbiosRecordSize;
+  UINT16                                        Type4Handle;
+  UINTN                                         Index;
+  CM_ARCH_COMMON_PROCESSOR_SPECIFIC_BLOCK_INFO  *ProcSpecificBlockList;
+  UINT32                                        ProcSpecificBlockCount;
+  PROCESSOR_SPECIFIC_BLOCK_OPS                  *ProcBlockOps;
+  UINT32                                        ProcBlockSize;
+
+  ASSERT (This != NULL);
+  ASSERT (SmbiosTableInfo != NULL);
+  ASSERT (CfgMgrProtocol != NULL);
+  ASSERT (Table != NULL);
+  ASSERT (CmObjectToken != NULL);
+  ASSERT (TableCount != NULL);
+  ASSERT (SmbiosTableInfo->TableGeneratorId == This->GeneratorID);
+
+  if ((This == NULL) || (SmbiosTableInfo == NULL) || (CfgMgrProtocol == NULL) ||
+      (Table == NULL) || (TableCount == NULL) || (CmObjectToken == NULL) ||
+      (SmbiosTableInfo->TableGeneratorId != This->GeneratorID))
+  {
+    DEBUG ((DEBUG_ERROR, "%a:Invalid Paramater\n ", __func__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  TableList   = NULL;
+  *Table      = NULL;
+  *TableCount = 0;
+
+  Status = GetEArchCommonObjProcessorSpecificBlockInfo (
+             CfgMgrProtocol,
+             CM_NULL_TOKEN,
+             &ProcSpecificBlockList,
+             &ProcSpecificBlockCount
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get processor hierarchy info. Status = %r\n",
+      __func__,
+      Status
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  TableList = (SMBIOS_STRUCTURE **)AllocateZeroPool (sizeof (SMBIOS_STRUCTURE *) * ProcSpecificBlockCount);
+  if (TableList == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to alloc memory for %u devices table\n",
+      __func__,
+      ProcSpecificBlockCount
+      ));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ErrorHandler;
+  }
+
+  for (Index = 0; Index < ProcSpecificBlockCount; Index++) {
+    if (ProcSpecificBlockList[Index].ProcArchType >= ProcessorSpecificBlockArchTypeLoongArch32) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Unsupported Type: 0x%x\n",
+        __func__,
+        ProcSpecificBlockList[Index].ProcArchType
+        ));
+      Status = EFI_INVALID_PARAMETER;
+      goto ErrorHandler;
+    }
+
+    ProcBlockOps = &mProcSpecificBlockOps[ProcSpecificBlockList[Index].ProcArchType];
+    if (ProcBlockOps->Unsupported) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Unsupported Type: 0x%x\n",
+        __func__,
+        ProcSpecificBlockList[Index].ProcArchType
+        ));
+      Status = EFI_INVALID_PARAMETER;
+      goto ErrorHandler;
+    }
+
+    Type4Handle = FindSmbiosHandleEx (
+                    CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType04),
+                    ProcSpecificBlockList[Index].ProcSocketToken
+                    );
+    if (Type4Handle == SMBIOS_HANDLE_INVALID) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Failed to get related Type4 Handle. Token: %lx\n",
+        __func__,
+        ProcSpecificBlockList[Index].ProcSocketToken
+        ));
+      Status = EFI_INVALID_PARAMETER;
+      goto ErrorHandler;
+    }
+
+    Status = ProcBlockOps->GetProcBlockCmObj (
+                             CfgMgrProtocol,
+                             ProcSpecificBlockList[Index].ArchProcessorSpecificDataToken,
+                             ProcBlockOps
+                             );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Failed to get Processor specific data CM object. Token: %lx\n",
+        __func__,
+        ProcSpecificBlockList[Index].ArchProcessorSpecificDataToken
+        ));
+      goto ErrorHandler;
+    }
+
+    Status = ProcBlockOps->GetSizeofProcBlock (
+                             CfgMgrProtocol,
+                             ProcBlockOps->CmObject,
+                             &ProcBlockSize
+                             );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Failed to get Processor specific data size.\n",
+        __func__
+        ));
+      goto ErrorHandler;
+    }
+
+    // Include the empty string table.
+    SmbiosRecordSize = sizeof (SMBIOS_TABLE_TYPE44) + ProcBlockSize + 2;
+
+    SmbiosRecord = AllocateZeroPool (SmbiosRecordSize);
+    if (SmbiosRecord == NULL) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Failed to allocate SmbiosRecord.\n",
+        __func__
+        ));
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ErrorHandler;
+    }
+
+    // Set up the header
+    SmbiosRecord->Hdr.Type                                 = EFI_SMBIOS_TYPE_PROCESSOR_ADDITIONAL_INFORMATION;
+    SmbiosRecord->Hdr.Length                               = SmbiosRecordSize - 2;
+    SmbiosRecord->RefHandle                                = Type4Handle;
+    SmbiosRecord->ProcessorSpecificBlock.ProcessorArchType = ProcSpecificBlockList[Index].ProcArchType;
+    SmbiosRecord->ProcessorSpecificBlock.Length            = ProcBlockSize;
+
+    Status = ProcBlockOps->AddProcBlock (
+                             CfgMgrProtocol,
+                             ProcBlockOps->CmObject,
+                             SmbiosRecord
+                             );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Failed to add Processor Specific Data into SmbiosRecord Status=%r.\n",
+        __func__,
+        Status
+        ));
+      FreePool (SmbiosRecord);
+      goto ErrorHandler;
+    }
+
+    TableList[Index] = (SMBIOS_STRUCTURE *)SmbiosRecord;
+  }
+
+  ASSERT (Index == ProcSpecificBlockCount);
+
+  *Table         = TableList;
+  *CmObjectToken = NULL;
+  *TableCount    = ProcSpecificBlockCount;
+
+  return EFI_SUCCESS;
+
+ErrorHandler:
+  if (TableList != NULL) {
+    while (Index-- != 0) {
+      if (TableList[Index] != NULL) {
+        FreePool (TableList[Index]);
+      }
+    }
+
+    FreePool (TableList);
+  }
+
+  return Status;
+}
+
+/** The interface for the SMBIOS Type4 Table Generator.
+*/
+STATIC
+CONST
+SMBIOS_TABLE_GENERATOR  SmbiosType44Generator = {
+  // Generator ID
+  CREATE_STD_SMBIOS_TABLE_GEN_ID (EStdSmbiosTableIdType44),
+  // Generator Description
+  L"SMBIOS.TYPE44.GENERATOR",
+  // SMBIOS Table Type
+  EFI_SMBIOS_TYPE_PROCESSOR_ADDITIONAL_INFORMATION,
+  NULL,
+  NULL,
+  // Build table function.
+  BuildSmbiosType44TableEx,
+  // Free function.
+  FreeSmbiosType44TableEx,
+};
+
+/** Register the Generator with the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is registered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_ALREADY_STARTED   The Generator for the Table ID
+                                is already registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType44LibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = RegisterSmbiosTableGenerator (&SmbiosType44Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type 44: Register Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+/** Deregister the Generator from the SMBIOS Table Factory.
+
+  @param [in]  ImageHandle  The handle to the image.
+  @param [in]  SystemTable  Pointer to the System Table.
+
+  @retval EFI_SUCCESS           The Generator is deregistered.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @retval EFI_NOT_FOUND         The Generator is not registered.
+**/
+EFI_STATUS
+EFIAPI
+SmbiosType44LibDestructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = DeregisterSmbiosTableGenerator (&SmbiosType44Generator);
+  DEBUG ((
+    DEBUG_INFO,
+    "SMBIOS Type 44: Deregister Generator. Status = %r\n",
+    Status
+    ));
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.c
@@ -55,6 +55,12 @@ GET_OBJECT_LIST (
   CM_ARM_PROCESSOR_SPECIFIC_SUB_DATA_ARCH_INFO
   );
 
+GET_OBJECT_LIST (
+  EObjNameSpaceX64,
+  EX64ObjProcessorSpecificBlockInfo,
+  CM_X64_PROCESSOR_SPECIFIC_BLOCK_INFO
+  );
+
 /** Get Arm Processor Specific sub-data CM objects.
 
   @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
@@ -258,6 +264,51 @@ GetArmProcBlockCmObj (
   return EFI_SUCCESS;
 }
 
+/** Get x86 (x64) Processor Specific Block CM objects.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       Token                Processor Specific Block Token.
+  @param [out]      ProcBlockOps         Process Specific Block Operation.
+
+  @retval EFI_SUCCESS
+  @retval Others                         Failed to initialise
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetX64ProcBlockCmObj (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN            CM_OBJECT_TOKEN                               Token,
+  OUT           PROCESSOR_SPECIFIC_BLOCK_OPS                  *ProcBlockOps
+  )
+{
+  EFI_STATUS                            Status;
+  CM_X64_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+  UINT32                                BlockCount;
+
+  Status = GetEX64ObjProcessorSpecificBlockInfo (
+             CfgMgrProtocol,
+             Token,
+             &Block,
+             &BlockCount
+             );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get X64 processor data info. Status = %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  ProcBlockOps->CmObject = Block;
+
+  return EFI_SUCCESS;
+}
+
 /** Get size of Arm Processor Specific Block.
 
   @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
@@ -348,6 +399,57 @@ GetSizeofArmProcBlock (
   return EFI_SUCCESS;
 }
 
+/** Get size of x86 (x64) Processor Specific Block.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Block.
+  @param [out]      Size                 Size of Processor Specific Block.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetSizeofX64ProcBlock (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN      CONST VOID                                          *CmObject,
+  OUT     UINT32                                              *Size
+  )
+{
+  CONST CM_X64_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+
+  Block = CmObject;
+  *Size = 0;
+
+  if (Block->BlockIdentifier == X86_PROCESSOR_BLOCK_IDENTIFIER_USE_CONDITION_DATA) {
+    switch (Block->Revision) {
+      case PROCESSOR_SPECIFIC_VERSION_INFO (1, 0):
+        *Size = sizeof (X86_PROCESSOR_SPECIFIC_BLOCK);
+        break;
+      default:
+        DEBUG ((
+          DEBUG_ERROR,
+          "%a: Invalid revision for USE_CONDITION_DATA block.: 0x%x\n",
+          __func__,
+          Block->Revision
+          ));
+        return EFI_INVALID_PARAMETER;
+    }
+  } else {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Invalid Block Identifier: 0x%x\n",
+      __func__,
+      Block->BlockIdentifier
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
 /** Add Arm Processor Specific Block into SMBIOS record.
 
   @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
@@ -404,6 +506,39 @@ AddArmProcBlock (
                        );
 }
 
+/** Add x86 (x64) Processor Specific Block into SMBIOS record.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Block.
+  @param [out]      SmbiosRecord         Type 44 Smbios Record.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+AddX64ProcBlock (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN      CONST VOID                                          *CmObject,
+  OUT     SMBIOS_TABLE_TYPE44                                 *SmbiosRecord
+  )
+{
+  X86_PROCESSOR_SPECIFIC_BLOCK                *ProcBlock;
+  CONST CM_X64_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+
+  Block     = CmObject;
+  ProcBlock = (X86_PROCESSOR_SPECIFIC_BLOCK *)(SmbiosRecord + 1);
+
+  ProcBlock->BlockIdentifier        = Block->BlockIdentifier;
+  ProcBlock->BlockLength            = sizeof (X86_PROCESSOR_SPECIFIC_BLOCK);
+  ProcBlock->Revision               = Block->Revision;
+  ProcBlock->UseConditionAttributes = Block->UseConditionAttributes;
+
+  return EFI_SUCCESS;
+}
+
 /** Operation table to handle Processor Specific Block to generate
     Smbios Type 44 record.
 **/
@@ -417,24 +552,24 @@ STATIC PROCESSOR_SPECIFIC_BLOCK_OPS  mProcSpecificBlockOps[] = {
   },
   {
     ProcessorSpecificBlockArchTypeIa32,
-    NULL,
-    NULL,
-    NULL,
-    TRUE,
+    GetX64ProcBlockCmObj,
+    GetSizeofX64ProcBlock,
+    AddX64ProcBlock,
+    X86_SMBIOS_TYPE44_RECORD_UNSUPPORTED,
   },
   {
     ProcessorSpecificBlockArchTypeX64,
-    NULL,
-    NULL,
-    NULL,
-    TRUE,
+    GetX64ProcBlockCmObj,
+    GetSizeofX64ProcBlock,
+    AddX64ProcBlock,
+    X86_SMBIOS_TYPE44_RECORD_UNSUPPORTED,
   },
   {
     ProcessorSpecificBlockArchTypeItanium,
-    NULL,
-    NULL,
-    NULL,
-    TRUE,
+    GetX64ProcBlockCmObj,
+    GetSizeofX64ProcBlock,
+    AddX64ProcBlock,
+    X86_SMBIOS_TYPE44_RECORD_UNSUPPORTED,
   },
   {
     ProcessorSpecificBlockArchTypeAarch32,

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.c
@@ -61,6 +61,12 @@ GET_OBJECT_LIST (
   CM_X64_PROCESSOR_SPECIFIC_BLOCK_INFO
   );
 
+GET_OBJECT_LIST (
+  EObjNameSpaceRiscV,
+  ERiscVObjProcessorSpecificBlockInfo,
+  CM_RISCV_PROCESSOR_SPECIFIC_BLOCK_INFO
+  );
+
 /** Get Arm Processor Specific sub-data CM objects.
 
   @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
@@ -309,6 +315,51 @@ GetX64ProcBlockCmObj (
   return EFI_SUCCESS;
 }
 
+/** Get RiscV Processor Specific Block CM objects.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       Token                Processor Specific Block Token.
+  @param [out]      ProcBlockOps         Process Specific Block Operation.
+
+  @retval EFI_SUCCESS
+  @retval Others                         Failed to initialise
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetRiscVProcBlockCmObj (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN            CM_OBJECT_TOKEN                               Token,
+  OUT           PROCESSOR_SPECIFIC_BLOCK_OPS                  *ProcBlockOps
+  )
+{
+  EFI_STATUS                              Status;
+  CM_RISCV_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+  UINT32                                  BlockCount;
+
+  Status = GetERiscVObjProcessorSpecificBlockInfo (
+             CfgMgrProtocol,
+             Token,
+             &Block,
+             &BlockCount
+             );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get risc-v processor data info. Status = %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  ProcBlockOps->CmObject = Block;
+
+  return EFI_SUCCESS;
+}
+
 /** Get size of Arm Processor Specific Block.
 
   @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
@@ -450,6 +501,47 @@ GetSizeofX64ProcBlock (
   return EFI_SUCCESS;
 }
 
+/** Get size of RiscV Processor Specific Block.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Block.
+  @param [out]      Size                 Size of Processor Specific Block.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetSizeofRiscVProcBlock (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN      CONST VOID                                          *CmObject,
+  OUT     UINT32                                              *Size
+  )
+{
+  CONST CM_RISCV_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+
+  Block = CmObject;
+  *Size = 0;
+
+  switch (Block->Revision) {
+    case PROCESSOR_SPECIFIC_VERSION_INFO (1, 0):
+      *Size = sizeof (RISCV_PROCESSOR_SPECIFIC_BLOCK);
+      break;
+    default:
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: Invalid revision for risc-v block.: 0x%x\n",
+        __func__,
+        Block->Revision
+        ));
+      return EFI_INVALID_PARAMETER;
+  }
+
+  return EFI_SUCCESS;
+}
+
 /** Add Arm Processor Specific Block into SMBIOS record.
 
   @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
@@ -539,6 +631,40 @@ AddX64ProcBlock (
   return EFI_SUCCESS;
 }
 
+/** Add risc-v Processor Specific Block into SMBIOS record.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Block.
+  @param [out]      SmbiosRecord         Type 44 Smbios Record.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+AddRiscVProcBlock (
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST  CfgMgrProtocol,
+  IN      CONST VOID                                          *CmObject,
+  OUT     SMBIOS_TABLE_TYPE44                                 *SmbiosRecord
+  )
+{
+  RISCV_PROCESSOR_SPECIFIC_BLOCK                *ProcBlock;
+  CONST CM_RISCV_PROCESSOR_SPECIFIC_BLOCK_INFO  *Block;
+
+  Block     = CmObject;
+  ProcBlock = (RISCV_PROCESSOR_SPECIFIC_BLOCK *)(SmbiosRecord + 1);
+
+  ProcBlock->Revision = Block->Revision;
+  ProcBlock->HartId   = Block->HartId;
+  ProcBlock->VendorId = Block->VendorId;
+  ProcBlock->ArchId   = Block->ArchId;
+  ProcBlock->ImplId   = Block->ImplId;
+
+  return EFI_SUCCESS;
+}
+
 /** Operation table to handle Processor Specific Block to generate
     Smbios Type 44 record.
 **/
@@ -587,24 +713,24 @@ STATIC PROCESSOR_SPECIFIC_BLOCK_OPS  mProcSpecificBlockOps[] = {
   },
   {
     ProcessorSpecificBlockArchTypeRiscVRV32,
-    NULL,
-    NULL,
-    NULL,
-    TRUE,
+    GetRiscVProcBlockCmObj,
+    GetSizeofRiscVProcBlock,
+    AddRiscVProcBlock,
+    RISCV_SMBIOS_TYPE44_RECORD_UNSUPPORTED,
   },
   {
     ProcessorSpecificBlockArchTypeRiscVRV64,
-    NULL,
-    NULL,
-    NULL,
-    TRUE,
+    GetRiscVProcBlockCmObj,
+    GetSizeofRiscVProcBlock,
+    AddRiscVProcBlock,
+    RISCV_SMBIOS_TYPE44_RECORD_UNSUPPORTED,
   },
   {
     ProcessorSpecificBlockArchTypeRiscVRV128,
-    NULL,
-    NULL,
-    NULL,
-    TRUE,
+    GetRiscVProcBlockCmObj,
+    GetSizeofRiscVProcBlock,
+    AddRiscVProcBlock,
+    RISCV_SMBIOS_TYPE44_RECORD_UNSUPPORTED,
   },
 };
 

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.h
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.h
@@ -24,6 +24,12 @@
 #define   X86_SMBIOS_TYPE44_RECORD_UNSUPPORTED  FALSE
 #endif
 
+#if !defined (MDE_CPU_RISCV64)
+#define   RISCV_SMBIOS_TYPE44_RECORD_UNSUPPORTED  TRUE
+#else
+#define   RISCV_SMBIOS_TYPE44_RECORD_UNSUPPORTED  FALSE
+#endif
+
 typedef struct ArmProcessorSubDataOps     ARM_PROCESSOR_SUB_DATA_OPS;
 typedef struct ProcessorSpecificBlockOps  PROCESSOR_SPECIFIC_BLOCK_OPS;
 

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.h
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.h
@@ -18,6 +18,12 @@
 #define   ARM_SMBIOS_TYPE44_RECORD_UNSUPPORTED  FALSE
 #endif
 
+#if !defined (MDE_CPU_X64) && !defined (MDE_CPU_IA32)
+#define   X86_SMBIOS_TYPE44_RECORD_UNSUPPORTED  TRUE
+#else
+#define   X86_SMBIOS_TYPE44_RECORD_UNSUPPORTED  FALSE
+#endif
+
 typedef struct ArmProcessorSubDataOps     ARM_PROCESSOR_SUB_DATA_OPS;
 typedef struct ProcessorSpecificBlockOps  PROCESSOR_SPECIFIC_BLOCK_OPS;
 

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.h
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Generator.h
@@ -1,0 +1,171 @@
+/** @file
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Cm or CM   - Configuration Manager
+    - Obj or OBJ - Object
+    - Std or STD - Standard
+**/
+
+#pragma once
+
+#if !defined (MDE_CPU_AARCH64)
+#define   ARM_SMBIOS_TYPE44_RECORD_UNSUPPORTED  TRUE
+#else
+#define   ARM_SMBIOS_TYPE44_RECORD_UNSUPPORTED  FALSE
+#endif
+
+typedef struct ArmProcessorSubDataOps     ARM_PROCESSOR_SUB_DATA_OPS;
+typedef struct ProcessorSpecificBlockOps  PROCESSOR_SPECIFIC_BLOCK_OPS;
+
+/** Get Arm Processor Specific sub-data CM objects.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       Token                Arm Sub Data Token.
+  @param [out]      ArmSubDataOps        Arm Sub Data Operation.
+
+  @retval EFI_SUCCESS
+  @retval Others                         Failed to initialise
+**/
+typedef
+EFI_STATUS
+(EFIAPI *GET_ARM_PROCESSOR_SUB_DATA_CM_OBJ)(
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST           CfgMgrProtocol,
+  IN            CM_OBJECT_TOKEN                                        Token,
+  OUT           ARM_PROCESSOR_SUB_DATA_OPS                             *ArmSubDataOps
+  );
+
+/** Get size of Arm Processor Specific sub-data.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Data.
+  @param [out]      Size                 Size of Processor Specific Data or SubData.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *GET_SIZE_OF_ARM_PROCESSOR_SUB_DATA)(
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST           CfgMgrProtocol,
+  IN      CONST VOID                                                   *CmObject,
+  OUT     UINT32                                                       *Size
+  );
+
+/** Add Arm Processor Specific sub-data into ARM_PROCESSOR_SPECIFIC_DATA.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific sub-data.
+  @param [out]      ProcBlock             Arm Processor Specific Block.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *ADD_ARM_PROCESSOR_SUB_DATA)(
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST           CfgMgrProtocol,
+  IN      CONST VOID                                                   *CmObject,
+  OUT     ARM_PROCESSOR_SPECIFIC_BLOCK                                 *ProcBlock
+  );
+
+/** Get Architecture Processor Specific Data CM objects.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       Token                Processor Specific Block Token.
+  @param [out]      ProcBlockOps         Process Specific Block Operation.
+
+  @retval EFI_SUCCESS
+  @retval Others                         Failed to initialise
+**/
+typedef
+EFI_STATUS
+(EFIAPI *GET_PROCESSOR_SPECIFIC_BLOCK_CM_OBJ)(
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST           CfgMgrProtocol,
+  IN            CM_OBJECT_TOKEN                                        Token,
+  OUT           PROCESSOR_SPECIFIC_BLOCK_OPS                           *ProcBlockOps
+  );
+
+/** Get size of Processor Specific Block.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Data.
+  @param [out]      Size                 Size of Processor Specific Data.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *GET_SIZE_OF_PROCESSOR_SPECIFIC_BLOCK)(
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST           CfgMgrProtocol,
+  IN      CONST VOID                                                   *CmObject,
+  OUT     UINT32                                                       *Size
+  );
+
+/** Add Processor Specific Block into SMBIOS record.
+
+  @param [in]       CfgMgrProtocol       Pointer to the Configuration Manager
+                                         Protocol Interface.
+  @param [in]       CmObject             CM object of Processor Specific Data.
+  @param [out]      SmbiosRecord         Type 44 Smbios Record.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETER          A parameter is invalid.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *ADD_PROCESSOR_SPECIFIC_BLOCK)(
+  IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL  *CONST           CfgMgrProtocol,
+  IN      CONST VOID                                                   *CmObject,
+  OUT     SMBIOS_TABLE_TYPE44                                          *SmbiosRecord
+  );
+
+/** A structure that describes operation relevant error source.
+*/
+typedef struct ArmProcessorSubDataOps {
+  /// Processor Specific Block Arch Type.
+  ARM_PROCESSOR_SPECIFIC_DATA_SUB_TYPE    SubDataType;
+
+  /// Get CM objects for Process Specific Data.
+  GET_ARM_PROCESSOR_SUB_DATA_CM_OBJ       GetProcSubDataCmObj;
+
+  /// Get  size of Process Specific Data.
+  GET_SIZE_OF_ARM_PROCESSOR_SUB_DATA      GetSizeofProcSubData;
+
+  /// Add Error source to HEST
+  ADD_ARM_PROCESSOR_SUB_DATA              AddProcSubData;
+
+  /// Architecture Processor Specific Data CM object.
+  VOID                                    *CmObject;
+} ARM_PROCESSOR_SUB_DATA_OPS;
+
+/** A structure that describes operation relevant error source.
+*/
+typedef struct ProcessorSpecificBlockOps {
+  /// Processor Specific Block Arch Type.
+  PROCESSOR_SPECIFIC_BLOCK_ARCH_TYPE      ArchType;
+
+  /// Get CM objects for Process Specific Data.
+  GET_PROCESSOR_SPECIFIC_BLOCK_CM_OBJ     GetProcBlockCmObj;
+
+  /// Get  size of Process Specific Data.
+  GET_SIZE_OF_PROCESSOR_SPECIFIC_BLOCK    GetSizeofProcBlock;
+
+  /// Add Error source to HEST
+  ADD_PROCESSOR_SPECIFIC_BLOCK            AddProcBlock;
+
+  /// If FALSE, generate sub-tables for this error source type.
+  BOOLEAN                                 Unsupported;
+
+  /// Architecture Processor Specific Data CM object.
+  VOID                                    *CmObject;
+} PROCESSOR_SPECIFIC_BLOCK_OPS;

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Lib.inf
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType44Lib/SmbiosType44Lib.inf
@@ -1,0 +1,33 @@
+## @file
+#  SMBIOS Type44 Table Generator
+#
+#  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x0001001B
+  BASE_NAME      = SmbiosType44Lib
+  FILE_GUID      = a2b7a71c-789e-11f1-a2e6-f708b60945d7
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = DXE_DRIVER
+  LIBRARY_CLASS  = NULL|DXE_DRIVER
+  CONSTRUCTOR    = SmbiosType44LibConstructor
+  DESTRUCTOR     = SmbiosType44LibDestructor
+
+[Sources]
+  SmbiosType44Generator.c
+  SmbiosType44Generator.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  DynamicTablesPkg/DynamicTablesPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  SmbiosStringTableLib

--- a/DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType4Lib/SmbiosType4Generator.c
@@ -177,6 +177,7 @@ BuildSmbiosType4TableEx (
   UINTN                           CpuIndex2;
   PROCESSOR_STATUS_DATA           *StatusData;
   PROCESSOR_CHARACTERISTIC_FLAGS  *CharacteristicFlags;
+  CM_OBJECT_TOKEN                 *CmObjectList;
 
   UINT32  ProcHierarchyNodeCount;
   UINT32  CacheStructCount;
@@ -213,7 +214,9 @@ BuildSmbiosType4TableEx (
     return EFI_INVALID_PARAMETER;
   }
 
-  *Table = NULL;
+  *Table         = NULL;
+  *CmObjectToken = NULL;
+  CmObjectList   = NULL;
 
   // Get the processor hierarchy info and update the processor topology
   // structure count with Processor Hierarchy Nodes (Type 0)
@@ -263,6 +266,18 @@ BuildSmbiosType4TableEx (
   if (SocketCount == 0) {
     ASSERT (SocketCount != 0);
     return EFI_INVALID_PARAMETER;
+  }
+
+  CmObjectList = AllocateZeroPool (sizeof (CM_OBJECT_TOKEN) * SocketCount);
+  if (CmObjectList == NULL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to alloc memory for %u tokens.\n",
+      __func__,
+      SocketCount
+      ));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto exitErrorBuildSmbiosType4Table;
   }
 
   TableList = (SMBIOS_STRUCTURE **)AllocateZeroPool (sizeof (SMBIOS_STRUCTURE *) * SocketCount);
@@ -497,7 +512,8 @@ BuildSmbiosType4TableEx (
 
     StringTableFree (&StrTable);
 
-    TableList[ObjIndex] = (SMBIOS_STRUCTURE *)SmbiosRecord;
+    TableList[ObjIndex]    = (SMBIOS_STRUCTURE *)SmbiosRecord;
+    CmObjectList[ObjIndex] = ProcHierarchyNodeList[Index].Token;
     ObjIndex++;
     ASSERT (ObjIndex <= SocketCount);
   }
@@ -505,7 +521,7 @@ BuildSmbiosType4TableEx (
   ASSERT (ObjIndex == SocketCount);
 
   *Table         = TableList;
-  *CmObjectToken = NULL;
+  *CmObjectToken = CmObjectList;
   *TableCount    = SocketCount;
 
   return EFI_SUCCESS;
@@ -519,6 +535,10 @@ exitErrorBuildSmbiosType4Table:
     }
 
     FreePool (TableList);
+  }
+
+  if (CmObjectList != NULL) {
+    FreePool (CmObjectList);
   }
 
   return Status;

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -3011,6 +3011,25 @@ typedef struct AArch64ProcessorSpecificSubDataArch {
   UINT64    IdAA64Zfr0;
 } AARCH64_PROCESSOR_SPECIFIC_SUB_DATA_ARCH;
 
+#define X86_PROCESSOR_BLOCK_IDENTIFIER_USE_CONDITION_DATA  (0x01)
+
+///
+/// X86 (X64) processor specific Block.
+///
+typedef struct X86ProcessorSpecificBlock {
+  /// Identifier.
+  UINT8     BlockIdentifier;
+
+  /// Length of Processor-specific Block
+  UINT8     BlockLength;
+
+  /// Revision
+  UINT16    Revision;
+
+  /// Use Condition Attributes
+  UINT32    UseConditionAttributes;
+} X86_PROCESSOR_SPECIFIC_BLOCK;
+
 ///
 /// Processor Additional Information(Type 44).
 ///

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -2896,6 +2896,121 @@ typedef struct {
   ///
 } PROCESSOR_SPECIFIC_BLOCK;
 
+#define PROCESSOR_SPECIFIC_MAJOR_VERSION_SHIFT  (8)
+#define PROCESSOR_SPECIFIC_MAJOR_VERSION_MASK   (0xff00)
+#define PROCESSOR_SPECIFIC_MINOR_VERSION_SHIFT  (0)
+#define PROCESSOR_SPECIFIC_MINOR_VERSION_MASK   (0x00ff)
+#define PROCESSOR_SPECIFIC_VERSION_INFO(major, minor) \
+        ((UINT16)((((major) & ((PROCESSOR_SPECIFIC_MAJOR_VERSION_MASK >> \
+                                PROCESSOR_SPECIFIC_MAJOR_VERSION_SHIFT))) << \
+                  PROCESSOR_SPECIFIC_MAJOR_VERSION_SHIFT) | \
+                  (((minor) & PROCESSOR_SPECIFIC_MINOR_VERSION_MASK) << \
+                   PROCESSOR_SPECIFIC_MINOR_VERSION_SHIFT)))
+
+///
+/// Arm (AARCH64) processor specific Block.
+///
+typedef struct ArmProcSpecificBlock {
+  /// Revision for processor specific block
+  UINT16    Revision;
+
+  /// Length of this structure.
+  UINT8     Length;
+
+  /// Reserved;
+  UINT8     Reserved0;
+
+  /// Vendor ID.
+  UINT16    VendorId;
+
+  /// Sub type of Processor specific sub-data.
+  UINT8     SubType;
+
+  /// Reserved;
+  UINT8     Reserved1;
+
+  ///
+  /// Below followed by Arm Processor-specific sub-data
+  ///
+} ARM_PROCESSOR_SPECIFIC_BLOCK;
+
+///
+/// AArch64 Architecture Data for ArmProcessorSpecificDataSubTypeArch.
+///
+typedef struct AArch64ProcessorSpecificSubDataArch {
+  /// Version for Processor Specific Sub Data (Arch Data).
+  UINT16    Version;
+
+  /// Length of this structure.
+  UINT8     Length;
+
+  /// Reserved.
+  UINT8     Reserved0;
+
+  /// Reserved.
+  UINT32    Reserved1;
+
+  /// Value of ID_AA64AFR0_EL1.
+  UINT64    IdAA64Afr0;
+
+  /// Value of ID_AA64AFR1_EL1.
+  UINT64    IdAA64Afr1;
+
+  /// Value of ID_AA64DFR0_EL1.
+  UINT64    IdAA64Dfr0;
+
+  /// Value of ID_AA64DFR1_EL1.
+  UINT64    IdAA64Dfr1;
+
+  /// Value of ID_AA64DFR2_EL1.
+  UINT64    IdAA64Dfr2;
+
+  /// Value of ID_AA64FPFR0_EL1.
+  UINT64    IdAA64Fpfr0;
+
+  /// Value of ID_AA64ISAR0_EL1.
+  UINT64    IdAA64Isar0;
+
+  /// Value of ID_AA64ISAR1_EL1.
+  UINT64    IdAA64Isar1;
+
+  /// Value of ID_AA64ISAR2_EL1.
+  UINT64    IdAA64Isar2;
+
+  /// Value of ID_AA64ISAR3_EL1.
+  UINT64    IdAA64Isar3;
+
+  /// Value of ID_AA64MMFR0_EL1.
+  UINT64    IdAA64Mmfr0;
+
+  /// Value of ID_AA64MMFR1_EL1.
+  UINT64    IdAA64Mmfr1;
+
+  /// Value of ID_AA64MMFR2_EL1.
+  UINT64    IdAA64Mmfr2;
+
+  /// Value of ID_AA64MMFR3_EL1.
+  UINT64    IdAA64Mmfr3;
+
+  /// Value of ID_AA64MMFR4_EL1.
+  UINT64    IdAA64Mmfr4;
+
+  /// Value of ID_AA64PFR0_EL1.
+  UINT64    IdAA64Pfr0;
+
+  /// Value of ID_AA64PFR1_EL1.
+  UINT64    IdAA64Pfr1;
+
+  /// Value of ID_AA64PFR2_EL1.
+  UINT64    IdAA64Pfr2;
+
+  /// Value of ID_AA64SMFR0_EL1.
+  UINT64    IdAA64Smfr0;
+
+  /// Value of ID_AA64ZFR0_EL1.
+  UINT64    IdAA64Zfr0;
+} AARCH64_PROCESSOR_SPECIFIC_SUB_DATA_ARCH;
+
 ///
 /// Processor Additional Information(Type 44).
 ///

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -3031,6 +3031,26 @@ typedef struct X86ProcessorSpecificBlock {
 } X86_PROCESSOR_SPECIFIC_BLOCK;
 
 ///
+/// RiscV processor specific Block.
+///
+typedef struct RiscVProcessorSpecificBlock {
+  /// Revision
+  UINT16    Revision;
+
+  /// The ID of this RISC-V hart.
+  UINT64    HartId;
+
+  /// Vendor ID.
+  UINT64    VendorId;
+
+  /// Machine Architecture ID.
+  UINT64    ArchId;
+
+  /// Machine Implementation ID.
+  UINT64    ImplId;
+} RISCV_PROCESSOR_SPECIFIC_BLOCK;
+
+///
 /// Processor Additional Information(Type 44).
 ///
 /// The information in this structure defines the processor additional information in case


### PR DESCRIPTION
# Description

This patch adds support for Smbios Type 44 Record in DynamicTable.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Confirmed the Type 44 generation with the DynamicTable framework.

## Integration Instructions

N/A