### PR TITLE
BaseTools: Add RecommendedLibraryInstance Parsing and Fallback

### DIFF
--- a/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
+++ b/BaseTools/Source/Python/AutoGen/AutoGenWorker.py
@@ -216,6 +216,7 @@ class AutoGenWorkerInProcess(mp.Process):
             GlobalData.gModuleHashFile = dict()
             GlobalData.gFileHashDict = dict()
             GlobalData.gEnableGenfdsMultiThread = self.data_pipe.Get("EnableGenfdsMultiThread")
+            GlobalData.gUseRecommendedInstances = self.data_pipe.Get("UseRecommendedInstances")
             GlobalData.gPlatformFinalPcds = self.data_pipe.Get("gPlatformFinalPcds")
             GlobalData.file_lock = self.file_lock
             CommandTarget = self.data_pipe.Get("CommandTarget")

--- a/BaseTools/Source/Python/AutoGen/DataPipe.py
+++ b/BaseTools/Source/Python/AutoGen/DataPipe.py
@@ -170,4 +170,6 @@ class MemoryDataPipe(DataPipe):
 
         self.DataContainer = {"EnableGenfdsMultiThread":GlobalData.gEnableGenfdsMultiThread}
 
+        self.DataContainer = {"UseRecommendedInstances":GlobalData.gUseRecommendedInstances}
+
         self.DataContainer = {"gPlatformFinalPcds":GlobalData.gPlatformFinalPcds}

--- a/BaseTools/Source/Python/Common/GlobalData.py
+++ b/BaseTools/Source/Python/Common/GlobalData.py
@@ -120,6 +120,13 @@ gModuleCacheHit = None
 
 gEnableGenfdsMultiThread = True
 gSikpAutoGenCache = set()
+
+#
+# Build flag to allow the use of "## @RecommendedInstance" comments in INF files
+# as a fallback when a library class to instance mapping is missing in the DSC.
+#
+gUseRecommendedInstances = True
+
 # Common lock for the file access in multiple process AutoGens
 file_lock = None
 gStackCookieValues32 = []

--- a/BaseTools/Source/Python/Workspace/InfBuildData.py
+++ b/BaseTools/Source/Python/Workspace/InfBuildData.py
@@ -564,6 +564,30 @@ class InfBuildData(ModuleBuildClassObject):
                 RetVal[Lib] = None
         return RetVal
 
+    ## Retrieve the recommended library instances declared in the [LibraryClasses]
+    #  section(s) via "## @RecommendedInstance <PackageRelativePath>" comments.
+    #
+    #  @retval  An OrderedDict mapping a library class name to a PathClass that
+    #           points to the recommended library instance INF file.
+    #
+    @cached_property
+    def RecommendedInstances(self):
+        RetVal = OrderedDict()
+        RecordList = self._RawData[MODEL_EFI_LIBRARY_CLASS, self._Arch, self._Platform]
+        for Record in RecordList:
+            Lib = Record[0]
+            Instance = Record[2]
+            if not Instance:
+                continue
+            LibraryPath = PathClass(NormPath(Instance, self._Macros), GlobalData.gWorkspace, Arch=self._Arch)
+            # check the file validation
+            ErrorCode, ErrorInfo = LibraryPath.Validate('.inf')
+            if ErrorCode != 0:
+                EdkLogger.error('build', ErrorCode, File=self.MetaFile, Line=Record[-1],
+                                ExtraData=ErrorInfo)
+            RetVal[Lib] = LibraryPath
+        return RetVal
+
     ## Retrieve library names (for Edk.x style of modules)
     @cached_property
     def Libraries(self):

--- a/BaseTools/Source/Python/Workspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Workspace/MetaFileParser.py
@@ -36,6 +36,8 @@ from Common.DataType import TAB_COMMENT_EDK_START, TAB_COMMENT_EDK_END
 hexVersionPattern = re.compile(r'0[xX][\da-f-A-F]{5,8}')
 decVersionPattern = re.compile(r'\d+\.\d+')
 CODEPattern = re.compile(r"{CODE\([a-fA-F0-9Xx\{\},\s]*\)}")
+## RegEx for the "## @RecommendedInstance" comment used in INF [LibraryClasses] sections
+RecommendedInstancePattern = re.compile(r'^#+\s*@RecommendedInstance\s+(\S+)')
 
 ## A decorator used to parse macro definition
 def ParseMacro(Parser):
@@ -679,6 +681,18 @@ class InfParser(MetaFileParser):
                 Comments.append((Comment, Index + 1))
             if GlobalData.gOptions and GlobalData.gOptions.CheckUsage:
                 CheckInfComment(self._SectionType, Comments, str(self.MetaFile), Index + 1, self._ValueList)
+            #
+            # Capture the recommended library instance specified by a preceding
+            # "## @RecommendedInstance <PackageRelativePath>" comment in a
+            # [LibraryClasses] section. The resolved path is stored in Value3
+            # of the library class record so it can be used as a fallback when a
+            # library class to instance mapping is missing from the DSC file.
+            #
+            if self._SectionType == MODEL_EFI_LIBRARY_CLASS and self._ValueList[0]:
+                for Cmt, _ in Comments:
+                    Match = RecommendedInstancePattern.match(Cmt)
+                    if Match:
+                        self._ValueList[2] = ReplaceMacro(Match.group(1), self._Macros)
             #
             # Model, Value1, Value2, Value3, Arch, Platform, BelongsToItem=-1,
             # LineBegin=-1, ColumnBegin=-1, LineEnd=-1, ColumnEnd=-1, Enabled=-1

--- a/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
@@ -141,6 +141,21 @@ def GetModuleLibInstances(Module, Platform, BuildDatabase, Arch, Target, Toolcha
                 if LibraryPath is None:
                     LibraryPath = M.LibraryClasses.get(LibraryClassName)
                     if LibraryPath is None:
+                        # As a fallback, honor a "## @RecommendedInstance" comment
+                        # declared in the [LibraryClasses] section of the consuming
+                        # module/library INF when the DSC file is missing this
+                        # library class to instance mapping. This is enabled by
+                        # default; it can be disabled with --no-recommended-instances
+                        # to make a missing mapping fail the build.
+                        RecommendedInstance = M.RecommendedInstances.get(LibraryClassName)
+                        if RecommendedInstance is not None and GlobalData.gUseRecommendedInstances:
+                            EdkLogger.warn("build",
+                                           f"Instance of library class [{LibraryClassName}] is not found in the DSC for"
+                                           f" module [{Module}]; using @RecommendedInstance [{RecommendedInstance}]"
+                                           f" declared in [{M}] instead.",
+                                           File=FileName)
+                            LibraryPath = RecommendedInstance
+                    if LibraryPath is None:
                         if not Module.LibraryClass:
                             EdkLogger.error("build", RESOURCE_NOT_AVAILABLE,
                                             f"Instance of library class [{LibraryClassName}] is not found for"

--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -741,6 +741,7 @@ class Build():
         GlobalData.gBinCacheSource = BuildOptions.BinCacheSource
         GlobalData.gEnableGenfdsMultiThread = not BuildOptions.NoGenfdsMultiThread
         GlobalData.gDisableIncludePathCheck = BuildOptions.DisableIncludePathCheck
+        GlobalData.gUseRecommendedInstances = BuildOptions.UseRecommendedInstances and not BuildOptions.NoRecommendedInstances
 
         if GlobalData.gBinCacheDest and not GlobalData.gUseHashCache:
             EdkLogger.error("build", OPTION_NOT_SUPPORTED, ExtraData="--binary-destination must be used together with --hash.")

--- a/BaseTools/Source/Python/build/buildoptions.py
+++ b/BaseTools/Source/Python/build/buildoptions.py
@@ -103,4 +103,10 @@ class MyOptionParser():
         Parser.add_option("--genfds-multi-thread", action="store_true", dest="GenfdsMultiThread", default=True, help="Enable GenFds multi thread to generate ffs file.")
         Parser.add_option("--no-genfds-multi-thread", action="store_true", dest="NoGenfdsMultiThread", default=False, help="Disable GenFds multi thread to generate ffs file.")
         Parser.add_option("--disable-include-path-check", action="store_true", dest="DisableIncludePathCheck", default=False, help="Disable the include path check for outside of package.")
+        Parser.add_option("--use-recommended-instances", action="store_true", dest="UseRecommendedInstances", default=True,
+            help="When a library class to instance mapping is missing in the DSC file, use the '## @RecommendedInstance' "\
+                 "instance declared in the consuming INF file (if any) and emit a warning, instead of failing the build. This is the default.")
+        Parser.add_option("--no-recommended-instances", action="store_true", dest="NoRecommendedInstances", default=False,
+            help="Disable the use of '## @RecommendedInstance' comments as a fallback and fail the build when a library "\
+                 "class to instance mapping is missing in the DSC file.")
         self.BuildOption, self.BuildTarget = Parser.parse_args()

--- a/BaseTools/Tests/PythonToolsTests.py
+++ b/BaseTools/Tests/PythonToolsTests.py
@@ -20,6 +20,8 @@ def TheTestSuite():
     suites.append(CheckPythonSyntax.TheTestSuite())
     import CheckUnicodeSourceFiles
     suites.append(CheckUnicodeSourceFiles.TheTestSuite())
+    import TestRecommendedInstance
+    suites.append(TestRecommendedInstance.TheTestSuite())
     return unittest.TestSuite(suites)
 
 if __name__ == '__main__':

--- a/BaseTools/Tests/TestRecommendedInstance.py
+++ b/BaseTools/Tests/TestRecommendedInstance.py
@@ -1,0 +1,186 @@
+## @file
+# Unit tests for parsing the "## @RecommendedInstance" comment used in the
+# [LibraryClasses] section of an EDK II INF file.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+
+#
+# Make sure the BaseTools Python modules can be imported whether this test is
+# run standalone, via pytest, or through the BaseTools test suite runner.
+#
+BaseToolsPythonDir = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), '..', 'Source', 'Python'))
+if BaseToolsPythonDir not in sys.path:
+    sys.path.insert(0, BaseToolsPythonDir)
+
+import Common.GlobalData as GlobalData
+from Common.Misc import PathClass
+from CommonDataClass.DataClass import (
+    MODEL_FILE_INF,
+    MODEL_EFI_LIBRARY_CLASS,
+)
+from Workspace.MetaFileParser import InfParser, RecommendedInstancePattern
+from Workspace.MetaFileTable import MetaFileStorage
+
+
+class _FakeDB(object):
+    """A minimal stand-in for the BaseTools workspace database.
+
+    MetaFileTable only requires an object exposing a ``TblFile`` list, so the
+    parser can be exercised without a real SQLite database.
+    """
+
+    def __init__(self):
+        self.TblFile = []
+
+
+class TestRecommendedInstancePattern(unittest.TestCase):
+    """Tests for the RecommendedInstancePattern regular expression."""
+
+    def test_double_hash_with_macro(self):
+        Match = RecommendedInstancePattern.match(
+            "## @RecommendedInstance $(MDE)/BaseDebugLibNull/BaseDebugLibNull.inf")
+        self.assertIsNotNone(Match)
+        self.assertEqual(
+            Match.group(1), "$(MDE)/BaseDebugLibNull/BaseDebugLibNull.inf")
+
+    def test_single_hash(self):
+        Match = RecommendedInstancePattern.match(
+            "#  @RecommendedInstance MdePkg/Library/BaseLib/BaseLib.inf")
+        self.assertIsNotNone(Match)
+        self.assertEqual(Match.group(1), "MdePkg/Library/BaseLib/BaseLib.inf")
+
+    def test_trailing_whitespace_is_ignored(self):
+        Match = RecommendedInstancePattern.match(
+            "## @RecommendedInstance   MdePkg/Library/UefiLib/UefiLib.inf   ")
+        self.assertIsNotNone(Match)
+        self.assertEqual(Match.group(1), "MdePkg/Library/UefiLib/UefiLib.inf")
+
+    def test_non_recommended_comment(self):
+        self.assertIsNone(
+            RecommendedInstancePattern.match("# Just a normal comment"))
+
+    def test_missing_path(self):
+        self.assertIsNone(
+            RecommendedInstancePattern.match("## @RecommendedInstance"))
+
+
+class TestRecommendedInstanceParsing(unittest.TestCase):
+    """Tests that InfParser stores the recommended instance in the library
+    class record's Value3 field."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._SavedWorkspace = GlobalData.gWorkspace
+        GlobalData.gWorkspace = self.tmpdir
+
+    def tearDown(self):
+        GlobalData.gWorkspace = self._SavedWorkspace
+        if os.path.exists(self.tmpdir):
+            shutil.rmtree(self.tmpdir)
+
+    def _ParseInf(self, Content):
+        InfPath = os.path.join(self.tmpdir, "TestModule.inf")
+        with open(InfPath, "w") as InfFile:
+            InfFile.write(Content)
+
+        MetaFile = PathClass(InfPath)
+        Table = MetaFileStorage(_FakeDB(), MetaFile, MODEL_FILE_INF,
+                                Temporary=False)
+        Parser = InfParser(MetaFile, MODEL_FILE_INF, "COMMON", Table)
+        Parser.Start()
+
+        # Return a dict mapping library class name -> recommended instance
+        # (Value3) for every parsed [LibraryClasses] record.
+        RetVal = {}
+        for Row in Table.CurrentContent:
+            # Row layout: [ID, Model, Value1, Value2, Value3, Scope1, ...]
+            if Row[0] >= 0 and Row[1] == MODEL_EFI_LIBRARY_CLASS:
+                RetVal[Row[2]] = Row[4]
+        return RetVal
+
+    _INF_TEMPLATE = """## @file
+# Test module
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = TestModule
+  FILE_GUID                      = 12345678-1234-1234-1234-123456789abc
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+
+[Sources]
+  TestModule.c
+
+[LibraryClasses]
+{Body}
+"""
+
+    def _Parse(self, Body):
+        return self._ParseInf(self._INF_TEMPLATE.format(Body=Body))
+
+    def test_macro_is_resolved(self):
+        Result = self._Parse(
+            "  DEFINE MDE = MdePkg/Library\n"
+            "  ## @RecommendedInstance $(MDE)/BaseDebugLibNull/BaseDebugLibNull.inf\n"
+            "  DebugLib\n")
+        self.assertEqual(
+            Result.get("DebugLib"),
+            "MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf")
+
+    def test_no_recommended_instance(self):
+        Result = self._Parse("  UefiDriverModelLib\n")
+        self.assertEqual(Result.get("UefiDriverModelLib"), "")
+
+    def test_comment_binds_to_following_class(self):
+        # The @RecommendedInstance comment sits between two library classes
+        # and must be associated with the one that follows it (BaseLib), not
+        # the one that precedes it (UefiDriverModelLib).
+        Result = self._Parse(
+            "  UefiDriverModelLib\n"
+            "  ## @RecommendedInstance MdePkg/Library/BaseLib/BaseLib.inf\n"
+            "  BaseLib\n")
+        self.assertEqual(Result.get("UefiDriverModelLib"), "")
+        self.assertEqual(
+            Result.get("BaseLib"), "MdePkg/Library/BaseLib/BaseLib.inf")
+
+    def test_multiple_recommended_instances(self):
+        Result = self._Parse(
+            "  DEFINE MDE = MdePkg/Library\n"
+            "  ## @RecommendedInstance $(MDE)/BaseDebugLibNull/BaseDebugLibNull.inf\n"
+            "  DebugLib\n"
+            "  UefiDriverModelLib\n"
+            "  ## @RecommendedInstance MdePkg/Library/BaseLib/BaseLib.inf\n"
+            "  BaseLib\n")
+        self.assertEqual(
+            Result.get("DebugLib"),
+            "MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf")
+        self.assertEqual(Result.get("UefiDriverModelLib"), "")
+        self.assertEqual(
+            Result.get("BaseLib"), "MdePkg/Library/BaseLib/BaseLib.inf")
+
+    def test_ordinary_comment_is_ignored(self):
+        Result = self._Parse(
+            "  ## This is just a description, not a recommendation\n"
+            "  DebugLib\n")
+        self.assertEqual(Result.get("DebugLib"), "")
+
+
+def TheTestSuite():
+    suites = [
+        unittest.TestLoader().loadTestsFromTestCase(TestRecommendedInstancePattern),
+        unittest.TestLoader().loadTestsFromTestCase(TestRecommendedInstanceParsing),
+    ]
+    return unittest.TestSuite(suites)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

The edk2 INF spec defines a [recommended library instance comment](https://tianocore-docs.github.io/edk2-InfSpecification/draft/3_edk_ii_inf_file_format/36_%5Blibraryclasses%5D_sections.html#36-libraryclasses-sections) that can be made in an INF to specify which library instance is intended to be used for this module.

Today, BaseTools does not parse this or take action with it. This commit parses the comment (if present) and if a DSC does not contain a library class mapping for that library already, it will fallback to using the recommended library class and print a warning. This functionality can be disabled.

This addresses the fact that edk2 has one abstraction (Library Classes) for two different use cases:
- Single instance modularization of code to share across components
- Platform abstraction points

This causes churn for downstream consumers who must update DSCs to include new library dependencies, even for the first case where there is only ever intended to be one instance used, for example SafeIntLib. This prevents adding these single instance library dependencies becoming breaking changes. Platforms will continue to build with the correct functionality.

This design came from a suggestion from @mdkinney: https://github.com/tianocore/edk2/pull/12086#issuecomment-4031914231.

There are tradeoffs to this design that I am open to discussing different paths:
- This design uses an existing INF spec definition which is beneficial.
- It is odd that a comment can define behavior for the build, it would make more sense in a defined section.
- By having the INF specify the recommended library instance, every INF must then define the recommended instance. I.e. for BaseLib, every single INF would have to update to this to get the benefit (note, this is not required by any means, this mechanism is intended to ease breaking change integration into platforms, not completely remove library classes from DSCs). It would make more sense for a DEC to specify the recommended instance for the library class, that centralizes it one place. However, that mechanism is not defined.
- By having each INF define the recommended instance, it does allow for each module to differentiate here. For BaseLib, we would want all modules to have the same instance, but for MemoryAllocationLib, you may want DxeCore to specify MemoryAllocationLibOptDxe and PeiCore to specify MemoryAllocationLibOptPei, for example.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested with the added tests and doing tests like:

<img width="986" height="620" alt="image" src="https://github.com/user-attachments/assets/ac27db23-4392-4788-b05f-2a26b4c86acc" />

When run with existing BaseTools (or the recommended library instance feature disabled) gives:

<img width="1813" height="74" alt="image" src="https://github.com/user-attachments/assets/46267596-5ffd-4bd9-a636-7a3664a34956" />

With the feature enabled it builds and reports:

```text
INFO - /workspaces/edk2/MdeModulePkg/MdeModulePkg.dsc(...): warning: Instance of library class [ImagePropertiesRecordLib] is not found in the DSC for module [/workspaces/edk2/MdeModulePkg/Core/Dxe/DxeMain.inf]; using @RecommendedInstance [/workspaces/edk2/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf] declared in [/workspaces/edk2/MdeModulePkg/Core/Dxe/DxeMain.inf] instead.
INFO - build...
INFO - /workspaces/edk2/MdeModulePkg/MdeModulePkg.dsc(...): warning: Instance of library class [ImagePropertiesRecordLib] is not found in the DSC for module [/workspaces/edk2/MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf]; using @RecommendedInstance [/workspaces/edk2/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf] declared in [/workspaces/edk2/MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf] instead.
```

## Integration Instructions

Rebuild BaseTools to gain this new functionality. `--no-recommended-instances` can be passed to the build to disable this functionality. INFs may now add the recommend instance comment defined here: https://tianocore-docs.github.io/edk2-InfSpecification/draft/3_edk_ii_inf_file_format/36_%5Blibraryclasses%5D_sections.html#36-libraryclasses-sections.