### PR TITLE
MdePkg: BasePeCoffLib: Record security data directory

### DIFF
--- a/MdePkg/Include/Library/PeCoffLib.h
+++ b/MdePkg/Include/Library/PeCoffLib.h
@@ -196,6 +196,14 @@ typedef struct {
   /// Private storage for implementation specific data.
   ///
   UINT64                      Context;
+  ///
+  /// Set by PeCoffLoaderGetImageInfo() to a copy of the image's
+  /// EFI_IMAGE_DIRECTORY_ENTRY_SECURITY data directory entry. If the image
+  /// does not contain a security data directory entry, this field is set to
+  /// zero. The VirtualAddress field represents the offset to the security
+  /// data from the start of the unloaded image.
+  ///
+  EFI_IMAGE_DATA_DIRECTORY    SecurityDataDirectory;
 } PE_COFF_LOADER_IMAGE_CONTEXT;
 
 /**

--- a/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
+++ b/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
@@ -76,6 +76,14 @@ PeCoffLoaderGetPeHeader (
   EFI_IMAGE_SECTION_HEADER  SectionHeader;
 
   //
+  // Zero the security data directory. It is populated below only if the image
+  // has a non-empty EFI_IMAGE_DIRECTORY_ENTRY_SECURITY entry that passes
+  // bounds checking.
+  //
+  ImageContext->SecurityDataDirectory.VirtualAddress = 0;
+  ImageContext->SecurityDataDirectory.Size           = 0;
+
+  //
   // Read the DOS image header to check for its existence
   //
   Size     = sizeof (EFI_IMAGE_DOS_HEADER);
@@ -303,6 +311,16 @@ PeCoffLoaderGetPeHeader (
 
             return Status;
           }
+
+          //
+          // The security data directory exists and is within the image bounds. Record a copy of it
+          // in the image context so callers can locate the certificate data without re-parsing the headers.
+          //
+          CopyMem (
+            &ImageContext->SecurityDataDirectory,
+            &Hdr.Pe32->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY],
+            sizeof (EFI_IMAGE_DATA_DIRECTORY)
+            );
         }
       }
 
@@ -425,6 +443,16 @@ PeCoffLoaderGetPeHeader (
 
             return Status;
           }
+
+          //
+          // The security data directory exists and is within the image bounds. Record a copy of it
+          // in the image context so callers can locate the certificate data without re-parsing the headers.
+          //
+          CopyMem (
+            &ImageContext->SecurityDataDirectory,
+            &Hdr.Pe32Plus->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY],
+            sizeof (EFI_IMAGE_DATA_DIRECTORY)
+            );
         }
       }
 


### PR DESCRIPTION
# Description

Add a new field, SecurityDataDirectory, to PE_COFF_LOADER_IMAGE_CONTEXT that records the security data directory of the image. This occurs when PeCoffLoaderGetImageInfo is called.

This is to support DxeImageValidationLib changes in support of PQC by allowing us to remove all custom PECOFF parsing from the implementation.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A

## Integration Instructions

N/A
