### PR TITLE
BaseTools/Conf: Do not copy PDB files for GCC/CLANGDWARF

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -419,7 +419,6 @@
         $(CP) ${dst} $(DEBUG_DIR)
         $(CP) ${dst} $(BIN_DIR)(+)$(MODULE_NAME_GUID).efi
         -$(CP) $(DEBUG_DIR)(+)*.map $(OUTPUT_DIR)
-        -$(CP) $(DEBUG_DIR)(+)*.pdb $(OUTPUT_DIR)
 
     <Command.XCODE>
         # tool to convert Mach-O to PE/COFF


### PR DESCRIPTION
# Description

Commit 20233f156c2e merged the CLANGDWARF and GCC rules used to convert ELF images to PE/COFF images. It also added an attempt to copy PDB files to the combined rule.

Neither GCC nor CLANGDWARF produces PDB files. Consequently, each applicable module build invokes `cp` with an unmatched `*.pdb` pattern and prints an ignored error:

```text
cp: cannot stat '.../DEBUG/*.pdb': No such file or directory
make: [...] Error 1 (ignored)
```

Remove the PDB copy from the GCC/CLANGDWARF rule. The existing MSFT/INTEL/CLANGPDB rule continues to copy PDB files.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Rebuilt a LoongArch64 module with GCC before and after the change. The ignored copy error was eliminated and the generated EFI image was unchanged.
- Built `ArmVirtPkg/ArmVirtQemu.dsc` for AArch64 with CLANGDWARF/NOOPT. The original rule attempted 95 PDB copies. Rebuilding `EnglishDxe` without the PDB copy eliminated the ignored error and produced the same EFI image.
- `python3 BaseTools/Scripts/PatchCheck.py HEAD`

## Integration Instructions

N/A
