### PR TITLE
MdePkg/IndustryStandard: Add MemoryTypeLpDdr6 to MEMORY_DEVICE_TYPE enum

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1995,7 +1995,8 @@ typedef enum {
   MemoryTypeDdr5                     = 0x22,
   MemoryTypeLpddr5                   = 0x23,
   MemoryTypeHBM3                     = 0x24,
-  MemoryTypeMrDimm                   = 0x25  ///< SMBIOS spec 3.9.0 CR248
+  MemoryTypeMrDimm                   = 0x25, ///< SMBIOS spec 3.9.0 CR248
+  MemoryTypeLpddr6                   = 0x26  ///< SMBIOS spec 3.10
 } MEMORY_DEVICE_TYPE;
 
 ///

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c
@@ -2901,6 +2901,10 @@ TABLE_ITEM  MemoryDeviceTypeTable[] = {
   {
     MemoryTypeMrDimm,
     L"  MRDIMM (Multi-Channel RDIMM)"
+  },
+  {
+    MemoryTypeLpddr6,
+    L"  LPDDR6"
   }
 };
 


### PR DESCRIPTION
# Description

Add `MemoryTypeLpddr6 = 0x26` to the `MEMORY_DEVICE_TYPE` enum in
`MdePkg/Include/IndustryStandard/SmBios.h` to align with the SMBIOS
Specification 3.10 draft definition for LP DDR6 memory type.

The corresponding human-readable string for `MemoryTypeLpddr6` has also
been added to `ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/QueryTable.c`
so that `smbiosview` correctly displays the memory type name.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
