### PR TITLE
fix gcc build

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -561,7 +561,7 @@
       "$(PP)" $(DEPS_FLAGS) $(PP_FLAGS) $(INC) ${src} > ${d_path}(+)${s_base}.ii
       Trim --source-code -o ${d_path}(+)${s_base}.iii ${d_path}(+)${s_base}.ii
       "$(ASM)" -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj $(ASM_FLAGS) $(INC) ${d_path}(+)${s_base}.iii
-      "$(DLINK)" -o ${dst} $(DLINK_FLAGS) --start-group $(DLINK_SPATH) $(LIBS) $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj --end-group
+      "$(DLINK)" -o ${dst} $(DLINK_FLAGS) -Wl,--start-group $(DLINK_SPATH) $(LIBS) $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj -Wl,--end-group
 
     <Command.XCODE>
       Trim --asm-file -o ${d_path}(+)${s_base}.i -i $(INC_LIST) ${src}


### PR DESCRIPTION
Prefix --start-group and --end-group with -Wl

# Description

This patch fixes the gcc build by
prefixing -start-group and --end-group with -Wl

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?

This doesn't change run-time, and
hopefully does not break build. It was
actually broken before.

- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?

No security impact.

- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?

The build process is a test.

## How This Was Tested

By successfully building up to the end.

## Integration Instructions

N/A