### PR TITLE
ArmVirtPkg, OvmfPkg: Add PATH_TO_OS Helper in PlatformCI

### DIFF
--- a/ArmVirtPkg/PlatformCI/PlatformBuildLib.py
+++ b/ArmVirtPkg/PlatformCI/PlatformBuildLib.py
@@ -17,7 +17,7 @@ from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import RunCmd
 from edk2toollib.utility_functions import GetHostInfo
-
+from pathlib import Path
 
     # ####################################################################################### #
     #                         Configuration for Update & Setup                                #
@@ -236,11 +236,33 @@ class PlatformBuilder(UefiBuilder, BuildSettingsManager):
 
         # Common Args
         args += CommonPlatform.FvQemuArg + Built_FV                         # path to fw
-        args += " -m 1024"                                                  # 1gb memory
         # turn off network
         args += " -net none"
         # Serial messages out
         args += " -serial stdio"
+
+        path_to_os = self.env.GetValue("PATH_TO_OS")
+        if path_to_os is not None:
+            args += f" -m 8192"                                      # 8gb memory for OS
+            file_extension = Path(path_to_os).suffix.lower().replace('"', '')
+
+            storage_format = {
+                ".vhd": "raw",
+                ".qcow2": "qcow2",
+                ".iso": "iso",
+            }.get(file_extension, None)
+
+            if storage_format is None:
+                raise Exception(f"Unknown OS storage type: {path_to_os}")
+
+            if storage_format == "iso":
+                args += f" -cdrom \"{path_to_os}\""
+            else:
+                args += f" -drive file=\"{path_to_os}\",format={storage_format},if=none,id=os_nvme"
+                args += " -device nvme,serial=nvme-1,drive=os_nvme,bootindex=0"
+        else:
+            args += " -m 1024"                                       # 1gb memory
+
         # Mount disk with startup.nsh
         args += f" -drive file=fat:rw:{VirtualDrive},format=raw,media=disk"
         # Provides Rng services to the Guest VM

--- a/OvmfPkg/PlatformCI/PlatformBuildLib.py
+++ b/OvmfPkg/PlatformCI/PlatformBuildLib.py
@@ -16,7 +16,7 @@ from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubm
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
 from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toollib.utility_functions import RunCmd
-
+from pathlib import Path
 
     # ####################################################################################### #
     #                         Configuration for Update & Setup                                #
@@ -209,6 +209,27 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         args += " -cpu IvyBridge,+rdrand"                                   # IvyBridge is the first CPU that supported
                                                                             # RDRAND, which is required for dynamic
                                                                             # stack cookies
+
+        path_to_os = self.env.GetValue("PATH_TO_OS")
+        if path_to_os is not None:
+            args += f" -m 8192"                                             # 8gb memory for OS
+            file_extension = Path(path_to_os).suffix.lower().replace('"', '')
+
+            storage_format = {
+                ".vhd": "raw",
+                ".qcow2": "qcow2",
+                ".iso": "iso",
+            }.get(file_extension, None)
+
+            if storage_format is None:
+                raise Exception(f"Unknown OS storage type: {path_to_os}")
+
+            if storage_format == "iso":
+                args += f" -cdrom \"{path_to_os}\""
+            else:
+                args += f" -drive file=\"{path_to_os}\",format={storage_format},if=none,id=os_nvme"
+                args += " -device nvme,serial=nvme-1,drive=os_nvme,bootindex=0"
+
         args += f" -drive file=fat:rw:{VirtualDrive},format=raw,media=disk" # Mount disk with startup.nsh
         # Provides Rng services to the Guest VM
         args += " -device virtio-rng-pci"


### PR DESCRIPTION
# Description

This adds a PATH_TO_OS variable that can be passed on the stuart cmdline to provide a path to an OS disk to boot for ArmVirtPkg and OvmfPkg.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

`stuart_build -c OvmfPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=CLANGPDB PATH_TO_OS=myOS.qcow2`
`stuart_build -c ArmVirtPkg/PlatformCI/QemuBuild.py TOOL_CHAIN_TAG=CLANGPDB PATH_TO_OS=myOS.qcow2`

boot to OSes directly.

## Integration Instructions

N/A.
