### PR TITLE
Add Memory Protections Hob

### DIFF
--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -91,6 +91,8 @@
 
   OemMiscLib|ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLibNull.inf
 
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -92,6 +92,8 @@
 
   OemMiscLib|ArmPkg/Universal/Smbios/OemMiscLibNull/OemMiscLibNull.inf
 
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.c
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.c
@@ -12,6 +12,7 @@
 #include <Guid/IdleLoopEvent.h>
 
 #include <Library/MemoryAllocationLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
 
 BOOLEAN  mIsFlushingGCD;
 
@@ -301,7 +302,6 @@ RemapUnusedMemoryNx (
   VOID
   )
 {
-  UINT64                 TestBit;
   UINTN                  MemoryMapSize;
   UINTN                  MapKey;
   UINTN                  DescriptorSize;
@@ -311,8 +311,7 @@ RemapUnusedMemoryNx (
   EFI_MEMORY_DESCRIPTOR  *MemoryMapEnd;
   EFI_STATUS             Status;
 
-  TestBit = LShiftU64 (1, EfiBootServicesData);
-  if ((PcdGet64 (PcdDxeNxMemoryProtectionPolicy) & TestBit) == 0) {
+  if (gDxeMps.NxProtectionPolicy.Fields.EfiConventionalMemory == 0) {
     return;
   }
 

--- a/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
+++ b/ArmPkg/Drivers/CpuDxe/CpuDxe.inf
@@ -49,6 +49,7 @@
   PeCoffGetEntryPointLib
   UefiDriverEntryPoint
   UefiLib
+  DxeMemoryProtectionHobLib
 
 [Protocols]
   gEfiCpuArchProtocolGuid
@@ -62,7 +63,6 @@
   gEfiVectorHandoffTableGuid
 
 [Pcd.common]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy
 
 [FeaturePcd.common]
   gArmTokenSpaceGuid.PcdRemapUnusedMemoryNx

--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -70,6 +70,7 @@ DEFINE FD_SIZE_IN_MB    = 3
   UefiDecompressLib|MdePkg/Library/BaseUefiDecompressLib/BaseUefiDecompressLib.inf
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   HobLib|ArmVirtPkg/Library/ArmVirtDxeHobLib/ArmVirtDxeHobLib.inf

--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -93,6 +93,7 @@ DEFINE FD_SIZE_IN_MB    = 3
   UefiDecompressLib|MdePkg/Library/BaseUefiDecompressLib/BaseUefiDecompressLib.inf
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   ImagePropertiesRecordLib|MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
   HobLib|ArmVirtPkg/Library/ArmVirtDxeHobLib/ArmVirtDxeHobLib.inf

--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -157,6 +157,7 @@ DEFINE FD_SIZE_IN_MB    = 3
 
   PlatformPeiLib|ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
   MemoryInitPeiLib|ArmVirtPkg/Library/ArmVirtMemoryInitPeiLib/ArmVirtMemoryInitPeiLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   ResetSystemLib|ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
 
   # ARM PL031 RTC Driver

--- a/ArmVirtPkg/Library/KvmtoolPlatformPeiLib/KvmtoolPlatformPeiLib.c
+++ b/ArmVirtPkg/Library/KvmtoolPlatformPeiLib/KvmtoolPlatformPeiLib.c
@@ -19,6 +19,7 @@
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PeiServicesLib.h>
+#include <Library/PlatformMemoryProtectionLib.h>
 
 /** Initialise Platform HOBs
 
@@ -82,6 +83,13 @@ PlatformPeim (
     ASSERT (0);
     return (EFI_STATUS)RetStatus;
   }
+
+  //
+  // Build the DXE memory protection settings HOB from fw_cfg. If no fw_cfg
+  // selector is present (or fw_cfg is not available on this platform), no HOB
+  // is produced and the memory protection PCDs are used as a fallback.
+  //
+  PlatformBuildMemoryProtectionSettingsHob ();
 
   return EFI_SUCCESS;
 }

--- a/ArmVirtPkg/Library/KvmtoolPlatformPeiLib/KvmtoolPlatformPeiLib.inf
+++ b/ArmVirtPkg/Library/KvmtoolPlatformPeiLib/KvmtoolPlatformPeiLib.inf
@@ -32,6 +32,7 @@
   FdtLib
   PcdLib
   PeiServicesLib
+  PlatformMemoryProtectionLib
 
 [FixedPcd]
   gArmTokenSpaceGuid.PcdFvSize

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c
@@ -17,6 +17,7 @@
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PeiServicesLib.h>
+#include <Library/PlatformMemoryProtectionLib.h>
 #include <Library/FdtSerialPortAddressLib.h>
 #include <Library/QemuFwCfgSimpleParserLib.h>
 
@@ -295,6 +296,13 @@ PlatformPeim (
   }
 
   BuildFvHob (PcdGet64 (PcdFvBaseAddress), PcdGet32 (PcdFvSize));
+
+  //
+  // Build the DXE memory protection settings HOB from fw_cfg. If no fw_cfg
+  // selector is present (or fw_cfg is not available on this platform), no HOB
+  // is produced and the memory protection PCDs are used as a fallback.
+  //
+  PlatformBuildMemoryProtectionSettingsHob ();
 
   return EFI_SUCCESS;
 }

--- a/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
+++ b/ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.inf
@@ -39,6 +39,7 @@
   PcdLib
   PeiServicesLib
   QemuFwCfgSimpleParserLib
+  PlatformMemoryProtectionLib
 
 [FixedPcd]
   gArmTokenSpaceGuid.PcdFvSize

--- a/EmulatorPkg/EmulatorPkg.dsc
+++ b/EmulatorPkg/EmulatorPkg.dsc
@@ -158,6 +158,7 @@
   OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   TlsLib|CryptoPkg/Library/TlsLib/TlsLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   PlatformSecureLib|SecurityPkg/Library/PlatformSecureLibNull/PlatformSecureLibNull.inf

--- a/EmulatorPkg/EmulatorPkg.dsc
+++ b/EmulatorPkg/EmulatorPkg.dsc
@@ -160,6 +160,7 @@
   OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
   TlsLib|CryptoPkg/Library/TlsLib/TlsLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   PlatformSecureLib|SecurityPkg/Library/PlatformSecureLibNull/PlatformSecureLibNull.inf

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -85,6 +85,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugAgentLib.h>
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/OrderedCollectionLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
 
 #include <MemoryBin.h>
 

--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -97,6 +97,7 @@
   PcdLib
   ImagePropertiesRecordLib
   OrderedCollectionLib
+  DxeMemoryProtectionHobLib
 
 [Guids]
   gEfiEventMemoryMapChangeGuid                  ## PRODUCES             ## Event
@@ -126,6 +127,7 @@
   gEfiMemoryAttributesTableGuid                 ## SOMETIMES_PRODUCES   ## SystemTable
   gEfiEndOfDxeEventGroupGuid                    ## SOMETIMES_CONSUMES   ## Event
   gEfiHobMemoryAllocStackGuid                   ## SOMETIMES_CONSUMES   ## SystemTable
+  gDxeMemoryProtectionSettingsGuid              ## CONSUMES             ## HOB
 
 [Ppis]
   gEfiVectorHandoffInfoPpiGuid                  ## UNDEFINED # HOB
@@ -183,13 +185,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryProfileMemoryType                 ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryProfilePropertyMask               ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryProfileDriverPath                 ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdImageProtectionPolicy                   ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy             ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask        ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPageType                       ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPoolType                       ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask                   ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                           ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdFwVolDxeMaxEncapsulationDepth           ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdImageLargeAddressLoad                   ## CONSUMES
 

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
@@ -553,7 +553,7 @@ UnsetGuardPage (
   // memory.
   //
   Attributes = 0;
-  if ((PcdGet64 (PcdDxeNxMemoryProtectionPolicy) & (1 << EfiConventionalMemory)) != 0) {
+  if (gDxeMps.NxProtectionPolicy.Fields.EfiConventionalMemory) {
     Attributes |= EFI_MEMORY_XP;
   }
 
@@ -590,38 +590,17 @@ IsMemoryTypeToGuard (
   IN UINT8              PageOrPool
   )
 {
-  UINT64  TestBit;
-  UINT64  ConfigBit;
-
   if (AllocateType == AllocateAddress) {
     return FALSE;
   }
 
-  if ((PcdGet8 (PcdHeapGuardPropertyMask) & PageOrPool) == 0) {
-    return FALSE;
+  if ((PageOrPool == GUARD_HEAP_TYPE_POOL) && gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard) {
+    return GetDxeMemoryTypeSettingFromBitfield (MemoryType, gDxeMps.HeapGuardPoolType);
+  } else if ((PageOrPool == GUARD_HEAP_TYPE_PAGE) && gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) {
+    return GetDxeMemoryTypeSettingFromBitfield (MemoryType, gDxeMps.HeapGuardPageType);
   }
 
-  if (PageOrPool == GUARD_HEAP_TYPE_POOL) {
-    ConfigBit = PcdGet64 (PcdHeapGuardPoolType);
-  } else if (PageOrPool == GUARD_HEAP_TYPE_PAGE) {
-    ConfigBit = PcdGet64 (PcdHeapGuardPageType);
-  } else {
-    ConfigBit = (UINT64)-1;
-  }
-
-  if ((UINT32)MemoryType >= MEMORY_TYPE_OS_RESERVED_MIN) {
-    TestBit = BIT63;
-  } else if ((UINT32)MemoryType >= MEMORY_TYPE_OEM_RESERVED_MIN) {
-    TestBit = BIT62;
-  } else if (MemoryType < EfiMaxMemoryType) {
-    TestBit = LShiftU64 (1, MemoryType);
-  } else if (MemoryType == EfiMaxMemoryType) {
-    TestBit = (UINT64)-1;
-  } else {
-    TestBit = 0;
-  }
-
-  return ((ConfigBit & TestBit) != 0);
+  return FALSE;
 }
 
 /**
@@ -675,7 +654,14 @@ IsHeapGuardEnabled (
   UINT8  GuardType
   )
 {
-  return IsMemoryTypeToGuard (EfiMaxMemoryType, AllocateAnyPages, GuardType);
+  if ((((GuardType & GUARD_HEAP_TYPE_PAGE) == GUARD_HEAP_TYPE_PAGE) && gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) ||
+      (((GuardType & GUARD_HEAP_TYPE_POOL) == GUARD_HEAP_TYPE_POOL) && gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard) ||
+      (((GuardType & GUARD_HEAP_TYPE_FREED) == GUARD_HEAP_TYPE_FREED) && gDxeMps.HeapGuardPolicy.Fields.UefiFreedMemoryGuard))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 /**
@@ -851,7 +837,7 @@ AdjustMemoryS (
   // indicated to put the pool near the Tail Guard, we need extra bytes to
   // make sure alignment of the returned pool address.
   //
-  if ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) == 0) {
+  if (gDxeMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_TAIL) {
     *SizeRequested = ALIGN_VALUE (*SizeRequested, 8);
   }
 
@@ -1052,7 +1038,7 @@ AdjustPoolHeadA (
   IN UINTN                 Size
   )
 {
-  if ((Memory == 0) || ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) != 0)) {
+  if ((Memory == 0) || (gDxeMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_HEAD)) {
     //
     // Pool head is put near the head Guard
     //
@@ -1083,7 +1069,7 @@ AdjustPoolHeadF (
   IN UINTN                 Size
   )
 {
-  if ((Memory == 0) || ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) != 0)) {
+  if ((Memory == 0) || (gDxeMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_HEAD)) {
     //
     // Pool head is put near the head Guard
     //

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
@@ -553,7 +553,7 @@ UnsetGuardPage (
   // memory.
   //
   Attributes = 0;
-  if ((PcdGet64 (PcdDxeNxMemoryProtectionPolicy) & (1 << EfiConventionalMemory)) != 0) {
+  if (gDxeMps.NxProtectionPolicy.Fields.EfiConventionalMemory) {
     Attributes |= EFI_MEMORY_XP;
   }
 
@@ -590,38 +590,17 @@ IsMemoryTypeToGuard (
   IN UINT8              PageOrPool
   )
 {
-  UINT64  TestBit;
-  UINT64  ConfigBit;
-
   if (AllocateType == AllocateAddress) {
     return FALSE;
   }
 
-  if ((PcdGet8 (PcdHeapGuardPropertyMask) & PageOrPool) == 0) {
-    return FALSE;
+  if ((PageOrPool == GUARD_HEAP_TYPE_POOL) && gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard) {
+    return GetDxeMemoryTypeSettingFromBitField (MemoryType, gDxeMps.HeapGuardPoolType);
+  } else if ((PageOrPool == GUARD_HEAP_TYPE_PAGE) && gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) {
+    return GetDxeMemoryTypeSettingFromBitField (MemoryType, gDxeMps.HeapGuardPageType);
   }
 
-  if (PageOrPool == GUARD_HEAP_TYPE_POOL) {
-    ConfigBit = PcdGet64 (PcdHeapGuardPoolType);
-  } else if (PageOrPool == GUARD_HEAP_TYPE_PAGE) {
-    ConfigBit = PcdGet64 (PcdHeapGuardPageType);
-  } else {
-    ConfigBit = (UINT64)-1;
-  }
-
-  if ((UINT32)MemoryType >= MEMORY_TYPE_OS_RESERVED_MIN) {
-    TestBit = BIT63;
-  } else if ((UINT32)MemoryType >= MEMORY_TYPE_OEM_RESERVED_MIN) {
-    TestBit = BIT62;
-  } else if (MemoryType < EfiMaxMemoryType) {
-    TestBit = LShiftU64 (1, MemoryType);
-  } else if (MemoryType == EfiMaxMemoryType) {
-    TestBit = (UINT64)-1;
-  } else {
-    TestBit = 0;
-  }
-
-  return ((ConfigBit & TestBit) != 0);
+  return FALSE;
 }
 
 /**
@@ -675,7 +654,14 @@ IsHeapGuardEnabled (
   UINT8  GuardType
   )
 {
-  return IsMemoryTypeToGuard (EfiMaxMemoryType, AllocateAnyPages, GuardType);
+  if ((((GuardType & GUARD_HEAP_TYPE_PAGE) == GUARD_HEAP_TYPE_PAGE) && gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) ||
+      (((GuardType & GUARD_HEAP_TYPE_POOL) == GUARD_HEAP_TYPE_POOL) && gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard) ||
+      (((GuardType & GUARD_HEAP_TYPE_FREED) == GUARD_HEAP_TYPE_FREED) && gDxeMps.HeapGuardPolicy.Fields.UefiFreedMemoryGuard))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 /**
@@ -851,7 +837,7 @@ AdjustMemoryS (
   // indicated to put the pool near the Tail Guard, we need extra bytes to
   // make sure alignment of the returned pool address.
   //
-  if ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) == 0) {
+  if (gDxeMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_TAIL) {
     *SizeRequested = ALIGN_VALUE (*SizeRequested, 8);
   }
 
@@ -1052,7 +1038,7 @@ AdjustPoolHeadA (
   IN UINTN                 Size
   )
 {
-  if ((Memory == 0) || ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) != 0)) {
+  if ((Memory == 0) || (gDxeMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_HEAD)) {
     //
     // Pool head is put near the head Guard
     //
@@ -1083,7 +1069,7 @@ AdjustPoolHeadF (
   IN UINTN                 Size
   )
 {
-  if ((Memory == 0) || ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) != 0)) {
+  if ((Memory == 0) || (gDxeMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_HEAD)) {
     //
     // Pool head is put near the head Guard
     //

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.h
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.h
@@ -474,17 +474,3 @@ PromoteGuardedFreePages (
   );
 
 extern BOOLEAN  mOnGuarding;
-
-//
-// The heap guard system does not support non-EFI_PAGE_SIZE alignments.
-// Architectures that require larger RUNTIME_PAGE_ALLOCATION_GRANULARITY
-// cannot have EfiRuntimeServicesCode, EfiRuntimeServicesData, EfiReservedMemoryType,
-// and EfiACPIMemoryNVS guarded. OSes do not map guard pages anyway, so this is a
-// minimal loss. Not guarding prevents alignment mismatches
-//
-STATIC_ASSERT (
-  RUNTIME_PAGE_ALLOCATION_GRANULARITY == EFI_PAGE_SIZE ||
-  (((FixedPcdGet64 (PcdHeapGuardPageType) & 0x461) == 0) &&
-   ((FixedPcdGet64 (PcdHeapGuardPoolType) & 0x461) == 0)),
-  "Unsupported Heap Guard configuration on system with greater than EFI_PAGE_SIZE RUNTIME_PAGE_ALLOCATION_GRANULARITY"
-  );

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -193,7 +193,7 @@ CoreAddRange (
   // used for other purposes.
   //
   if ((Type == EfiConventionalMemory) && (Start == 0) && (End >= EFI_PAGE_SIZE - 1)) {
-    if ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT0) == 0) {
+    if (!gDxeMps.NullPointerDetectionPolicy.Fields.UefiNullDetection) {
       SetMem ((VOID *)(UINTN)Start, EFI_PAGE_SIZE, 0);
     }
   }

--- a/MdeModulePkg/Core/Dxe/Mem/Pool.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Pool.c
@@ -394,9 +394,8 @@ CoreAllocatePoolI (
   //
   // Adjust the size by the pool header & tail overhead
   //
-
   HasPoolTail = !(NeedGuard &&
-                  ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) == 0));
+                  gDxeMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_TAIL);
   PageAsPool = (IsHeapGuardEnabled (GUARD_HEAP_TYPE_FREED) && !mOnGuarding);
 
   //
@@ -732,7 +731,7 @@ CoreFreePoolI (
   IsGuarded = IsPoolTypeToGuard (Head->Type) &&
               IsMemoryGuarded ((EFI_PHYSICAL_ADDRESS)(UINTN)Head);
   HasPoolTail = !(IsGuarded &&
-                  ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) == 0));
+                  gDxeMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_TAIL);
   PageAsPool = (Head->Signature == POOLPAGE_HEAD_SIGNATURE);
 
   if (HasPoolTail) {

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -27,6 +27,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiDxe.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/DxeServicesTableLib.h>
@@ -61,8 +62,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define PREVIOUS_MEMORY_DESCRIPTOR(MemoryDescriptor, Size) \
   ((EFI_MEMORY_DESCRIPTOR *)((UINT8 *)(MemoryDescriptor) - (Size)))
-
-UINT32  mImageProtectionPolicy;
 
 extern LIST_ENTRY  mGcdMemorySpaceMap;
 
@@ -130,10 +129,12 @@ GetProtectionPolicyFromImageType (
   IN UINT32  ImageType
   )
 {
-  if ((ImageType & mImageProtectionPolicy) == 0) {
-    return DO_NOT_PROTECT;
-  } else {
+  if (((ImageType == IMAGE_UNKNOWN) && gDxeMps.ImageProtectionPolicy.Fields.ProtectImageFromUnknown) ||
+      ((ImageType == IMAGE_FROM_FV) && gDxeMps.ImageProtectionPolicy.Fields.ProtectImageFromFv))
+  {
     return PROTECT_IF_ALIGNED_ELSE_ALLOW;
+  } else {
+    return DO_NOT_PROTECT;
   }
 }
 
@@ -151,9 +152,13 @@ GetUefiImageProtectionPolicy (
   IN EFI_DEVICE_PATH_PROTOCOL   *LoadedImageDevicePath
   )
 {
-  BOOLEAN  InSmm;
-  UINT32   ImageType;
-  UINT32   ProtectionPolicy;
+  BOOLEAN                         InSmm;
+  UINT32                          ImageType;
+  UINT32                          ProtectionPolicy;
+  DXE_MEMORY_PROTECTION_SETTINGS  *Settings;
+  VOID                            *Hob;
+
+  Settings = NULL;
 
   //
   // Check SMM
@@ -171,6 +176,25 @@ GetUefiImageProtectionPolicy (
   // Check DevicePath
   //
   if (LoadedImage == gDxeCoreLoadedImage) {
+    // If the image is DxeCore, DxeMemoryProtectionHobLib entry point has not
+    // yet executed and so gDxeMps is not yet valid. Get the memory protection
+    // HOB directly and check if DxeCore should be protected.
+    Hob = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
+    if (Hob != NULL) {
+      Settings = (DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (Hob);
+      if (Settings->StructVersion == DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
+        // Valid settings
+      } else {
+        Settings = NULL;
+      }
+    }
+
+    if (Settings != NULL) {
+      if (Settings->ImageProtectionPolicy.Fields.ProtectImageFromFv == 1) {
+        return PROTECT_IF_ALIGNED_ELSE_ALLOW;
+      }
+    }
+
     ImageType = IMAGE_FROM_FV;
   } else {
     ImageType = GetImageType (LoadedImageDevicePath);
@@ -517,7 +541,7 @@ UnprotectUefiImage (
   IMAGE_PROPERTIES_RECORD  *ImageRecord;
   LIST_ENTRY               *ImageRecordLink;
 
-  if (PcdGet32 (PcdImageProtectionPolicy) != 0) {
+  if (gDxeMps.ImageProtectionPolicy.Data != 0) {
     for (ImageRecordLink = mProtectedImageRecordList.ForwardLink;
          ImageRecordLink != &mProtectedImageRecordList;
          ImageRecordLink = ImageRecordLink->ForwardLink)
@@ -554,21 +578,11 @@ GetPermissionAttributeForMemoryType (
   IN EFI_MEMORY_TYPE  MemoryType
   )
 {
-  UINT64  TestBit;
-
-  if ((UINT32)MemoryType >= MEMORY_TYPE_OS_RESERVED_MIN) {
-    TestBit = BIT63;
-  } else if ((UINT32)MemoryType >= MEMORY_TYPE_OEM_RESERVED_MIN) {
-    TestBit = BIT62;
-  } else {
-    TestBit = LShiftU64 (1, MemoryType);
-  }
-
-  if ((PcdGet64 (PcdDxeNxMemoryProtectionPolicy) & TestBit) != 0) {
+  if (GetDxeMemoryTypeSettingFromBitfield (MemoryType, gDxeMps.NxProtectionPolicy)) {
     return EFI_MEMORY_XP;
-  } else {
-    return 0;
   }
+
+  return 0;
 }
 
 /**
@@ -678,7 +692,7 @@ MergeMemoryMapForProtectionPolicy (
 
 /**
   Remove exec permissions from all regions whose type is identified by
-  PcdDxeNxMemoryProtectionPolicy.
+  gDxeMps.NxProtectionPolicy.
 **/
 STATIC
 VOID
@@ -733,7 +747,7 @@ InitializeDxeNxMemoryProtectionPolicy (
   ASSERT_EFI_ERROR (Status);
 
   StackBase = 0;
-  if (PcdGetBool (PcdCpuStackGuard)) {
+  if (gDxeMps.CpuStackGuard) {
     //
     // Get the base of stack from Hob.
     //
@@ -791,7 +805,7 @@ InitializeDxeNxMemoryProtectionPolicy (
       // enabled.
       //
       if ((MemoryMapEntry->PhysicalStart == 0) &&
-          (PcdGet8 (PcdNullPointerDetectionPropertyMask) != 0))
+          (gDxeMps.NullPointerDetectionPolicy.Data != 0))
       {
         ASSERT (MemoryMapEntry->NumberOfPages > 0);
         SetUefiImageMemoryAttributes (
@@ -809,7 +823,7 @@ InitializeDxeNxMemoryProtectionPolicy (
           ((StackBase >= MemoryMapEntry->PhysicalStart) &&
            (StackBase <  MemoryMapEntry->PhysicalStart +
             LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT))) &&
-          PcdGetBool (PcdCpuStackGuard))
+          gDxeMps.CpuStackGuard)
       {
         SetUefiImageMemoryAttributes (
           StackBase,
@@ -904,7 +918,7 @@ MemoryProtectionCpuArchProtocolNotify (
   //
   // Apply the memory protection policy on non-BScode/RTcode regions.
   //
-  if (PcdGet64 (PcdDxeNxMemoryProtectionPolicy) != 0) {
+  if (gDxeMps.NxProtectionPolicy.Data != 0) {
     InitializeDxeNxMemoryProtectionPolicy ();
   }
 
@@ -913,7 +927,7 @@ MemoryProtectionCpuArchProtocolNotify (
   //
   HeapGuardCpuArchProtocolNotify ();
 
-  if (mImageProtectionPolicy == 0) {
+  if (gDxeMps.ImageProtectionPolicy.Data == 0) {
     goto Done;
   }
 
@@ -976,7 +990,7 @@ MemoryProtectionExitBootServicesCallback (
   // delay setting protections on RT code pages until after SetVirtualAddressMap().
   // OS may set protection on RT based upon EFI_MEMORY_ATTRIBUTES_TABLE later.
   //
-  if (mImageProtectionPolicy != 0) {
+  if (gDxeMps.ImageProtectionPolicy.Data != 0) {
     for (Link = gRuntime->ImageHead.ForwardLink; Link != &gRuntime->ImageHead; Link = Link->ForwardLink) {
       RuntimeImage = BASE_CR (Link, EFI_RUNTIME_IMAGE_ENTRY, Link);
       SetUefiImageMemoryAttributes ((UINT64)(UINTN)RuntimeImage->ImageBase, ALIGN_VALUE (RuntimeImage->ImageSize, EFI_PAGE_SIZE), 0);
@@ -1081,8 +1095,6 @@ CoreInitializeMemoryProtection (
   EFI_EVENT   EndOfDxeEvent;
   VOID        *Registration;
 
-  mImageProtectionPolicy = PcdGet32 (PcdImageProtectionPolicy);
-
   InitializeListHead (&mProtectedImageRecordList);
 
   //
@@ -1150,9 +1162,7 @@ CoreInitializeMemoryProtection (
   //
   // Register a callback to disable NULL pointer detection at EndOfDxe
   //
-  if ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & (BIT0|BIT7))
-      == (BIT0|BIT7))
-  {
+  if (gDxeMps.NullPointerDetectionPolicy.Fields.DisableEndOfDxe) {
     Status = CoreCreateEventEx (
                EVT_NOTIFY_SIGNAL,
                TPL_NOTIFY,
@@ -1235,7 +1245,7 @@ ApplyMemoryProtectionPolicy (
   //
   // Check if a DXE memory protection policy has been configured
   //
-  if (PcdGet64 (PcdDxeNxMemoryProtectionPolicy) == 0) {
+  if (!gDxeMps.NxProtectionPolicy.Data) {
     return EFI_SUCCESS;
   }
 

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -27,6 +27,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiDxe.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/DxeServicesTableLib.h>
@@ -61,8 +62,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define PREVIOUS_MEMORY_DESCRIPTOR(MemoryDescriptor, Size) \
   ((EFI_MEMORY_DESCRIPTOR *)((UINT8 *)(MemoryDescriptor) - (Size)))
-
-UINT32  mImageProtectionPolicy;
 
 extern LIST_ENTRY  mGcdMemorySpaceMap;
 
@@ -130,10 +129,12 @@ GetProtectionPolicyFromImageType (
   IN UINT32  ImageType
   )
 {
-  if ((ImageType & mImageProtectionPolicy) == 0) {
-    return DO_NOT_PROTECT;
-  } else {
+  if (((ImageType == IMAGE_UNKNOWN) && gDxeMps.ImageProtectionPolicy.Fields.ProtectImageFromUnknown) ||
+      ((ImageType == IMAGE_FROM_FV) && gDxeMps.ImageProtectionPolicy.Fields.ProtectImageFromFv))
+  {
     return PROTECT_IF_ALIGNED_ELSE_ALLOW;
+  } else {
+    return DO_NOT_PROTECT;
   }
 }
 
@@ -151,9 +152,13 @@ GetUefiImageProtectionPolicy (
   IN EFI_DEVICE_PATH_PROTOCOL   *LoadedImageDevicePath
   )
 {
-  BOOLEAN  InSmm;
-  UINT32   ImageType;
-  UINT32   ProtectionPolicy;
+  BOOLEAN                         InSmm;
+  UINT32                          ImageType;
+  UINT32                          ProtectionPolicy;
+  DXE_MEMORY_PROTECTION_SETTINGS  *Settings;
+  VOID                            *Hob;
+
+  Settings = NULL;
 
   //
   // Check SMM
@@ -171,6 +176,25 @@ GetUefiImageProtectionPolicy (
   // Check DevicePath
   //
   if (LoadedImage == gDxeCoreLoadedImage) {
+    // If the image is DxeCore, DxeMemoryProtectionHobLib entry point has not
+    // yet executed and so gDxeMps is not yet valid. Get the memory protection
+    // HOB directly and check if DxeCore should be protected.
+    Hob = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
+    if (Hob != NULL) {
+      Settings = (DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (Hob);
+      if (Settings->StructVersion == DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
+        // Valid settings
+      } else {
+        Settings = NULL;
+      }
+    }
+
+    if (Settings != NULL) {
+      if (Settings->ImageProtectionPolicy.Fields.ProtectImageFromFv == 1) {
+        return PROTECT_IF_ALIGNED_ELSE_ALLOW;
+      }
+    }
+
     ImageType = IMAGE_FROM_FV;
   } else {
     ImageType = GetImageType (LoadedImageDevicePath);
@@ -517,7 +541,7 @@ UnprotectUefiImage (
   IMAGE_PROPERTIES_RECORD  *ImageRecord;
   LIST_ENTRY               *ImageRecordLink;
 
-  if (PcdGet32 (PcdImageProtectionPolicy) != 0) {
+  if (gDxeMps.ImageProtectionPolicy.Data != 0) {
     for (ImageRecordLink = mProtectedImageRecordList.ForwardLink;
          ImageRecordLink != &mProtectedImageRecordList;
          ImageRecordLink = ImageRecordLink->ForwardLink)
@@ -554,21 +578,11 @@ GetPermissionAttributeForMemoryType (
   IN EFI_MEMORY_TYPE  MemoryType
   )
 {
-  UINT64  TestBit;
-
-  if ((UINT32)MemoryType >= MEMORY_TYPE_OS_RESERVED_MIN) {
-    TestBit = BIT63;
-  } else if ((UINT32)MemoryType >= MEMORY_TYPE_OEM_RESERVED_MIN) {
-    TestBit = BIT62;
-  } else {
-    TestBit = LShiftU64 (1, MemoryType);
-  }
-
-  if ((PcdGet64 (PcdDxeNxMemoryProtectionPolicy) & TestBit) != 0) {
+  if (GetDxeMemoryTypeSettingFromBitField (MemoryType, gDxeMps.NxProtectionPolicy)) {
     return EFI_MEMORY_XP;
-  } else {
-    return 0;
   }
+
+  return 0;
 }
 
 /**
@@ -678,7 +692,7 @@ MergeMemoryMapForProtectionPolicy (
 
 /**
   Remove exec permissions from all regions whose type is identified by
-  PcdDxeNxMemoryProtectionPolicy.
+  gDxeMps.NxProtectionPolicy.
 **/
 STATIC
 VOID
@@ -733,7 +747,7 @@ InitializeDxeNxMemoryProtectionPolicy (
   ASSERT_EFI_ERROR (Status);
 
   StackBase = 0;
-  if (PcdGetBool (PcdCpuStackGuard)) {
+  if (gDxeMps.CpuStackGuard) {
     //
     // Get the base of stack from Hob.
     //
@@ -791,7 +805,7 @@ InitializeDxeNxMemoryProtectionPolicy (
       // enabled.
       //
       if ((MemoryMapEntry->PhysicalStart == 0) &&
-          (PcdGet8 (PcdNullPointerDetectionPropertyMask) != 0))
+          (gDxeMps.NullPointerDetectionPolicy.Data != 0))
       {
         ASSERT (MemoryMapEntry->NumberOfPages > 0);
         SetUefiImageMemoryAttributes (
@@ -809,7 +823,7 @@ InitializeDxeNxMemoryProtectionPolicy (
           ((StackBase >= MemoryMapEntry->PhysicalStart) &&
            (StackBase <  MemoryMapEntry->PhysicalStart +
             LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT))) &&
-          PcdGetBool (PcdCpuStackGuard))
+          gDxeMps.CpuStackGuard)
       {
         SetUefiImageMemoryAttributes (
           StackBase,
@@ -904,7 +918,7 @@ MemoryProtectionCpuArchProtocolNotify (
   //
   // Apply the memory protection policy on non-BScode/RTcode regions.
   //
-  if (PcdGet64 (PcdDxeNxMemoryProtectionPolicy) != 0) {
+  if (gDxeMps.NxProtectionPolicy.Data != 0) {
     InitializeDxeNxMemoryProtectionPolicy ();
   }
 
@@ -913,7 +927,7 @@ MemoryProtectionCpuArchProtocolNotify (
   //
   HeapGuardCpuArchProtocolNotify ();
 
-  if (mImageProtectionPolicy == 0) {
+  if (gDxeMps.ImageProtectionPolicy.Data == 0) {
     goto Done;
   }
 
@@ -976,7 +990,7 @@ MemoryProtectionExitBootServicesCallback (
   // delay setting protections on RT code pages until after SetVirtualAddressMap().
   // OS may set protection on RT based upon EFI_MEMORY_ATTRIBUTES_TABLE later.
   //
-  if (mImageProtectionPolicy != 0) {
+  if (gDxeMps.ImageProtectionPolicy.Data != 0) {
     for (Link = gRuntime->ImageHead.ForwardLink; Link != &gRuntime->ImageHead; Link = Link->ForwardLink) {
       RuntimeImage = BASE_CR (Link, EFI_RUNTIME_IMAGE_ENTRY, Link);
       SetUefiImageMemoryAttributes ((UINT64)(UINTN)RuntimeImage->ImageBase, ALIGN_VALUE (RuntimeImage->ImageSize, EFI_PAGE_SIZE), 0);
@@ -1081,8 +1095,6 @@ CoreInitializeMemoryProtection (
   EFI_EVENT   EndOfDxeEvent;
   VOID        *Registration;
 
-  mImageProtectionPolicy = PcdGet32 (PcdImageProtectionPolicy);
-
   InitializeListHead (&mProtectedImageRecordList);
 
   //
@@ -1150,9 +1162,7 @@ CoreInitializeMemoryProtection (
   //
   // Register a callback to disable NULL pointer detection at EndOfDxe
   //
-  if ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & (BIT0|BIT7))
-      == (BIT0|BIT7))
-  {
+  if (gDxeMps.NullPointerDetectionPolicy.Fields.DisableEndOfDxe) {
     Status = CoreCreateEventEx (
                EVT_NOTIFY_SIGNAL,
                TPL_NOTIFY,
@@ -1235,7 +1245,7 @@ ApplyMemoryProtectionPolicy (
   //
   // Check if a DXE memory protection policy has been configured
   //
-  if (PcdGet64 (PcdDxeNxMemoryProtectionPolicy) == 0) {
+  if (!gDxeMps.NxProtectionPolicy.Data) {
     return EFI_SUCCESS;
   }
 

--- a/MdeModulePkg/Core/PiSmmCore/HeapGuard.c
+++ b/MdeModulePkg/Core/PiSmmCore/HeapGuard.c
@@ -8,6 +8,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "HeapGuard.h"
 
+#include <Library/MmMemoryProtectionHobLib.h>
+
 //
 // Global to avoid infinite reentrance of memory allocation when updating
 // page table attributes, which may need allocating pages for new PDE/PTE.
@@ -595,36 +597,19 @@ IsMemoryTypeToGuard (
   IN UINT8              PageOrPool
   )
 {
-  UINT64  TestBit;
-  UINT64  ConfigBit;
-
-  if (  ((PcdGet8 (PcdHeapGuardPropertyMask) & PageOrPool) == 0)
-     || mOnGuarding
-     || (AllocateType == AllocateAddress))
-  {
+  if (mOnGuarding || (AllocateType == AllocateAddress)) {
     return FALSE;
   }
 
-  ConfigBit = 0;
-  if ((PageOrPool & GUARD_HEAP_TYPE_POOL) != 0) {
-    ConfigBit |= PcdGet64 (PcdHeapGuardPoolType);
+  if (((PageOrPool & GUARD_HEAP_TYPE_POOL) == GUARD_HEAP_TYPE_POOL) && gMmMps.HeapGuardPolicy.Fields.MmPoolGuard) {
+    return GetMmMemoryTypeSettingFromBitfield (MemoryType, gMmMps.HeapGuardPoolType);
   }
 
-  if ((PageOrPool & GUARD_HEAP_TYPE_PAGE) != 0) {
-    ConfigBit |= PcdGet64 (PcdHeapGuardPageType);
+  if (((PageOrPool & GUARD_HEAP_TYPE_PAGE) == GUARD_HEAP_TYPE_PAGE) && gMmMps.HeapGuardPolicy.Fields.MmPageGuard) {
+    return GetMmMemoryTypeSettingFromBitfield (MemoryType, gMmMps.HeapGuardPageType);
   }
 
-  if ((MemoryType == EfiRuntimeServicesData) ||
-      (MemoryType == EfiRuntimeServicesCode))
-  {
-    TestBit = LShiftU64 (1, MemoryType);
-  } else if (MemoryType == EfiMaxMemoryType) {
-    TestBit = (UINT64)-1;
-  } else {
-    TestBit = 0;
-  }
-
-  return ((ConfigBit & TestBit) != 0);
+  return FALSE;
 }
 
 /**
@@ -676,11 +661,7 @@ IsHeapGuardEnabled (
   VOID
   )
 {
-  return IsMemoryTypeToGuard (
-           EfiMaxMemoryType,
-           AllocateAnyPages,
-           GUARD_HEAP_TYPE_POOL|GUARD_HEAP_TYPE_PAGE
-           );
+  return gMmMps.HeapGuardPolicy.Fields.MmPageGuard || gMmMps.HeapGuardPolicy.Fields.MmPoolGuard;
 }
 
 /**
@@ -954,7 +935,7 @@ AdjustPoolHeadA (
   IN UINTN                 Size
   )
 {
-  if ((Memory == 0) || ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) != 0)) {
+  if ((Memory == 0) || (gMmMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_HEAD)) {
     //
     // Pool head is put near the head Guard
     //
@@ -980,7 +961,7 @@ AdjustPoolHeadF (
   IN EFI_PHYSICAL_ADDRESS  Memory
   )
 {
-  if ((Memory == 0) || ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) != 0)) {
+  if ((Memory == 0) || (gMmMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_HEAD)) {
     //
     // Pool head is put near the head Guard
     //

--- a/MdeModulePkg/Core/PiSmmCore/HeapGuard.c
+++ b/MdeModulePkg/Core/PiSmmCore/HeapGuard.c
@@ -8,6 +8,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "HeapGuard.h"
 
+#include <Library/MmMemoryProtectionHobLib.h>
+
 //
 // Global to avoid infinite reentrance of memory allocation when updating
 // page table attributes, which may need allocating pages for new PDE/PTE.
@@ -595,36 +597,19 @@ IsMemoryTypeToGuard (
   IN UINT8              PageOrPool
   )
 {
-  UINT64  TestBit;
-  UINT64  ConfigBit;
-
-  if (  ((PcdGet8 (PcdHeapGuardPropertyMask) & PageOrPool) == 0)
-     || mOnGuarding
-     || (AllocateType == AllocateAddress))
-  {
+  if (mOnGuarding || (AllocateType == AllocateAddress)) {
     return FALSE;
   }
 
-  ConfigBit = 0;
-  if ((PageOrPool & GUARD_HEAP_TYPE_POOL) != 0) {
-    ConfigBit |= PcdGet64 (PcdHeapGuardPoolType);
+  if (((PageOrPool & GUARD_HEAP_TYPE_POOL) == GUARD_HEAP_TYPE_POOL) && gMmMps.HeapGuardPolicy.Fields.MmPoolGuard) {
+    return GetMmMemoryTypeSettingFromBitField (MemoryType, gMmMps.HeapGuardPoolType);
   }
 
-  if ((PageOrPool & GUARD_HEAP_TYPE_PAGE) != 0) {
-    ConfigBit |= PcdGet64 (PcdHeapGuardPageType);
+  if (((PageOrPool & GUARD_HEAP_TYPE_PAGE) == GUARD_HEAP_TYPE_PAGE) && gMmMps.HeapGuardPolicy.Fields.MmPageGuard) {
+    return GetMmMemoryTypeSettingFromBitField (MemoryType, gMmMps.HeapGuardPageType);
   }
 
-  if ((MemoryType == EfiRuntimeServicesData) ||
-      (MemoryType == EfiRuntimeServicesCode))
-  {
-    TestBit = LShiftU64 (1, MemoryType);
-  } else if (MemoryType == EfiMaxMemoryType) {
-    TestBit = (UINT64)-1;
-  } else {
-    TestBit = 0;
-  }
-
-  return ((ConfigBit & TestBit) != 0);
+  return FALSE;
 }
 
 /**
@@ -676,11 +661,7 @@ IsHeapGuardEnabled (
   VOID
   )
 {
-  return IsMemoryTypeToGuard (
-           EfiMaxMemoryType,
-           AllocateAnyPages,
-           GUARD_HEAP_TYPE_POOL|GUARD_HEAP_TYPE_PAGE
-           );
+  return gMmMps.HeapGuardPolicy.Fields.MmPageGuard || gMmMps.HeapGuardPolicy.Fields.MmPoolGuard;
 }
 
 /**
@@ -954,7 +935,7 @@ AdjustPoolHeadA (
   IN UINTN                 Size
   )
 {
-  if ((Memory == 0) || ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) != 0)) {
+  if ((Memory == 0) || (gMmMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_HEAD)) {
     //
     // Pool head is put near the head Guard
     //
@@ -980,7 +961,7 @@ AdjustPoolHeadF (
   IN EFI_PHYSICAL_ADDRESS  Memory
   )
 {
-  if ((Memory == 0) || ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) != 0)) {
+  if ((Memory == 0) || (gMmMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_HEAD)) {
     //
     // Pool head is put near the head Guard
     //

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmCore.h
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmCore.h
@@ -54,6 +54,7 @@
 #include <Library/HobLib.h>
 #include <Library/SmmMemLib.h>
 #include <Library/SafeIntLib.h>
+#include <Library/MmMemoryProtectionHobLib.h>
 
 #include "PiSmmCorePrivateData.h"
 #include "HeapGuard.h"

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
@@ -62,6 +62,7 @@
   SmmMemLib
   SafeIntLib
   ImagePropertiesRecordLib
+  MmMemoryProtectionHobLib
 
 [Protocols]
   gEfiDxeSmmReadyToLockProtocolGuid             ## UNDEFINED # SmiHandlerRegister
@@ -94,9 +95,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryProfilePropertyMask           ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdMemoryProfileDriverPath             ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmiHandlerProfilePropertyMask       ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPageType                   ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPoolType                   ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask               ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable                        ## CONSUMES
 
 [Guids]

--- a/MdeModulePkg/Core/PiSmmCore/Pool.c
+++ b/MdeModulePkg/Core/PiSmmCore/Pool.c
@@ -262,7 +262,7 @@ SmmInternalAllocatePool (
 
   NeedGuard   = IsPoolTypeToGuard (PoolType);
   HasPoolTail = !(NeedGuard &&
-                  ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) == 0));
+                  gMmMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_TAIL);
 
   //
   // Adjust the size by the pool header & tail overhead
@@ -396,7 +396,7 @@ SmmInternalFreePool (
   MemoryGuarded = IsHeapGuardEnabled () &&
                   IsMemoryGuarded ((EFI_PHYSICAL_ADDRESS)(UINTN)FreePoolHdr);
   HasPoolTail = !(MemoryGuarded &&
-                  ((PcdGet8 (PcdHeapGuardPropertyMask) & BIT7) == 0));
+                  gMmMps.HeapGuardPolicy.Fields.Direction == HEAP_GUARD_ALIGNED_TO_TAIL);
 
   if (HasPoolTail) {
     PoolTail = HEAD_TO_TAIL (&FreePoolHdr->Header);

--- a/MdeModulePkg/Include/Guid/DxeMemoryProtectionSettings.h
+++ b/MdeModulePkg/Include/Guid/DxeMemoryProtectionSettings.h
@@ -1,0 +1,501 @@
+/** @file
+Defines memory protection settings guid and struct
+for runtime configuration of memory protection settings.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#define HOB_DXE_MEMORY_PROTECTION_SETTINGS_GUID \
+  { \
+    { 0xE9DD2850, 0xB4D9, 0x4573, { 0xAA, 0x31, 0x80, 0xFF, 0x1C, 0x3E, 0xF5, 0x47 }} \
+  }
+
+extern GUID  gDxeMemoryProtectionSettingsGuid;
+
+typedef union {
+  UINT8    Data;
+  struct {
+    UINT8    UefiNullDetection : 1;
+    UINT8    DisableEndOfDxe   : 1;
+    UINT8    NonStopMode       : 1;
+  } Fields;
+} DXE_NULL_DETECTION_POLICY;
+
+typedef union {
+  UINT8    Data;
+  struct {
+    UINT8    UefiPageGuard        : 1;
+    UINT8    UefiPoolGuard        : 1;
+    UINT8    UefiFreedMemoryGuard : 1;
+    UINT8    Direction            : 1;
+    UINT8    NonStopMode          : 1;
+  } Fields;
+} DXE_HEAP_GUARD_POLICY;
+
+typedef union {
+  UINT32    Data;
+  struct {
+    UINT8    EfiReservedMemoryType      : 1;
+    UINT8    EfiLoaderCode              : 1;
+    UINT8    EfiLoaderData              : 1;
+    UINT8    EfiBootServicesCode        : 1;
+    UINT8    EfiBootServicesData        : 1;
+    UINT8    EfiRuntimeServicesCode     : 1;
+    UINT8    EfiRuntimeServicesData     : 1;
+    UINT8    EfiConventionalMemory      : 1;
+    UINT8    EfiUnusableMemory          : 1;
+    UINT8    EfiACPIReclaimMemory       : 1;
+    UINT8    EfiACPIMemoryNVS           : 1;
+    UINT8    EfiMemoryMappedIO          : 1;
+    UINT8    EfiMemoryMappedIOPortSpace : 1;
+    UINT8    EfiPalCode                 : 1;
+    UINT8    EfiPersistentMemory        : 1;
+    UINT8    EfiUnacceptedMemoryType    : 1;
+    UINT8    OEMReserved                : 1;
+    UINT8    OSReserved                 : 1;
+  } Fields;
+} DXE_HEAP_GUARD_MEMORY_TYPES;
+
+typedef union {
+  UINT8    Data;
+  struct {
+    UINT8    ProtectImageFromUnknown : 1;
+    UINT8    ProtectImageFromFv      : 1;
+  } Fields;
+} DXE_IMAGE_PROTECTION_POLICY;
+
+typedef UINT8 DXE_MEMORY_PROTECTION_SETTINGS_VERSION;
+
+#define DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION  1
+
+//
+// Memory Protection Settings struct
+//
+typedef struct {
+  // The current version of the structure definition. This is used to ensure there isn't a definition mismatch
+  // if modules have differing iterations of this header. When creating this struct, use the
+  // DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION macro.
+  DXE_MEMORY_PROTECTION_SETTINGS_VERSION    StructVersion;
+
+  // Indicates if UEFI Stack Guard will be enabled.
+  //
+  // If enabled, stack overflow in UEFI can be caught.
+  //  TRUE  - UEFI Stack Guard will be enabled.
+  //  FALSE - UEFI Stack Guard will be disabled.
+  BOOLEAN                                   CpuStackGuard;
+
+  // Bitfield to control the NULL address detection in code for different phases.
+  // If enabled, accessing NULL address in UEFI or SMM code can be caught by marking
+  // the NULL page as not present.
+  //   .UefiNullDetection   : Enable NULL pointer detection for UEFI.
+  //   .DisableEndOfDxe     : Disable NULL pointer detection just after EndOfDxe.
+  //                          This is a workaround for those unsolvable NULL access issues in
+  //                          OptionROM, boot loader, etc. It can also help to avoid unnecessary
+  //                          exception caused by legacy memory (0-4095) access after EndOfDxe,
+  //                          such as Windows 7 boot on Qemu.
+  //   .NonStopMode         : Continue execution (non-stop mode) after a NULL pointer
+  //                          detection fault instead of halting. Only meaningful when
+  //                          UEFI NULL pointer detection is enabled.
+  DXE_NULL_DETECTION_POLICY    NullPointerDetectionPolicy;
+
+  // Bitfield to control Heap Guard behavior.
+  //
+  // Note:
+  //  a) Due to the limit of pool memory implementation and the alignment
+  //     requirement of UEFI spec, HeapGuardPolicy.Direction is a try-best
+  //     setting which cannot guarantee that the returned pool is exactly
+  //     adjacent to head guard page or tail guard page.
+  //  b) UEFI freed-memory guard and UEFI pool/page guard cannot be enabled
+  //     at the same time.
+  //
+  //  .UefiPageGuard         : Enable UEFI page guard.
+  //  .UefiPoolGuard         : Enable UEFI pool guard.
+  //  .Direction             : The direction of Guard Page for Pool Guard.
+  //                           0 - The returned pool is near the tail guard page.
+  //                           1 - The returned pool is near the head guard page.
+  //  .NonStopMode           : Continue execution (non-stop mode) after a heap guard
+  //                           page fault instead of halting. Only meaningful when a
+  //                           UEFI heap guard (page, pool, or freed-memory) is enabled.
+  DXE_HEAP_GUARD_POLICY    HeapGuardPolicy;
+
+  // Set image protection policy.
+  //
+  //  .ProtectImageFromUnknown          : If set, images from unknown devices will be protected by DxeCore
+  //                                      if they are aligned. The code section becomes read-only, and the data
+  //                                      section becomes non-executable.
+  //  .ProtectImageFromFv               : If set, images from firmware volumes will be protected by DxeCore
+  //                                      if they are aligned. The code section becomes read-only, and the data
+  //                                      section becomes non-executable.
+  //
+  // Note: If a bit is cleared, an image data section could be still non-executable if
+  // NxProtectionPolicy is enabled for EfiLoaderData, EfiBootServicesData or EfiRuntimeServicesData.
+  DXE_IMAGE_PROTECTION_POLICY    ImageProtectionPolicy;
+
+  // Indicates which type allocation need guard page.
+  //
+  // If bit is set, a head guard page and a tail guard page will be added just
+  // before and after corresponding type of pages which the allocated pool occupies,
+  // if there's enough free memory for all of them. The pool allocation for the
+  // type related to cleared bits keeps the same as usual.
+  //
+  // This bitfield is only valid if UefiPoolGuard and/or MmPoolGuard are set in HeapGuardPolicy.
+  DXE_HEAP_GUARD_MEMORY_TYPES    HeapGuardPoolType;
+
+  // Indicates which type allocation need guard page.
+  //
+  // If a bit is set, a head guard page and a tail guard page will be added just
+  // before and after corresponding type of pages allocated if there's enough
+  // free pages for all of them. The page allocation for the type related to
+  // cleared bits keeps the same as usual.
+  //
+  // This bitfield is only valid if UefiPageGuard is set in HeapGuardPolicy.
+  DXE_HEAP_GUARD_MEMORY_TYPES    HeapGuardPageType;
+
+  // DXE no execute memory protection policy.
+  //
+  // If a bit is set, memory regions of the associated type will be mapped
+  // non-executable. If a bit is cleared, nothing will be done to associated type of memory.
+  DXE_HEAP_GUARD_MEMORY_TYPES    NxProtectionPolicy;
+} DXE_MEMORY_PROTECTION_SETTINGS;
+
+// HeapGuardPolicy.Fields.Direction value indicating tail alignment
+#define HEAP_GUARD_ALIGNED_TO_TAIL  0
+
+// HeapGuardPolicy.Fields.Direction value indicating head alignment
+#define HEAP_GUARD_ALIGNED_TO_HEAD  1
+
+//
+//  A memory profile with strict settings. This will likely add to the
+//  total boot time but will catch more configuration and memory errors.
+//
+#define DXE_MEMORY_PROTECTION_SETTINGS_DEBUG                    \
+          {                                                     \
+            DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
+            TRUE,   /* Stack Guard On */                        \
+            {                                                   \
+              .Fields.UefiNullDetection               = 1,      \
+              .Fields.DisableEndOfDxe                 = 0,      \
+            },                                                  \
+            {                                                   \
+              .Fields.UefiPageGuard                   = 1,      \
+              .Fields.UefiPoolGuard                   = 1,      \
+              .Fields.Direction                       = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.ProtectImageFromUnknown         = 1,      \
+              .Fields.ProtectImageFromFv              = 1,      \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 1,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 1,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 1,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 1,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 1,      \
+              .Fields.OSReserved                      = 1       \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 1,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 1,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 1,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 1,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 1,      \
+              .Fields.OSReserved                      = 1       \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 1,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 1,      \
+              .Fields.OSReserved                      = 1       \
+            }                                                   \
+          }
+
+//
+//  A memory profile recommended for SHIP_MODE. Compared to the debug
+//  settings, this removes the pool guards and doesn't unload images
+//  which fail protection.
+//
+#define DXE_MEMORY_PROTECTION_SETTINGS_SHIP_MODE                \
+          {                                                     \
+            DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
+            TRUE,   /* Stack Guard On */                        \
+            {                                                   \
+              .Fields.UefiNullDetection               = 1,      \
+              .Fields.DisableEndOfDxe                 = 0,      \
+            },                                                  \
+            {                                                   \
+              .Fields.UefiPageGuard                   = 1,      \
+              .Fields.UefiPoolGuard                   = 0,      \
+              .Fields.Direction                       = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.ProtectImageFromUnknown         = 0,      \
+              .Fields.ProtectImageFromFv              = 1,      \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 1,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 1,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            }                                                   \
+          }
+
+//
+//  A memory profile which mirrors DXE_MEMORY_PROTECTION_SETTINGS_SHIP_MODE
+//  but doesn't include page guards.
+//
+#define DXE_MEMORY_PROTECTION_SETTINGS_SHIP_MODE_NO_PAGE_GUARDS \
+          {                                                     \
+            DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
+            TRUE,   /* Stack Guard On */                        \
+            {                                                   \
+              .Fields.UefiNullDetection               = 1,      \
+              .Fields.DisableEndOfDxe                 = 0,      \
+            },                                                  \
+            {                                                   \
+              .Fields.UefiPageGuard                   = 0,      \
+              .Fields.UefiPoolGuard                   = 0,      \
+              .Fields.Direction                       = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.ProtectImageFromUnknown         = 0,      \
+              .Fields.ProtectImageFromFv              = 1,      \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 1,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 1,      \
+              .Fields.EfiPersistentMemory             = 1,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            }                                                   \
+          }
+
+//
+//  A memory profile which disables all memory protection settings.
+//
+#define DXE_MEMORY_PROTECTION_SETTINGS_OFF                      \
+          {                                                     \
+            DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
+            FALSE,   /* Stack Guard Off */                      \
+            {                                                   \
+              .Fields.UefiNullDetection               = 0,      \
+              .Fields.DisableEndOfDxe                 = 0,      \
+            },                                                  \
+            {                                                   \
+              .Fields.UefiPageGuard                   = 0,      \
+              .Fields.UefiPoolGuard                   = 0,      \
+              .Fields.Direction                       = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.ProtectImageFromUnknown         = 0,      \
+              .Fields.ProtectImageFromFv              = 0,      \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            }                                                   \
+          }

--- a/MdeModulePkg/Include/Guid/DxeMemoryProtectionSettings.h
+++ b/MdeModulePkg/Include/Guid/DxeMemoryProtectionSettings.h
@@ -1,0 +1,525 @@
+/** @file
+Defines memory protection settings guid and struct
+for runtime configuration of memory protection settings.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#define HOB_DXE_MEMORY_PROTECTION_SETTINGS_GUID \
+  { \
+    { 0xE9DD2850, 0xB4D9, 0x4573, { 0xAA, 0x31, 0x80, 0xFF, 0x1C, 0x3E, 0xF5, 0x47 }} \
+  }
+
+extern GUID  gDxeMemoryProtectionSettingsGuid;
+
+typedef union {
+  UINT8    Data;
+  struct {
+    UINT8    UefiNullDetection : 1;
+    UINT8    DisableEndOfDxe   : 1;
+    UINT8    NonStopMode       : 1;
+  } Fields;
+} DXE_NULL_DETECTION_POLICY;
+
+typedef union {
+  UINT8    Data;
+  struct {
+    UINT8    UefiPageGuard        : 1;
+    UINT8    UefiPoolGuard        : 1;
+    UINT8    UefiFreedMemoryGuard : 1;
+    UINT8    Direction            : 1;
+    UINT8    NonStopMode          : 1;
+  } Fields;
+} DXE_HEAP_GUARD_POLICY;
+
+typedef union {
+  UINT32    Data;
+  struct {
+    UINT8    EfiReservedMemoryType      : 1;
+    UINT8    EfiLoaderCode              : 1;
+    UINT8    EfiLoaderData              : 1;
+    UINT8    EfiBootServicesCode        : 1;
+    UINT8    EfiBootServicesData        : 1;
+    UINT8    EfiRuntimeServicesCode     : 1;
+    UINT8    EfiRuntimeServicesData     : 1;
+    UINT8    EfiConventionalMemory      : 1;
+    UINT8    EfiUnusableMemory          : 1;
+    UINT8    EfiACPIReclaimMemory       : 1;
+    UINT8    EfiACPIMemoryNVS           : 1;
+    UINT8    EfiMemoryMappedIO          : 1;
+    UINT8    EfiMemoryMappedIOPortSpace : 1;
+    UINT8    EfiPalCode                 : 1;
+    UINT8    EfiPersistentMemory        : 1;
+    UINT8    EfiUnacceptedMemoryType    : 1;
+    UINT8    OEMReserved                : 1;
+    UINT8    OSReserved                 : 1;
+  } Fields;
+} DXE_HEAP_GUARD_MEMORY_TYPES;
+
+typedef union {
+  UINT8    Data;
+  struct {
+    UINT8    ProtectImageFromUnknown : 1;
+    UINT8    ProtectImageFromFv      : 1;
+  } Fields;
+} DXE_IMAGE_PROTECTION_POLICY;
+
+typedef UINT8 DXE_MEMORY_PROTECTION_SETTINGS_VERSION;
+
+#define DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION  1
+
+//
+// Memory Protection Settings struct
+//
+typedef struct {
+  // The current version of the structure definition. This is used to ensure there isn't a definition mismatch
+  // if modules have differing iterations of this header. When creating this struct, use the
+  // DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION macro.
+  DXE_MEMORY_PROTECTION_SETTINGS_VERSION    StructVersion;
+
+  // Indicates if UEFI Stack Guard will be enabled.
+  //
+  // If enabled, stack overflow in UEFI can be caught.
+  //  TRUE  - UEFI Stack Guard will be enabled.
+  //  FALSE - UEFI Stack Guard will be disabled.
+  BOOLEAN                                   CpuStackGuard;
+
+  // Bitfield to control the NULL address detection in code for different phases.
+  // If enabled, accessing NULL address in UEFI or SMM code can be caught by marking
+  // the NULL page as not present.
+  //   .UefiNullDetection   : Enable NULL pointer detection for UEFI.
+  //   .DisableEndOfDxe     : Disable NULL pointer detection just after EndOfDxe.
+  //                          This is a workaround for those unsolvable NULL access issues in
+  //                          OptionROM, boot loader, etc. It can also help to avoid unnecessary
+  //                          exception caused by legacy memory (0-4095) access after EndOfDxe,
+  //                          such as Windows 7 boot on Qemu.
+  //   .NonStopMode         : Continue execution (non-stop mode) after a NULL pointer
+  //                          detection fault instead of halting. Only meaningful when
+  //                          UEFI NULL pointer detection is enabled.
+  DXE_NULL_DETECTION_POLICY    NullPointerDetectionPolicy;
+
+  // Bitfield to control Heap Guard behavior.
+  //
+  // Note:
+  //  a) Due to the limit of pool memory implementation and the alignment
+  //     requirement of UEFI spec, HeapGuardPolicy.Direction is a try-best
+  //     setting which cannot guarantee that the returned pool is exactly
+  //     adjacent to head guard page or tail guard page.
+  //  b) UEFI freed-memory guard and UEFI pool/page guard cannot be enabled
+  //     at the same time.
+  //
+  //  .UefiPageGuard         : Enable UEFI page guard.
+  //  .UefiPoolGuard         : Enable UEFI pool guard.
+  //  .Direction             : The direction of Guard Page for Pool Guard.
+  //                           0 - The returned pool is near the tail guard page.
+  //                           1 - The returned pool is near the head guard page.
+  //  .NonStopMode           : Continue execution (non-stop mode) after a heap guard
+  //                           page fault instead of halting. Only meaningful when a
+  //                           UEFI heap guard (page, pool, or freed-memory) is enabled.
+  DXE_HEAP_GUARD_POLICY    HeapGuardPolicy;
+
+  // Set image protection policy.
+  //
+  //  .ProtectImageFromUnknown          : If set, images from unknown devices will be protected by DxeCore
+  //                                      if they are aligned. The code section becomes read-only, and the data
+  //                                      section becomes non-executable.
+  //  .ProtectImageFromFv               : If set, images from firmware volumes will be protected by DxeCore
+  //                                      if they are aligned. The code section becomes read-only, and the data
+  //                                      section becomes non-executable.
+  //
+  // Note: If a bit is cleared, an image data section could be still non-executable if
+  // NxProtectionPolicy is enabled for EfiLoaderData, EfiBootServicesData or EfiRuntimeServicesData.
+  DXE_IMAGE_PROTECTION_POLICY    ImageProtectionPolicy;
+
+  // Indicates which type allocation need guard page.
+  //
+  // If bit is set, a head guard page and a tail guard page will be added just
+  // before and after corresponding type of pages which the allocated pool occupies,
+  // if there's enough free memory for all of them. The pool allocation for the
+  // type related to cleared bits keeps the same as usual.
+  //
+  // This bitfield is only valid if UefiPoolGuard and/or MmPoolGuard are set in HeapGuardPolicy.
+  DXE_HEAP_GUARD_MEMORY_TYPES    HeapGuardPoolType;
+
+  // Indicates which type allocation need guard page.
+  //
+  // If a bit is set, a head guard page and a tail guard page will be added just
+  // before and after corresponding type of pages allocated if there's enough
+  // free pages for all of them. The page allocation for the type related to
+  // cleared bits keeps the same as usual.
+  //
+  // This bitfield is only valid if UefiPageGuard is set in HeapGuardPolicy.
+  DXE_HEAP_GUARD_MEMORY_TYPES    HeapGuardPageType;
+
+  // DXE no execute memory protection policy.
+  //
+  // If a bit is set, memory regions of the associated type will be mapped
+  // non-executable. If a bit is cleared, nothing will be done to associated type of memory.
+  DXE_HEAP_GUARD_MEMORY_TYPES    NxProtectionPolicy;
+} DXE_MEMORY_PROTECTION_SETTINGS;
+
+// HeapGuardPolicy.Fields.Direction value indicating tail alignment
+#define HEAP_GUARD_ALIGNED_TO_TAIL  0
+
+// HeapGuardPolicy.Fields.Direction value indicating head alignment
+#define HEAP_GUARD_ALIGNED_TO_HEAD  1
+
+//
+//  A memory profile with strict settings. This will likely add to the
+//  total boot time but will catch more configuration and memory errors.
+//
+#define DXE_MEMORY_PROTECTION_SETTINGS_DEBUG                    \
+          {                                                     \
+            DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
+            TRUE,   /* Stack Guard On */                        \
+  /* Null Detection Policy */                         \
+            {                                                   \
+              .Fields.UefiNullDetection               = 1,      \
+              .Fields.DisableEndOfDxe                 = 0,      \
+            },                                                  \
+  /* Heap Guard Policy */                             \
+            {                                                   \
+              .Fields.UefiPageGuard                   = 1,      \
+              .Fields.UefiPoolGuard                   = 1,      \
+              .Fields.Direction                       = 0       \
+            },                                                  \
+  /* Image Protection Policy */                       \
+            {                                                   \
+              .Fields.ProtectImageFromUnknown         = 1,      \
+              .Fields.ProtectImageFromFv              = 1,      \
+            },                                                  \
+  /* Pool Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 1,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 1,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 1,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 1,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 1,      \
+              .Fields.OSReserved                      = 1       \
+            },                                                  \
+  /* Page Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 1,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 1,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 1,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 1,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 1,      \
+              .Fields.OSReserved                      = 1       \
+            },                                                  \
+  /* NX Protection Memory Types */                    \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 1,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 1,      \
+              .Fields.OSReserved                      = 1       \
+            }                                                   \
+          }
+
+//
+//  A memory profile recommended for RELEASE. Compared to the debug
+//  settings, this removes the pool guards and doesn't unload images
+//  which fail protection.
+//
+#define DXE_MEMORY_PROTECTION_SETTINGS_RELEASE                  \
+          {                                                     \
+            DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
+            TRUE,   /* Stack Guard On */                        \
+  /* Null Detection Policy */                         \
+            {                                                   \
+              .Fields.UefiNullDetection               = 1,      \
+              .Fields.DisableEndOfDxe                 = 0,      \
+            },                                                  \
+  /* Heap Guard Policy */                             \
+            {                                                   \
+              .Fields.UefiPageGuard                   = 1,      \
+              .Fields.UefiPoolGuard                   = 0,      \
+              .Fields.Direction                       = 0       \
+            },                                                  \
+  /* Image Protection Policy */                       \
+            {                                                   \
+              .Fields.ProtectImageFromUnknown         = 0,      \
+              .Fields.ProtectImageFromFv              = 1,      \
+            },                                                  \
+  /* Pool Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+  /* Page Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+  /* NX Protection Memory Types */                    \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 1,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 1,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            }                                                   \
+          }
+
+//
+//  A memory profile which mirrors DXE_MEMORY_PROTECTION_SETTINGS_RELEASE
+//  but doesn't include page guards.
+//
+#define DXE_MEMORY_PROTECTION_SETTINGS_RELEASE_NO_PAGE_GUARDS   \
+          {                                                     \
+            DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
+            TRUE,   /* Stack Guard On */                        \
+  /* Null Detection Policy */                         \
+            {                                                   \
+              .Fields.UefiNullDetection               = 1,      \
+              .Fields.DisableEndOfDxe                 = 0,      \
+            },                                                  \
+  /* Heap Guard Policy */                             \
+            {                                                   \
+              .Fields.UefiPageGuard                   = 0,      \
+              .Fields.UefiPoolGuard                   = 0,      \
+              .Fields.Direction                       = 0       \
+            },                                                  \
+  /* Image Protection Policy */                       \
+            {                                                   \
+              .Fields.ProtectImageFromUnknown         = 0,      \
+              .Fields.ProtectImageFromFv              = 1,      \
+            },                                                  \
+  /* Pool Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+  /* Page Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+  /* NX Protection Memory Types */                    \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 1,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 1,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 1,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 1,      \
+              .Fields.EfiConventionalMemory           = 1,      \
+              .Fields.EfiUnusableMemory               = 1,      \
+              .Fields.EfiACPIReclaimMemory            = 1,      \
+              .Fields.EfiACPIMemoryNVS                = 1,      \
+              .Fields.EfiMemoryMappedIO               = 1,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 1,      \
+              .Fields.EfiPalCode                      = 1,      \
+              .Fields.EfiPersistentMemory             = 1,      \
+              .Fields.EfiUnacceptedMemoryType         = 1,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            }                                                   \
+          }
+
+//
+//  A memory profile which disables all memory protection settings.
+//
+#define DXE_MEMORY_PROTECTION_SETTINGS_OFF                      \
+          {                                                     \
+            DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
+            FALSE,   /* Stack Guard Off */                      \
+  /* Null Detection Policy */                         \
+            {                                                   \
+              .Fields.UefiNullDetection               = 0,      \
+              .Fields.DisableEndOfDxe                 = 0,      \
+            },                                                  \
+  /* Heap Guard Policy */                             \
+            {                                                   \
+              .Fields.UefiPageGuard                   = 0,      \
+              .Fields.UefiPoolGuard                   = 0,      \
+              .Fields.Direction                       = 0       \
+            },                                                  \
+  /* Image Protection Policy */                       \
+            {                                                   \
+              .Fields.ProtectImageFromUnknown         = 0,      \
+              .Fields.ProtectImageFromFv              = 0,      \
+            },                                                  \
+  /* Pool Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+  /* Page Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            },                                                  \
+  /* NX Protection Memory Types */                    \
+            {                                                   \
+              .Fields.EfiReservedMemoryType           = 0,      \
+              .Fields.EfiLoaderCode                   = 0,      \
+              .Fields.EfiLoaderData                   = 0,      \
+              .Fields.EfiBootServicesCode             = 0,      \
+              .Fields.EfiBootServicesData             = 0,      \
+              .Fields.EfiRuntimeServicesCode          = 0,      \
+              .Fields.EfiRuntimeServicesData          = 0,      \
+              .Fields.EfiConventionalMemory           = 0,      \
+              .Fields.EfiUnusableMemory               = 0,      \
+              .Fields.EfiACPIReclaimMemory            = 0,      \
+              .Fields.EfiACPIMemoryNVS                = 0,      \
+              .Fields.EfiMemoryMappedIO               = 0,      \
+              .Fields.EfiMemoryMappedIOPortSpace      = 0,      \
+              .Fields.EfiPalCode                      = 0,      \
+              .Fields.EfiPersistentMemory             = 0,      \
+              .Fields.EfiUnacceptedMemoryType         = 0,      \
+              .Fields.OEMReserved                     = 0,      \
+              .Fields.OSReserved                      = 0       \
+            }                                                   \
+          }

--- a/MdeModulePkg/Include/Guid/MmMemoryProtectionSettings.h
+++ b/MdeModulePkg/Include/Guid/MmMemoryProtectionSettings.h
@@ -1,0 +1,229 @@
+/** @file
+Defines memory protection settings guid and struct for
+runtime memory protections configuration.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#define HOB_MM_MEMORY_PROTECTION_SETTINGS_GUID \
+  { \
+    { 0xF8DFE785, 0x98F5, 0x41B0, { 0x93, 0x7D, 0xE5, 0x84, 0x85, 0x5F, 0xD5, 0x62 } } \
+  }
+
+extern GUID  gMmMemoryProtectionSettingsGuid;
+
+typedef union {
+  UINT8    Data;
+  struct {
+    UINT8    MmPageGuard : 1;
+    UINT8    MmPoolGuard : 1;
+    UINT8    Direction   : 1;
+    UINT8    NonStopMode : 1;
+  } Fields;
+} MM_HEAP_GUARD_POLICY;
+
+typedef union {
+  UINT32    Data;
+  struct {
+    UINT8    EfiReservedMemoryType      : 1;
+    UINT8    EfiLoaderCode              : 1;
+    UINT8    EfiLoaderData              : 1;
+    UINT8    EfiBootServicesCode        : 1;
+    UINT8    EfiBootServicesData        : 1;
+    UINT8    EfiRuntimeServicesCode     : 1;
+    UINT8    EfiRuntimeServicesData     : 1;
+    UINT8    EfiConventionalMemory      : 1;
+    UINT8    EfiUnusableMemory          : 1;
+    UINT8    EfiACPIReclaimMemory       : 1;
+    UINT8    EfiACPIMemoryNVS           : 1;
+    UINT8    EfiMemoryMappedIO          : 1;
+    UINT8    EfiMemoryMappedIOPortSpace : 1;
+    UINT8    EfiPalCode                 : 1;
+    UINT8    EfiPersistentMemory        : 1;
+    UINT8    EfiUnacceptedMemoryType    : 1;
+    UINT8    OEMReserved                : 1;
+    UINT8    OSReserved                 : 1;
+  } Fields;
+} MM_HEAP_GUARD_MEMORY_TYPES;
+
+typedef UINT8 MM_MEMORY_PROTECTION_SETTINGS_VERSION;
+
+#define MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION  1
+
+//
+// Memory Protection Settings struct
+//
+typedef struct {
+  // The current version of the structure definition. This is used to ensure there isn't a definition mismatch
+  // if modules have differing iterations of this header. When creating this struct, use the
+  // MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION macro.
+  MM_MEMORY_PROTECTION_SETTINGS_VERSION    StructVersion;
+
+  // If enabled, accessing NULL address in UEFI or SMM code can be caught by marking
+  // the NULL page as not present.
+  BOOLEAN                                  NullPointerDetectionPolicy;
+
+  // Bitfield to control Heap Guard behavior.
+  //
+  // Note:
+  //  a) Due to the limit of pool memory implementation and the alignment
+  //     requirement of UEFI spec, HeapGuardPolicy.Direction is a try-best
+  //     setting which cannot guarantee that the returned pool is exactly
+  //     adjacent to head guard page or tail guard page.
+  //
+  //  .MmPageGuard          : Enable SMM page guard.
+  //  .MmPoolGuard          : Enable SMM pool guard.
+  //  .Direction             : The direction of Guard Page for Pool Guard.
+  //                           0 - The returned pool is near the tail guard page.
+  //                           1 - The returned pool is near the head guard page.
+  //  .NonStopMode           : Continue execution (non-stop mode) after a heap guard
+  //                           page fault instead of halting. Only meaningful when an
+  //                           MM heap guard (page or pool) is enabled.
+  MM_HEAP_GUARD_POLICY    HeapGuardPolicy;
+
+  // Indicates which type allocation need guard page.
+  //
+  // If bit is set, a head guard page and a tail guard page will be added just
+  // before and after corresponding type of pages which the allocated pool occupies,
+  // if there's enough free memory for all of them. The pool allocation for the
+  // type related to cleared bits keeps the same as usual.
+  //
+  // This bitfield is only valid if UefiPoolGuard and/or MmPoolGuard are set in HeapGuardPolicy.
+  MM_HEAP_GUARD_MEMORY_TYPES    HeapGuardPoolType;
+
+  // Indicates which type allocation need guard page.
+  //
+  // If a bit is set, a head guard page and a tail guard page will be added just
+  // before and after corresponding type of pages allocated if there's enough
+  // free pages for all of them. The page allocation for the type related to
+  // cleared bits keeps the same as usual.
+  //
+  // This bitfield is only valid if MmPageGuard is set in HeapGuardPolicy.
+  MM_HEAP_GUARD_MEMORY_TYPES    HeapGuardPageType;
+
+  // Indicates if the MM environment continues execution (non-stop mode) after a
+  // NULL pointer detection fault instead of halting. This is only meaningful when
+  // MM NULL pointer detection is enabled.
+  BOOLEAN                       NullDetectionNonStopMode;
+} MM_MEMORY_PROTECTION_SETTINGS;
+
+// HeapGuardPolicy.Fields.Direction value indicating tail alignment
+#define HEAP_GUARD_ALIGNED_TO_TAIL  0
+
+// HeapGuardPolicy.Fields.Direction value indicating head alignment
+#define HEAP_GUARD_ALIGNED_TO_HEAD  1
+
+//
+//  An SMM memory profile with strict settings. This will likely add to the
+//  total boot time but will catch more configuration and memory errors.
+//
+#define MM_MEMORY_PROTECTION_SETTINGS_DEBUG                     \
+          {                                                     \
+            MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,      \
+            TRUE,                                               \
+            {                                                   \
+              .Fields.MmPageGuard                  = 1,         \
+              .Fields.MmPoolGuard                  = 1,         \
+              .Fields.Direction                    = 0          \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType        = 0,         \
+              .Fields.EfiLoaderCode                = 0,         \
+              .Fields.EfiLoaderData                = 0,         \
+              .Fields.EfiBootServicesCode          = 0,         \
+              .Fields.EfiBootServicesData          = 1,         \
+              .Fields.EfiRuntimeServicesCode       = 0,         \
+              .Fields.EfiRuntimeServicesData       = 1,         \
+              .Fields.EfiConventionalMemory        = 0,         \
+              .Fields.EfiUnusableMemory            = 0,         \
+              .Fields.EfiACPIReclaimMemory         = 0,         \
+              .Fields.EfiACPIMemoryNVS             = 0,         \
+              .Fields.EfiMemoryMappedIO            = 0,         \
+              .Fields.EfiMemoryMappedIOPortSpace   = 0,         \
+              .Fields.EfiPalCode                   = 0,         \
+              .Fields.EfiPersistentMemory          = 0,         \
+              .Fields.EfiUnacceptedMemoryType      = 0,         \
+              .Fields.OEMReserved                  = 0,         \
+              .Fields.OSReserved                   = 0          \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType        = 0,         \
+              .Fields.EfiLoaderCode                = 0,         \
+              .Fields.EfiLoaderData                = 0,         \
+              .Fields.EfiBootServicesCode          = 0,         \
+              .Fields.EfiBootServicesData          = 1,         \
+              .Fields.EfiRuntimeServicesCode       = 0,         \
+              .Fields.EfiRuntimeServicesData       = 1,         \
+              .Fields.EfiConventionalMemory        = 0,         \
+              .Fields.EfiUnusableMemory            = 0,         \
+              .Fields.EfiACPIReclaimMemory         = 0,         \
+              .Fields.EfiACPIMemoryNVS             = 0,         \
+              .Fields.EfiMemoryMappedIO            = 0,         \
+              .Fields.EfiMemoryMappedIOPortSpace   = 0,         \
+              .Fields.EfiPalCode                   = 0,         \
+              .Fields.EfiPersistentMemory          = 0,         \
+              .Fields.EfiUnacceptedMemoryType      = 0,         \
+              .Fields.OEMReserved                  = 0,         \
+              .Fields.OSReserved                   = 0          \
+            },                                                  \
+            FALSE   /* NULL Detection Non-Stop Mode Off */      \
+          }
+
+//
+//  An SMM memory profile with all settings off.
+//
+#define MM_MEMORY_PROTECTION_SETTINGS_OFF                       \
+          {                                                     \
+            MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,      \
+            FALSE,                                              \
+            {                                                   \
+              .Fields.MmPageGuard                  = 0,         \
+              .Fields.MmPoolGuard                  = 0,         \
+              .Fields.Direction                    = 0          \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType        = 0,         \
+              .Fields.EfiLoaderCode                = 0,         \
+              .Fields.EfiLoaderData                = 0,         \
+              .Fields.EfiBootServicesCode          = 0,         \
+              .Fields.EfiBootServicesData          = 0,         \
+              .Fields.EfiRuntimeServicesCode       = 0,         \
+              .Fields.EfiRuntimeServicesData       = 0,         \
+              .Fields.EfiConventionalMemory        = 0,         \
+              .Fields.EfiUnusableMemory            = 0,         \
+              .Fields.EfiACPIReclaimMemory         = 0,         \
+              .Fields.EfiACPIMemoryNVS             = 0,         \
+              .Fields.EfiMemoryMappedIO            = 0,         \
+              .Fields.EfiMemoryMappedIOPortSpace   = 0,         \
+              .Fields.EfiPalCode                   = 0,         \
+              .Fields.EfiPersistentMemory          = 0,         \
+              .Fields.EfiUnacceptedMemoryType      = 0,         \
+              .Fields.OEMReserved                  = 0,         \
+              .Fields.OSReserved                   = 0          \
+            },                                                  \
+            {                                                   \
+              .Fields.EfiReservedMemoryType        = 0,         \
+              .Fields.EfiLoaderCode                = 0,         \
+              .Fields.EfiLoaderData                = 0,         \
+              .Fields.EfiBootServicesCode          = 0,         \
+              .Fields.EfiBootServicesData          = 0,         \
+              .Fields.EfiRuntimeServicesCode       = 0,         \
+              .Fields.EfiRuntimeServicesData       = 0,         \
+              .Fields.EfiConventionalMemory        = 0,         \
+              .Fields.EfiUnusableMemory            = 0,         \
+              .Fields.EfiACPIReclaimMemory         = 0,         \
+              .Fields.EfiACPIMemoryNVS             = 0,         \
+              .Fields.EfiMemoryMappedIO            = 0,         \
+              .Fields.EfiMemoryMappedIOPortSpace   = 0,         \
+              .Fields.EfiPalCode                   = 0,         \
+              .Fields.EfiPersistentMemory          = 0,         \
+              .Fields.EfiUnacceptedMemoryType      = 0,         \
+              .Fields.OEMReserved                  = 0,         \
+              .Fields.OSReserved                   = 0          \
+            },                                                  \
+            FALSE   /* NULL Detection Non-Stop Mode Off */      \
+          }

--- a/MdeModulePkg/Include/Guid/MmMemoryProtectionSettings.h
+++ b/MdeModulePkg/Include/Guid/MmMemoryProtectionSettings.h
@@ -1,0 +1,235 @@
+/** @file
+Defines memory protection settings guid and struct for
+runtime memory protections configuration.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#define HOB_MM_MEMORY_PROTECTION_SETTINGS_GUID \
+  { \
+    { 0xF8DFE785, 0x98F5, 0x41B0, { 0x93, 0x7D, 0xE5, 0x84, 0x85, 0x5F, 0xD5, 0x62 } } \
+  }
+
+extern GUID  gMmMemoryProtectionSettingsGuid;
+
+typedef union {
+  UINT8    Data;
+  struct {
+    UINT8    MmPageGuard : 1;
+    UINT8    MmPoolGuard : 1;
+    UINT8    Direction   : 1;
+    UINT8    NonStopMode : 1;
+  } Fields;
+} MM_HEAP_GUARD_POLICY;
+
+typedef union {
+  UINT32    Data;
+  struct {
+    UINT8    EfiReservedMemoryType      : 1;
+    UINT8    EfiLoaderCode              : 1;
+    UINT8    EfiLoaderData              : 1;
+    UINT8    EfiBootServicesCode        : 1;
+    UINT8    EfiBootServicesData        : 1;
+    UINT8    EfiRuntimeServicesCode     : 1;
+    UINT8    EfiRuntimeServicesData     : 1;
+    UINT8    EfiConventionalMemory      : 1;
+    UINT8    EfiUnusableMemory          : 1;
+    UINT8    EfiACPIReclaimMemory       : 1;
+    UINT8    EfiACPIMemoryNVS           : 1;
+    UINT8    EfiMemoryMappedIO          : 1;
+    UINT8    EfiMemoryMappedIOPortSpace : 1;
+    UINT8    EfiPalCode                 : 1;
+    UINT8    EfiPersistentMemory        : 1;
+    UINT8    EfiUnacceptedMemoryType    : 1;
+    UINT8    OEMReserved                : 1;
+    UINT8    OSReserved                 : 1;
+  } Fields;
+} MM_HEAP_GUARD_MEMORY_TYPES;
+
+typedef UINT8 MM_MEMORY_PROTECTION_SETTINGS_VERSION;
+
+#define MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION  1
+
+//
+// Memory Protection Settings struct
+//
+typedef struct {
+  // The current version of the structure definition. This is used to ensure there isn't a definition mismatch
+  // if modules have differing iterations of this header. When creating this struct, use the
+  // MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION macro.
+  MM_MEMORY_PROTECTION_SETTINGS_VERSION    StructVersion;
+
+  // If enabled, accessing NULL address in UEFI or SMM code can be caught by marking
+  // the NULL page as not present.
+  BOOLEAN                                  NullPointerDetectionPolicy;
+
+  // Bitfield to control Heap Guard behavior.
+  //
+  // Note:
+  //  a) Due to the limit of pool memory implementation and the alignment
+  //     requirement of UEFI spec, HeapGuardPolicy.Direction is a try-best
+  //     setting which cannot guarantee that the returned pool is exactly
+  //     adjacent to head guard page or tail guard page.
+  //
+  //  .MmPageGuard          : Enable SMM page guard.
+  //  .MmPoolGuard          : Enable SMM pool guard.
+  //  .Direction             : The direction of Guard Page for Pool Guard.
+  //                           0 - The returned pool is near the tail guard page.
+  //                           1 - The returned pool is near the head guard page.
+  //  .NonStopMode           : Continue execution (non-stop mode) after a heap guard
+  //                           page fault instead of halting. Only meaningful when an
+  //                           MM heap guard (page or pool) is enabled.
+  MM_HEAP_GUARD_POLICY    HeapGuardPolicy;
+
+  // Indicates which type allocation need guard page.
+  //
+  // If bit is set, a head guard page and a tail guard page will be added just
+  // before and after corresponding type of pages which the allocated pool occupies,
+  // if there's enough free memory for all of them. The pool allocation for the
+  // type related to cleared bits keeps the same as usual.
+  //
+  // This bitfield is only valid if UefiPoolGuard and/or MmPoolGuard are set in HeapGuardPolicy.
+  MM_HEAP_GUARD_MEMORY_TYPES    HeapGuardPoolType;
+
+  // Indicates which type allocation need guard page.
+  //
+  // If a bit is set, a head guard page and a tail guard page will be added just
+  // before and after corresponding type of pages allocated if there's enough
+  // free pages for all of them. The page allocation for the type related to
+  // cleared bits keeps the same as usual.
+  //
+  // This bitfield is only valid if MmPageGuard is set in HeapGuardPolicy.
+  MM_HEAP_GUARD_MEMORY_TYPES    HeapGuardPageType;
+
+  // Indicates if the MM environment continues execution (non-stop mode) after a
+  // NULL pointer detection fault instead of halting. This is only meaningful when
+  // MM NULL pointer detection is enabled.
+  BOOLEAN                       NullDetectionNonStopMode;
+} MM_MEMORY_PROTECTION_SETTINGS;
+
+// HeapGuardPolicy.Fields.Direction value indicating tail alignment
+#define HEAP_GUARD_ALIGNED_TO_TAIL  0
+
+// HeapGuardPolicy.Fields.Direction value indicating head alignment
+#define HEAP_GUARD_ALIGNED_TO_HEAD  1
+
+//
+//  An SMM memory profile with strict settings. This will likely add to the
+//  total boot time but will catch more configuration and memory errors.
+//
+#define MM_MEMORY_PROTECTION_SETTINGS_DEBUG                     \
+          {                                                     \
+            MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,      \
+            TRUE, /* Null Detection Enabled */                  \
+  /* Heap Guard Policy */                             \
+            {                                                   \
+              .Fields.MmPageGuard                  = 1,         \
+              .Fields.MmPoolGuard                  = 1,         \
+              .Fields.Direction                    = 0          \
+            },                                                  \
+  /* Pool Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType        = 0,         \
+              .Fields.EfiLoaderCode                = 0,         \
+              .Fields.EfiLoaderData                = 0,         \
+              .Fields.EfiBootServicesCode          = 0,         \
+              .Fields.EfiBootServicesData          = 1,         \
+              .Fields.EfiRuntimeServicesCode       = 0,         \
+              .Fields.EfiRuntimeServicesData       = 1,         \
+              .Fields.EfiConventionalMemory        = 0,         \
+              .Fields.EfiUnusableMemory            = 0,         \
+              .Fields.EfiACPIReclaimMemory         = 0,         \
+              .Fields.EfiACPIMemoryNVS             = 0,         \
+              .Fields.EfiMemoryMappedIO            = 0,         \
+              .Fields.EfiMemoryMappedIOPortSpace   = 0,         \
+              .Fields.EfiPalCode                   = 0,         \
+              .Fields.EfiPersistentMemory          = 0,         \
+              .Fields.EfiUnacceptedMemoryType      = 0,         \
+              .Fields.OEMReserved                  = 0,         \
+              .Fields.OSReserved                   = 0          \
+            },                                                  \
+  /* Page Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType        = 0,         \
+              .Fields.EfiLoaderCode                = 0,         \
+              .Fields.EfiLoaderData                = 0,         \
+              .Fields.EfiBootServicesCode          = 0,         \
+              .Fields.EfiBootServicesData          = 1,         \
+              .Fields.EfiRuntimeServicesCode       = 0,         \
+              .Fields.EfiRuntimeServicesData       = 1,         \
+              .Fields.EfiConventionalMemory        = 0,         \
+              .Fields.EfiUnusableMemory            = 0,         \
+              .Fields.EfiACPIReclaimMemory         = 0,         \
+              .Fields.EfiACPIMemoryNVS             = 0,         \
+              .Fields.EfiMemoryMappedIO            = 0,         \
+              .Fields.EfiMemoryMappedIOPortSpace   = 0,         \
+              .Fields.EfiPalCode                   = 0,         \
+              .Fields.EfiPersistentMemory          = 0,         \
+              .Fields.EfiUnacceptedMemoryType      = 0,         \
+              .Fields.OEMReserved                  = 0,         \
+              .Fields.OSReserved                   = 0          \
+            },                                                  \
+            FALSE   /* NULL Detection Non-Stop Mode Off */      \
+          }
+
+//
+//  An SMM memory profile with all settings off.
+//
+#define MM_MEMORY_PROTECTION_SETTINGS_OFF                       \
+          {                                                     \
+            MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,      \
+            FALSE, /* Null Detection Disabled */                \
+  /* Heap Guard Policy */                             \
+            {                                                   \
+              .Fields.MmPageGuard                  = 0,         \
+              .Fields.MmPoolGuard                  = 0,         \
+              .Fields.Direction                    = 0          \
+            },                                                  \
+  /* Pool Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType        = 0,         \
+              .Fields.EfiLoaderCode                = 0,         \
+              .Fields.EfiLoaderData                = 0,         \
+              .Fields.EfiBootServicesCode          = 0,         \
+              .Fields.EfiBootServicesData          = 0,         \
+              .Fields.EfiRuntimeServicesCode       = 0,         \
+              .Fields.EfiRuntimeServicesData       = 0,         \
+              .Fields.EfiConventionalMemory        = 0,         \
+              .Fields.EfiUnusableMemory            = 0,         \
+              .Fields.EfiACPIReclaimMemory         = 0,         \
+              .Fields.EfiACPIMemoryNVS             = 0,         \
+              .Fields.EfiMemoryMappedIO            = 0,         \
+              .Fields.EfiMemoryMappedIOPortSpace   = 0,         \
+              .Fields.EfiPalCode                   = 0,         \
+              .Fields.EfiPersistentMemory          = 0,         \
+              .Fields.EfiUnacceptedMemoryType      = 0,         \
+              .Fields.OEMReserved                  = 0,         \
+              .Fields.OSReserved                   = 0          \
+            },                                                  \
+  /* Page Guard Memory Types */                       \
+            {                                                   \
+              .Fields.EfiReservedMemoryType        = 0,         \
+              .Fields.EfiLoaderCode                = 0,         \
+              .Fields.EfiLoaderData                = 0,         \
+              .Fields.EfiBootServicesCode          = 0,         \
+              .Fields.EfiBootServicesData          = 0,         \
+              .Fields.EfiRuntimeServicesCode       = 0,         \
+              .Fields.EfiRuntimeServicesData       = 0,         \
+              .Fields.EfiConventionalMemory        = 0,         \
+              .Fields.EfiUnusableMemory            = 0,         \
+              .Fields.EfiACPIReclaimMemory         = 0,         \
+              .Fields.EfiACPIMemoryNVS             = 0,         \
+              .Fields.EfiMemoryMappedIO            = 0,         \
+              .Fields.EfiMemoryMappedIOPortSpace   = 0,         \
+              .Fields.EfiPalCode                   = 0,         \
+              .Fields.EfiPersistentMemory          = 0,         \
+              .Fields.EfiUnacceptedMemoryType      = 0,         \
+              .Fields.OEMReserved                  = 0,         \
+              .Fields.OSReserved                   = 0          \
+            },                                                  \
+            FALSE   /* NULL Detection Non-Stop Mode Off */      \
+          }

--- a/MdeModulePkg/Include/Library/DxeMemoryProtectionHobLib.h
+++ b/MdeModulePkg/Include/Library/DxeMemoryProtectionHobLib.h
@@ -1,0 +1,33 @@
+/** @file
+
+Library for controlling hob-backed memory protection settings
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <Guid/DxeMemoryProtectionSettings.h>
+
+//
+//  The global used to access current Memory Protection Settings
+//
+extern DXE_MEMORY_PROTECTION_SETTINGS  gDxeMps;
+
+/**
+  Gets the input EFI_MEMORY_TYPE from the input DXE_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @param[in]  MemoryType            Memory type to check.
+  @param[in]  HeapGuardMemoryType   DXE_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @return TRUE  The given EFI_MEMORY_TYPE is TRUE in the given DXE_HEAP_GUARD_MEMORY_TYPES
+  @return FALSE The given EFI_MEMORY_TYPE is FALSE in the given DXE_HEAP_GUARD_MEMORY_TYPES
+**/
+BOOLEAN
+EFIAPI
+GetDxeMemoryTypeSettingFromBitfield (
+  IN EFI_MEMORY_TYPE              MemoryType,
+  IN DXE_HEAP_GUARD_MEMORY_TYPES  HeapGuardMemoryType
+  );

--- a/MdeModulePkg/Include/Library/DxeMemoryProtectionHobLib.h
+++ b/MdeModulePkg/Include/Library/DxeMemoryProtectionHobLib.h
@@ -1,0 +1,33 @@
+/** @file
+
+Library for controlling hob-backed memory protection settings
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <Guid/DxeMemoryProtectionSettings.h>
+
+//
+//  The global used to access current Memory Protection Settings
+//
+extern DXE_MEMORY_PROTECTION_SETTINGS  gDxeMps;
+
+/**
+  Gets the input EFI_MEMORY_TYPE from the input DXE_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @param[in]  MemoryType            Memory type to check.
+  @param[in]  HeapGuardMemoryType   DXE_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @return TRUE  The given EFI_MEMORY_TYPE is TRUE in the given DXE_HEAP_GUARD_MEMORY_TYPES
+  @return FALSE The given EFI_MEMORY_TYPE is FALSE in the given DXE_HEAP_GUARD_MEMORY_TYPES
+**/
+BOOLEAN
+EFIAPI
+GetDxeMemoryTypeSettingFromBitField (
+  IN EFI_MEMORY_TYPE              MemoryType,
+  IN DXE_HEAP_GUARD_MEMORY_TYPES  HeapGuardMemoryType
+  );

--- a/MdeModulePkg/Include/Library/MmMemoryProtectionHobLib.h
+++ b/MdeModulePkg/Include/Library/MmMemoryProtectionHobLib.h
@@ -1,0 +1,33 @@
+/** @file
+
+Library for controlling hob-backed memory protection settings
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <Guid/MmMemoryProtectionSettings.h>
+
+//
+//  The global used to access current Memory Protection Settings
+//
+extern MM_MEMORY_PROTECTION_SETTINGS  gMmMps;
+
+/**
+  Gets the input EFI_MEMORY_TYPE from the input MM_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @param[in]  MemoryType            Memory type to check.
+  @param[in]  HeapGuardMemoryType   MM_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @return TRUE  The given EFI_MEMORY_TYPE is TRUE in the given MM_HEAP_GUARD_MEMORY_TYPES
+  @return FALSE The given EFI_MEMORY_TYPE is FALSE in the given MM_HEAP_GUARD_MEMORY_TYPES
+**/
+BOOLEAN
+EFIAPI
+GetMmMemoryTypeSettingFromBitfield (
+  IN EFI_MEMORY_TYPE             MemoryType,
+  IN MM_HEAP_GUARD_MEMORY_TYPES  HeapGuardMemoryType
+  );

--- a/MdeModulePkg/Include/Library/MmMemoryProtectionHobLib.h
+++ b/MdeModulePkg/Include/Library/MmMemoryProtectionHobLib.h
@@ -1,0 +1,33 @@
+/** @file
+
+Library for controlling hob-backed memory protection settings
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <Guid/MmMemoryProtectionSettings.h>
+
+//
+//  The global used to access current Memory Protection Settings
+//
+extern MM_MEMORY_PROTECTION_SETTINGS  gMmMps;
+
+/**
+  Gets the input EFI_MEMORY_TYPE from the input MM_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @param[in]  MemoryType            Memory type to check.
+  @param[in]  HeapGuardMemoryType   MM_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @return TRUE  The given EFI_MEMORY_TYPE is TRUE in the given MM_HEAP_GUARD_MEMORY_TYPES
+  @return FALSE The given EFI_MEMORY_TYPE is FALSE in the given MM_HEAP_GUARD_MEMORY_TYPES
+**/
+BOOLEAN
+EFIAPI
+GetMmMemoryTypeSettingFromBitField (
+  IN EFI_MEMORY_TYPE             MemoryType,
+  IN MM_HEAP_GUARD_MEMORY_TYPES  HeapGuardMemoryType
+  );

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
@@ -1,0 +1,356 @@
+/** @file
+  Library fills out gDxeMps global
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Pi/PiMultiPhase.h>
+#include <Uefi/UefiMultiPhase.h>
+
+#include <Library/DxeMemoryProtectionHobLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcdLib.h>
+
+DXE_MEMORY_PROTECTION_SETTINGS  gDxeMps;
+
+/**
+  Gets the input EFI_MEMORY_TYPE from the input DXE_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @param[in]  MemoryType            Memory type to check.
+  @param[in]  HeapGuardMemoryType   DXE_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @return TRUE  The given EFI_MEMORY_TYPE is TRUE in the given DXE_HEAP_GUARD_MEMORY_TYPES
+  @return FALSE The given EFI_MEMORY_TYPE is FALSE in the given DXE_HEAP_GUARD_MEMORY_TYPES
+**/
+BOOLEAN
+EFIAPI
+GetDxeMemoryTypeSettingFromBitfield (
+  IN EFI_MEMORY_TYPE              MemoryType,
+  IN DXE_HEAP_GUARD_MEMORY_TYPES  HeapGuardMemoryType
+  )
+{
+  switch (MemoryType) {
+    case EfiReservedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiReservedMemoryType;
+    case EfiLoaderCode:
+      return HeapGuardMemoryType.Fields.EfiLoaderCode;
+    case EfiLoaderData:
+      return HeapGuardMemoryType.Fields.EfiLoaderData;
+    case EfiBootServicesCode:
+      return HeapGuardMemoryType.Fields.EfiBootServicesCode;
+    case EfiBootServicesData:
+      return HeapGuardMemoryType.Fields.EfiBootServicesData;
+    case EfiRuntimeServicesCode:
+      return HeapGuardMemoryType.Fields.EfiRuntimeServicesCode;
+    case EfiRuntimeServicesData:
+      return HeapGuardMemoryType.Fields.EfiRuntimeServicesData;
+    case EfiConventionalMemory:
+      return HeapGuardMemoryType.Fields.EfiConventionalMemory;
+    case EfiUnusableMemory:
+      return HeapGuardMemoryType.Fields.EfiUnusableMemory;
+    case EfiACPIReclaimMemory:
+      return HeapGuardMemoryType.Fields.EfiACPIReclaimMemory;
+    case EfiACPIMemoryNVS:
+      return HeapGuardMemoryType.Fields.EfiACPIMemoryNVS;
+    case EfiMemoryMappedIO:
+      return HeapGuardMemoryType.Fields.EfiMemoryMappedIO;
+    case EfiMemoryMappedIOPortSpace:
+      return HeapGuardMemoryType.Fields.EfiMemoryMappedIOPortSpace;
+    case EfiPalCode:
+      return HeapGuardMemoryType.Fields.EfiPalCode;
+    case EfiPersistentMemory:
+      return HeapGuardMemoryType.Fields.EfiPersistentMemory;
+    case EfiUnacceptedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiUnacceptedMemoryType;
+    default:
+      return FALSE;
+  }
+}
+
+/**
+  This function checks the memory protection settings and provides warnings of conflicts and/or
+  potentially unforseen consequences from the settings. This logic will only ever turn off
+  protections to create consistency, never turn others on.
+**/
+VOID
+DxeMemoryProtectionSettingsConsistencyCheck (
+  VOID
+  )
+{
+  if (!gDxeMps.ImageProtectionPolicy.Data &&
+      (gDxeMps.NxProtectionPolicy.Fields.EfiLoaderData       ||
+       gDxeMps.NxProtectionPolicy.Fields.EfiBootServicesData ||
+       gDxeMps.NxProtectionPolicy.Fields.EfiRuntimeServicesData))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Image Protection is inactive, but one or more of \
+      NxProtectionPolicy.EfiLoaderData \
+      NxProtectionPolicy.EfiBootServicesData \
+      NxProtectionPolicy.EfiRuntimeServicesData are active. \
+      Image data sections could still be non-executable.\n",
+      __func__
+      ));
+  }
+
+  if (gDxeMps.HeapGuardPoolType.Data &&
+      (!(gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard)))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Heap Guard Pool protections are active, \
+      but neither HeapGuardPolicy.UefiPoolGuard nor \
+      HeapGuardPolicy.MmPoolGuard are active.\n",
+      __func__
+      ));
+  }
+
+  if (gDxeMps.HeapGuardPageType.Data &&
+      (!(gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard)))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Heap Guard Page protections are active, \
+      but neither HeapGuardPolicy.UefiPageGuard nor \
+      HeapGuardPolicy.MmPageGuard are active.\n",
+      __func__
+      ));
+  }
+
+  if (gDxeMps.NxProtectionPolicy.Fields.EfiBootServicesData != gDxeMps.NxProtectionPolicy.Fields.EfiConventionalMemory) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - NxProtectionPolicy.EfiBootServicesData \
+      and NxProtectionPolicy.EfiConventionalMemory must have the same value. \
+      Setting both to ZERO in the memory protection settings global.\n",
+      __func__
+      ));
+    gDxeMps.NxProtectionPolicy.Fields.EfiBootServicesData   = 0;
+    gDxeMps.NxProtectionPolicy.Fields.EfiConventionalMemory = 0;
+  }
+
+  //
+  // the heap guard system does not support non-EFI_PAGE_SIZE alignments
+  // architectures that require larger RUNTIME_PAGE_ALLOCATION_GRANULARITY
+  // cannot have EfiRuntimeServicesCode, EfiRuntimeServicesData, EfiReservedMemoryType,
+  // and EfiACPIMemoryNVS guarded. OSes do not map guard pages anyway, so this is a
+  // minimal loss. Not guarding prevents alignment mismatches
+  //
+  if (RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE) {
+    if (gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) {
+      if (gDxeMps.HeapGuardPageType.Fields.EfiACPIMemoryNVS != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiACPIMemoryNVS. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiACPIMemoryNVS = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiReservedMemoryType != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiReservedMemoryType. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiReservedMemoryType = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesCode != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiRuntimeServicesCode. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesCode = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesData != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiRuntimeServicesData. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesData = 0;
+      }
+    }
+
+    if (gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard) {
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiACPIMemoryNVS != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiACPIMemoryNVS. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiACPIMemoryNVS = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiReservedMemoryType != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiReservedMemoryType. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiReservedMemoryType = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesCode != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiRuntimeServicesCode. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesCode = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesData != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiRuntimeServicesData. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesData = 0;
+      }
+    }
+  }
+}
+
+/**
+  Translates a memory type bitmask, ordered as defined by the memory protection PCDs
+  (UEFI spec memory type order in the low bits, OEM/OS reserved in the high bits), into
+  a DXE_HEAP_GUARD_MEMORY_TYPES bitfield.
+
+  @param[in]  Bitmask   The PCD-style memory type bitmask to translate.
+
+  @return The equivalent DXE_HEAP_GUARD_MEMORY_TYPES bitfield.
+**/
+STATIC
+DXE_HEAP_GUARD_MEMORY_TYPES
+DxeMemoryTypesFromBitmask (
+  IN UINT64  Bitmask
+  )
+{
+  DXE_HEAP_GUARD_MEMORY_TYPES  MemoryTypes;
+
+  //
+  // Bits 0 - 14 (EfiReservedMemoryType through EfiPersistentMemory) map directly
+  // to the low bits of the bitfield. The OEM/OS reserved types live in the high
+  // bits of the PCD but immediately after EfiUnacceptedMemoryType in the bitfield.
+  //
+  MemoryTypes.Data               = (UINT32)(Bitmask & 0x7FFF);
+  MemoryTypes.Fields.OEMReserved = ((Bitmask & BIT62) != 0) ? 1 : 0;
+  MemoryTypes.Fields.OSReserved  = ((Bitmask & BIT63) != 0) ? 1 : 0;
+
+  return MemoryTypes;
+}
+
+/**
+  Populates the gDxeMps global with the memory protection settings derived from the
+  platform memory protection PCDs. Used as a fallback when the Memory Protection
+  Settings HOB is not present.
+**/
+STATIC
+VOID
+PopulateDxeMpsFromPcds (
+  VOID
+  )
+{
+  UINT8   NullMask;
+  UINT8   HeapGuardMask;
+  UINT32  ImageProtectionMask;
+
+  ZeroMem (&gDxeMps, sizeof (gDxeMps));
+
+  gDxeMps.StructVersion = DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION;
+  gDxeMps.CpuStackGuard = PcdGetBool (PcdCpuStackGuard);
+
+  NullMask                                                    = PcdGet8 (PcdNullPointerDetectionPropertyMask);
+  gDxeMps.NullPointerDetectionPolicy.Fields.UefiNullDetection = (NullMask & BIT0) ? 1 : 0;
+  gDxeMps.NullPointerDetectionPolicy.Fields.DisableEndOfDxe   = (NullMask & BIT7) ? 1 : 0;
+
+  HeapGuardMask                                = PcdGet8 (PcdHeapGuardPropertyMask);
+  gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard = (HeapGuardMask & BIT0) ? 1 : 0;
+  gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard = (HeapGuardMask & BIT1) ? 1 : 0;
+  gDxeMps.HeapGuardPolicy.Fields.Direction     = (HeapGuardMask & BIT7) ? 1 : 0;
+
+  ImageProtectionMask                                          = PcdGet32 (PcdImageProtectionPolicy);
+  gDxeMps.ImageProtectionPolicy.Fields.ProtectImageFromUnknown = (ImageProtectionMask & BIT0) ? 1 : 0;
+  gDxeMps.ImageProtectionPolicy.Fields.ProtectImageFromFv      = (ImageProtectionMask & BIT1) ? 1 : 0;
+
+  gDxeMps.HeapGuardPoolType  = DxeMemoryTypesFromBitmask (PcdGet64 (PcdHeapGuardPoolType));
+  gDxeMps.HeapGuardPageType  = DxeMemoryTypesFromBitmask (PcdGet64 (PcdHeapGuardPageType));
+  gDxeMps.NxProtectionPolicy = DxeMemoryTypesFromBitmask (PcdGet64 (PcdDxeNxMemoryProtectionPolicy));
+
+  //
+  // Non-stop mode is only active when the corresponding UEFI protection is also enabled.
+  //
+  gDxeMps.HeapGuardPolicy.Fields.NonStopMode            = ((HeapGuardMask & (BIT6 | BIT4 | BIT1 | BIT0)) > BIT6) ? 1 : 0;
+  gDxeMps.NullPointerDetectionPolicy.Fields.NonStopMode = ((NullMask & (BIT6 | BIT0)) > BIT6) ? 1 : 0;
+}
+
+/**
+  Populates gDxeMps global with the data present in the HOB. If the HOB entry does not exist,
+  this constructor will populate the memory protection settings from the memory protection PCDs.
+
+  @param  ImageHandle   The firmware allocated handle for the EFI image.
+  @param  SystemTable   A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+DxeMemoryProtectionHobLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  VOID  *Ptr;
+
+  Ptr = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
+
+  //
+  // Cache the Memory Protection Settings HOB entry
+  //
+  if (Ptr != NULL) {
+    if (*((UINT8 *)GET_GUID_HOB_DATA (Ptr)) != (UINT8)DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "\nThe version number of the DXE Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
+        DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,
+        *((UINT8 *)GET_GUID_HOB_DATA (Ptr))
+        ));
+      DEBUG ((DEBUG_ERROR, "This usually happens when the Memory Protection Settings version was incremented\n"));
+      DEBUG ((DEBUG_ERROR, "and all modules have not been rebuilt with the new version number. Less likely but\n"));
+      DEBUG ((DEBUG_ERROR, "also possible is the HOB entry was corrupted or the producer of the HOB entry\n"));
+      DEBUG ((DEBUG_ERROR, "did not set the StructVersion field to DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION.\n"));
+      ASSERT (FALSE);
+      ZeroMem (&gDxeMps, sizeof (gDxeMps));
+      return EFI_SUCCESS;
+    }
+
+    CopyMem (&gDxeMps, GET_GUID_HOB_DATA (Ptr), sizeof (DXE_MEMORY_PROTECTION_SETTINGS));
+    DxeMemoryProtectionSettingsConsistencyCheck ();
+  } else {
+    DEBUG ((
+      DEBUG_INFO,
+      "DxeMemoryProtectionHobLibConstructor - Unable to fetch memory protection HOB. \
+       Falling back to memory protection PCDs\n"
+      ));
+    PopulateDxeMpsFromPcds ();
+    DxeMemoryProtectionSettingsConsistencyCheck ();
+  }
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
@@ -1,0 +1,358 @@
+/** @file
+  Library fills out gDxeMps global
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Pi/PiMultiPhase.h>
+#include <Uefi/UefiMultiPhase.h>
+
+#include <Library/DxeMemoryProtectionHobLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcdLib.h>
+
+DXE_MEMORY_PROTECTION_SETTINGS  gDxeMps;
+
+/**
+  Gets the input EFI_MEMORY_TYPE from the input DXE_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @param[in]  MemoryType            Memory type to check.
+  @param[in]  HeapGuardMemoryType   DXE_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @return TRUE  The given EFI_MEMORY_TYPE is TRUE in the given DXE_HEAP_GUARD_MEMORY_TYPES
+  @return FALSE The given EFI_MEMORY_TYPE is FALSE in the given DXE_HEAP_GUARD_MEMORY_TYPES
+**/
+BOOLEAN
+EFIAPI
+GetDxeMemoryTypeSettingFromBitField (
+  IN EFI_MEMORY_TYPE              MemoryType,
+  IN DXE_HEAP_GUARD_MEMORY_TYPES  HeapGuardMemoryType
+  )
+{
+  switch (MemoryType) {
+    case EfiReservedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiReservedMemoryType;
+    case EfiLoaderCode:
+      return HeapGuardMemoryType.Fields.EfiLoaderCode;
+    case EfiLoaderData:
+      return HeapGuardMemoryType.Fields.EfiLoaderData;
+    case EfiBootServicesCode:
+      return HeapGuardMemoryType.Fields.EfiBootServicesCode;
+    case EfiBootServicesData:
+      return HeapGuardMemoryType.Fields.EfiBootServicesData;
+    case EfiRuntimeServicesCode:
+      return HeapGuardMemoryType.Fields.EfiRuntimeServicesCode;
+    case EfiRuntimeServicesData:
+      return HeapGuardMemoryType.Fields.EfiRuntimeServicesData;
+    case EfiConventionalMemory:
+      return HeapGuardMemoryType.Fields.EfiConventionalMemory;
+    case EfiUnusableMemory:
+      return HeapGuardMemoryType.Fields.EfiUnusableMemory;
+    case EfiACPIReclaimMemory:
+      return HeapGuardMemoryType.Fields.EfiACPIReclaimMemory;
+    case EfiACPIMemoryNVS:
+      return HeapGuardMemoryType.Fields.EfiACPIMemoryNVS;
+    case EfiMemoryMappedIO:
+      return HeapGuardMemoryType.Fields.EfiMemoryMappedIO;
+    case EfiMemoryMappedIOPortSpace:
+      return HeapGuardMemoryType.Fields.EfiMemoryMappedIOPortSpace;
+    case EfiPalCode:
+      return HeapGuardMemoryType.Fields.EfiPalCode;
+    case EfiPersistentMemory:
+      return HeapGuardMemoryType.Fields.EfiPersistentMemory;
+    case EfiUnacceptedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiUnacceptedMemoryType;
+    default:
+      return FALSE;
+  }
+}
+
+/**
+  This function checks the memory protection settings and provides warnings of conflicts and/or
+  potentially unforseen consequences from the settings. This logic will only ever turn off
+  protections to create consistency, never turn others on.
+**/
+VOID
+DxeMemoryProtectionSettingsConsistencyCheck (
+  VOID
+  )
+{
+  if (!gDxeMps.ImageProtectionPolicy.Data &&
+      (gDxeMps.NxProtectionPolicy.Fields.EfiLoaderData       ||
+       gDxeMps.NxProtectionPolicy.Fields.EfiBootServicesData ||
+       gDxeMps.NxProtectionPolicy.Fields.EfiRuntimeServicesData))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Image Protection is inactive, but one or more of \
+      NxProtectionPolicy.EfiLoaderData \
+      NxProtectionPolicy.EfiBootServicesData \
+      NxProtectionPolicy.EfiRuntimeServicesData are active. \
+      Image data sections could still be non-executable.\n",
+      __func__
+      ));
+  }
+
+  if (gDxeMps.HeapGuardPoolType.Data &&
+      (!(gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard)))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Heap Guard Pool protections are active, \
+      but neither HeapGuardPolicy.UefiPoolGuard nor \
+      HeapGuardPolicy.MmPoolGuard are active.\n",
+      __func__
+      ));
+  }
+
+  if (gDxeMps.HeapGuardPageType.Data &&
+      (!(gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard)))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Heap Guard Page protections are active, \
+      but neither HeapGuardPolicy.UefiPageGuard nor \
+      HeapGuardPolicy.MmPageGuard are active.\n",
+      __func__
+      ));
+  }
+
+  if (gDxeMps.NxProtectionPolicy.Fields.EfiBootServicesData != gDxeMps.NxProtectionPolicy.Fields.EfiConventionalMemory) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - NxProtectionPolicy.EfiBootServicesData \
+      and NxProtectionPolicy.EfiConventionalMemory must have the same value. \
+      Setting both to ZERO in the memory protection settings global.\n",
+      __func__
+      ));
+    gDxeMps.NxProtectionPolicy.Fields.EfiBootServicesData   = 0;
+    gDxeMps.NxProtectionPolicy.Fields.EfiConventionalMemory = 0;
+  }
+
+  //
+  // the heap guard system does not support non-EFI_PAGE_SIZE alignments
+  // architectures that require larger RUNTIME_PAGE_ALLOCATION_GRANULARITY
+  // cannot have EfiRuntimeServicesCode, EfiRuntimeServicesData, EfiReservedMemoryType,
+  // and EfiACPIMemoryNVS guarded. OSes do not map guard pages anyway, so this is a
+  // minimal loss. Not guarding prevents alignment mismatches
+  //
+  if (RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE) {
+    if (gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) {
+      if (gDxeMps.HeapGuardPageType.Fields.EfiACPIMemoryNVS != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiACPIMemoryNVS. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiACPIMemoryNVS = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiReservedMemoryType != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiReservedMemoryType. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiReservedMemoryType = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesCode != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiRuntimeServicesCode. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesCode = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesData != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiRuntimeServicesData. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesData = 0;
+      }
+    }
+
+    if (gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard) {
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiACPIMemoryNVS != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiACPIMemoryNVS. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiACPIMemoryNVS = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiReservedMemoryType != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiReservedMemoryType. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiReservedMemoryType = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesCode != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiRuntimeServicesCode. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesCode = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesData != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiRuntimeServicesData. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesData = 0;
+      }
+    }
+  }
+}
+
+/**
+  Translates a memory type bitmask, ordered as defined by the memory protection PCDs
+  (UEFI spec memory type order in the low bits, OEM/OS reserved in the high bits), into
+  a DXE_HEAP_GUARD_MEMORY_TYPES bitfield.
+
+  @param[in]  Bitmask   The PCD-style memory type bitmask to translate.
+
+  @return The equivalent DXE_HEAP_GUARD_MEMORY_TYPES bitfield.
+**/
+STATIC
+DXE_HEAP_GUARD_MEMORY_TYPES
+DxeMemoryTypesFromBitmask (
+  IN UINT64  Bitmask
+  )
+{
+  DXE_HEAP_GUARD_MEMORY_TYPES  MemoryTypes;
+
+  //
+  // Bits 0 - 14 (EfiReservedMemoryType through EfiPersistentMemory) map directly
+  // to the low bits of the bitfield. The OEM/OS reserved types live in the high
+  // bits of the PCD but immediately after EfiUnacceptedMemoryType in the bitfield.
+  //
+  MemoryTypes.Data               = (UINT32)(Bitmask & 0x7FFF);
+  MemoryTypes.Fields.OEMReserved = ((Bitmask & BIT62) != 0) ? 1 : 0;
+  MemoryTypes.Fields.OSReserved  = ((Bitmask & BIT63) != 0) ? 1 : 0;
+
+  return MemoryTypes;
+}
+
+/**
+  Populates the gDxeMps global with the memory protection settings derived from the
+  platform memory protection PCDs. Used as a fallback when the Memory Protection
+  Settings HOB is not present.
+**/
+STATIC
+VOID
+PopulateDxeMpsFromPcds (
+  VOID
+  )
+{
+  UINT8   NullMask;
+  UINT8   HeapGuardMask;
+  UINT32  ImageProtectionMask;
+
+  ZeroMem (&gDxeMps, sizeof (gDxeMps));
+
+  gDxeMps.StructVersion = DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION;
+  gDxeMps.CpuStackGuard = PcdGetBool (PcdCpuStackGuard);
+
+  NullMask                                                    = PcdGet8 (PcdNullPointerDetectionPropertyMask);
+  gDxeMps.NullPointerDetectionPolicy.Fields.UefiNullDetection = (NullMask & BIT0) ? 1 : 0;
+  gDxeMps.NullPointerDetectionPolicy.Fields.DisableEndOfDxe   = (NullMask & BIT7) ? 1 : 0;
+
+  HeapGuardMask                                = PcdGet8 (PcdHeapGuardPropertyMask);
+  gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard = (HeapGuardMask & BIT0) ? 1 : 0;
+  gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard = (HeapGuardMask & BIT1) ? 1 : 0;
+  gDxeMps.HeapGuardPolicy.Fields.Direction     = (HeapGuardMask & BIT7) ? 1 : 0;
+
+  ImageProtectionMask                                          = PcdGet32 (PcdImageProtectionPolicy);
+  gDxeMps.ImageProtectionPolicy.Fields.ProtectImageFromUnknown = (ImageProtectionMask & BIT0) ? 1 : 0;
+  gDxeMps.ImageProtectionPolicy.Fields.ProtectImageFromFv      = (ImageProtectionMask & BIT1) ? 1 : 0;
+
+  gDxeMps.HeapGuardPoolType  = DxeMemoryTypesFromBitmask (PcdGet64 (PcdHeapGuardPoolType));
+  gDxeMps.HeapGuardPageType  = DxeMemoryTypesFromBitmask (PcdGet64 (PcdHeapGuardPageType));
+  gDxeMps.NxProtectionPolicy = DxeMemoryTypesFromBitmask (PcdGet64 (PcdDxeNxMemoryProtectionPolicy));
+
+  //
+  // Non-stop mode is only active when the corresponding UEFI protection is also enabled.
+  //
+  gDxeMps.HeapGuardPolicy.Fields.NonStopMode            = ((HeapGuardMask & (BIT6 | BIT4 | BIT1 | BIT0)) > BIT6) ? 1 : 0;
+  gDxeMps.NullPointerDetectionPolicy.Fields.NonStopMode = ((NullMask & (BIT6 | BIT0)) > BIT6) ? 1 : 0;
+}
+
+/**
+  Populates gDxeMps global with the data present in the HOB. If the HOB entry does not exist,
+  this constructor will populate the memory protection settings from the memory protection PCDs.
+
+  @param  ImageHandle   The firmware allocated handle for the EFI image.
+  @param  SystemTable   A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+DxeMemoryProtectionHobLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  VOID                            *Ptr;
+  DXE_MEMORY_PROTECTION_SETTINGS  *DxeMpsHob;
+
+  Ptr = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
+
+  //
+  // Cache the Memory Protection Settings HOB entry
+  //
+  if (Ptr != NULL) {
+    DxeMpsHob = (DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (Ptr);
+    if (DxeMpsHob->StructVersion != (UINT8)DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "\nThe version number of the DXE Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
+        DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,
+        DxeMpsHob->StructVersion
+        ));
+      DEBUG ((DEBUG_ERROR, "This usually happens when the Memory Protection Settings version was incremented\n"));
+      DEBUG ((DEBUG_ERROR, "and all modules have not been rebuilt with the new version number. Less likely but\n"));
+      DEBUG ((DEBUG_ERROR, "also possible is the HOB entry was corrupted or the producer of the HOB entry\n"));
+      DEBUG ((DEBUG_ERROR, "did not set the StructVersion field to DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION.\n"));
+      ASSERT (FALSE);
+      ZeroMem (&gDxeMps, sizeof (gDxeMps));
+      return EFI_SUCCESS;
+    }
+
+    CopyMem (&gDxeMps, DxeMpsHob, sizeof (DXE_MEMORY_PROTECTION_SETTINGS));
+    DxeMemoryProtectionSettingsConsistencyCheck ();
+  } else {
+    DEBUG ((
+      DEBUG_INFO,
+      "DxeMemoryProtectionHobLibConstructor - Unable to fetch memory protection HOB. \
+       Falling back to memory protection PCDs\n"
+      ));
+    PopulateDxeMpsFromPcds ();
+    DxeMemoryProtectionSettingsConsistencyCheck ();
+  }
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
@@ -1,0 +1,44 @@
+## @file
+# DXE library instance to support platform-specific global controls for all memory protections.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = DxeMemoryProtectionHobLib
+  FILE_GUID                      = f497f7de-b9ab-4b9f-807e-89778922542d
+  MODULE_TYPE                    = UEFI_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = DxeMemoryProtectionHobLib|DXE_DRIVER DXE_CORE UEFI_APPLICATION
+  CONSTRUCTOR                    = DxeMemoryProtectionHobLibConstructor
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  DxeMemoryProtectionHobLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  HobLib
+  DebugLib
+  BaseMemoryLib
+  PcdLib
+
+[Guids]
+  gDxeMemoryProtectionSettingsGuid
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                    ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask            ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdImageProtectionPolicy            ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPoolType                ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPageType                ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy      ## CONSUMES

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
@@ -1,0 +1,220 @@
+/** @file
+  Library fills out gMmMps global
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Pi/PiMultiPhase.h>
+#include <Uefi/UefiMultiPhase.h>
+
+#include <Library/MmMemoryProtectionHobLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcdLib.h>
+
+MM_MEMORY_PROTECTION_SETTINGS  gMmMps;
+
+/**
+  Gets the input EFI_MEMORY_TYPE from the input MM_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @param[in]  MemoryType            Memory type to check.
+  @param[in]  HeapGuardMemoryType   MM_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @return TRUE  The given EFI_MEMORY_TYPE is TRUE in the given MM_HEAP_GUARD_MEMORY_TYPES
+  @return FALSE The given EFI_MEMORY_TYPE is FALSE in the given MM_HEAP_GUARD_MEMORY_TYPES
+**/
+BOOLEAN
+EFIAPI
+GetMmMemoryTypeSettingFromBitfield (
+  IN EFI_MEMORY_TYPE             MemoryType,
+  IN MM_HEAP_GUARD_MEMORY_TYPES  HeapGuardMemoryType
+  )
+{
+  switch (MemoryType) {
+    case EfiReservedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiReservedMemoryType;
+    case EfiLoaderCode:
+      return HeapGuardMemoryType.Fields.EfiLoaderCode;
+    case EfiLoaderData:
+      return HeapGuardMemoryType.Fields.EfiLoaderData;
+    case EfiBootServicesCode:
+      return HeapGuardMemoryType.Fields.EfiBootServicesCode;
+    case EfiBootServicesData:
+      return HeapGuardMemoryType.Fields.EfiBootServicesData;
+    case EfiRuntimeServicesCode:
+      return HeapGuardMemoryType.Fields.EfiRuntimeServicesCode;
+    case EfiRuntimeServicesData:
+      return HeapGuardMemoryType.Fields.EfiRuntimeServicesData;
+    case EfiConventionalMemory:
+      return HeapGuardMemoryType.Fields.EfiConventionalMemory;
+    case EfiUnusableMemory:
+      return HeapGuardMemoryType.Fields.EfiUnusableMemory;
+    case EfiACPIReclaimMemory:
+      return HeapGuardMemoryType.Fields.EfiACPIReclaimMemory;
+    case EfiACPIMemoryNVS:
+      return HeapGuardMemoryType.Fields.EfiACPIMemoryNVS;
+    case EfiMemoryMappedIO:
+      return HeapGuardMemoryType.Fields.EfiMemoryMappedIO;
+    case EfiMemoryMappedIOPortSpace:
+      return HeapGuardMemoryType.Fields.EfiMemoryMappedIOPortSpace;
+    case EfiPalCode:
+      return HeapGuardMemoryType.Fields.EfiPalCode;
+    case EfiPersistentMemory:
+      return HeapGuardMemoryType.Fields.EfiPersistentMemory;
+    case EfiUnacceptedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiUnacceptedMemoryType;
+    default:
+      return FALSE;
+  }
+}
+
+/**
+  This function checks the memory protection settings and provides warnings of conflicts and/or
+  potentially unforseen consequences from the settings. This logic will only ever turn off
+  protections to create consistency, never turn others on.
+**/
+VOID
+MmMemoryProtectionSettingsConsistencyCheck (
+  VOID
+  )
+{
+  if (gMmMps.HeapGuardPoolType.Data &&
+      (!(gMmMps.HeapGuardPolicy.Fields.MmPoolGuard)))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Bits set in gMmMps.HeapGuardPoolType, but gMmMps.HeapGuardPolicy.Fields.MmPoolGuard is inactive. "
+      "No pool guards will be set.\n",
+      __func__
+      ));
+  }
+
+  if (gMmMps.HeapGuardPageType.Data &&
+      (!(gMmMps.HeapGuardPolicy.Fields.MmPageGuard)))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Bits are set in gMmMps.HeapGuardPageType, but gMmMps.HeapGuardPolicy.Fields.MmPageGuard is inactive. "
+      "No page guards will be set.\n",
+      __func__
+      ));
+  }
+}
+
+/**
+  Translates a memory type bitmask, ordered as defined by the memory protection PCDs
+  (UEFI spec memory type order in the low bits, OEM/OS reserved in the high bits), into
+  a MM_HEAP_GUARD_MEMORY_TYPES bitfield.
+
+  @param[in]  Bitmask   The PCD-style memory type bitmask to translate.
+
+  @return The equivalent MM_HEAP_GUARD_MEMORY_TYPES bitfield.
+**/
+STATIC
+MM_HEAP_GUARD_MEMORY_TYPES
+MmMemoryTypesFromBitmask (
+  IN UINT64  Bitmask
+  )
+{
+  MM_HEAP_GUARD_MEMORY_TYPES  MemoryTypes;
+
+  //
+  // Bits 0 - 14 (EfiReservedMemoryType through EfiPersistentMemory) map directly
+  // to the low bits of the bitfield. The OEM/OS reserved types live in the high
+  // bits of the PCD but immediately after EfiUnacceptedMemoryType in the bitfield.
+  //
+  MemoryTypes.Data               = (UINT32)(Bitmask & 0x7FFF);
+  MemoryTypes.Fields.OEMReserved = ((Bitmask & BIT62) != 0) ? 1 : 0;
+  MemoryTypes.Fields.OSReserved  = ((Bitmask & BIT63) != 0) ? 1 : 0;
+
+  return MemoryTypes;
+}
+
+/**
+  Populates the gMmMps global with the memory protection settings derived from the
+  platform memory protection PCDs. Used as a fallback when the Memory Protection
+  Settings HOB is not present.
+**/
+STATIC
+VOID
+PopulateMmMpsFromPcds (
+  VOID
+  )
+{
+  UINT8  NullMask;
+  UINT8  HeapGuardMask;
+
+  ZeroMem (&gMmMps, sizeof (gMmMps));
+
+  gMmMps.StructVersion = MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION;
+
+  NullMask                          = PcdGet8 (PcdNullPointerDetectionPropertyMask);
+  gMmMps.NullPointerDetectionPolicy = (NullMask & BIT1) ? TRUE : FALSE;
+
+  HeapGuardMask                             = PcdGet8 (PcdHeapGuardPropertyMask);
+  gMmMps.HeapGuardPolicy.Fields.MmPageGuard = (HeapGuardMask & BIT2) ? 1 : 0;
+  gMmMps.HeapGuardPolicy.Fields.MmPoolGuard = (HeapGuardMask & BIT3) ? 1 : 0;
+  gMmMps.HeapGuardPolicy.Fields.Direction   = (HeapGuardMask & BIT7) ? 1 : 0;
+
+  gMmMps.HeapGuardPoolType = MmMemoryTypesFromBitmask (PcdGet64 (PcdHeapGuardPoolType));
+  gMmMps.HeapGuardPageType = MmMemoryTypesFromBitmask (PcdGet64 (PcdHeapGuardPageType));
+
+  //
+  // Non-stop mode is only active when the corresponding MM protection is also enabled.
+  //
+  gMmMps.HeapGuardPolicy.Fields.NonStopMode = ((HeapGuardMask & (BIT6 | BIT3 | BIT2)) > BIT6) ? 1 : 0;
+  gMmMps.NullDetectionNonStopMode           = ((NullMask & (BIT6 | BIT1)) > BIT6) ? TRUE : FALSE;
+}
+
+/**
+  Abstraction layer for library constructor of Standalone MM and SMM instances.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+MmMemoryProtectionHobLibConstructorCommon (
+  VOID
+  )
+{
+  VOID  *Ptr;
+
+  Ptr = GetFirstGuidHob (&gMmMemoryProtectionSettingsGuid);
+
+  //
+  // Cache the Memory Protection Settings HOB entry
+  //
+  if (Ptr != NULL) {
+    if (*((UINT8 *)GET_GUID_HOB_DATA (Ptr)) != (UINT8)MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "\nThe version number of the MM Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
+        MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,
+        *((UINT8 *)GET_GUID_HOB_DATA (Ptr))
+        ));
+      DEBUG ((DEBUG_ERROR, "This usually happens when the Memory Protection Settings version was incremented\n"));
+      DEBUG ((DEBUG_ERROR, "and all modules have not been rebuilt with the new version number. Less likely but\n"));
+      DEBUG ((DEBUG_ERROR, "also possible is the HOB entry was corrupted or the producer of the HOB entry\n"));
+      DEBUG ((DEBUG_ERROR, "did not set the StructVersion field to MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION.\n"));
+      ASSERT (FALSE);
+      ZeroMem (&gMmMps, sizeof (gMmMps));
+      return EFI_SUCCESS;
+    }
+
+    CopyMem (&gMmMps, GET_GUID_HOB_DATA (Ptr), sizeof (MM_MEMORY_PROTECTION_SETTINGS));
+    MmMemoryProtectionSettingsConsistencyCheck ();
+  } else {
+    DEBUG ((
+      DEBUG_INFO,
+      "MmMemoryProtectionHobLibConstructor - Unable to fetch memory protection HOB. \
+Falling back to memory protection PCDs\n"
+      ));
+    PopulateMmMpsFromPcds ();
+    MmMemoryProtectionSettingsConsistencyCheck ();
+  }
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
@@ -1,0 +1,222 @@
+/** @file
+  Library fills out gMmMps global
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Pi/PiMultiPhase.h>
+#include <Uefi/UefiMultiPhase.h>
+
+#include <Library/MmMemoryProtectionHobLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcdLib.h>
+
+MM_MEMORY_PROTECTION_SETTINGS  gMmMps;
+
+/**
+  Gets the input EFI_MEMORY_TYPE from the input MM_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @param[in]  MemoryType            Memory type to check.
+  @param[in]  HeapGuardMemoryType   MM_HEAP_GUARD_MEMORY_TYPES bitfield
+
+  @return TRUE  The given EFI_MEMORY_TYPE is TRUE in the given MM_HEAP_GUARD_MEMORY_TYPES
+  @return FALSE The given EFI_MEMORY_TYPE is FALSE in the given MM_HEAP_GUARD_MEMORY_TYPES
+**/
+BOOLEAN
+EFIAPI
+GetMmMemoryTypeSettingFromBitField (
+  IN EFI_MEMORY_TYPE             MemoryType,
+  IN MM_HEAP_GUARD_MEMORY_TYPES  HeapGuardMemoryType
+  )
+{
+  switch (MemoryType) {
+    case EfiReservedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiReservedMemoryType;
+    case EfiLoaderCode:
+      return HeapGuardMemoryType.Fields.EfiLoaderCode;
+    case EfiLoaderData:
+      return HeapGuardMemoryType.Fields.EfiLoaderData;
+    case EfiBootServicesCode:
+      return HeapGuardMemoryType.Fields.EfiBootServicesCode;
+    case EfiBootServicesData:
+      return HeapGuardMemoryType.Fields.EfiBootServicesData;
+    case EfiRuntimeServicesCode:
+      return HeapGuardMemoryType.Fields.EfiRuntimeServicesCode;
+    case EfiRuntimeServicesData:
+      return HeapGuardMemoryType.Fields.EfiRuntimeServicesData;
+    case EfiConventionalMemory:
+      return HeapGuardMemoryType.Fields.EfiConventionalMemory;
+    case EfiUnusableMemory:
+      return HeapGuardMemoryType.Fields.EfiUnusableMemory;
+    case EfiACPIReclaimMemory:
+      return HeapGuardMemoryType.Fields.EfiACPIReclaimMemory;
+    case EfiACPIMemoryNVS:
+      return HeapGuardMemoryType.Fields.EfiACPIMemoryNVS;
+    case EfiMemoryMappedIO:
+      return HeapGuardMemoryType.Fields.EfiMemoryMappedIO;
+    case EfiMemoryMappedIOPortSpace:
+      return HeapGuardMemoryType.Fields.EfiMemoryMappedIOPortSpace;
+    case EfiPalCode:
+      return HeapGuardMemoryType.Fields.EfiPalCode;
+    case EfiPersistentMemory:
+      return HeapGuardMemoryType.Fields.EfiPersistentMemory;
+    case EfiUnacceptedMemoryType:
+      return HeapGuardMemoryType.Fields.EfiUnacceptedMemoryType;
+    default:
+      return FALSE;
+  }
+}
+
+/**
+  This function checks the memory protection settings and provides warnings of conflicts and/or
+  potentially unforseen consequences from the settings. This logic will only ever turn off
+  protections to create consistency, never turn others on.
+**/
+VOID
+MmMemoryProtectionSettingsConsistencyCheck (
+  VOID
+  )
+{
+  if (gMmMps.HeapGuardPoolType.Data &&
+      (!(gMmMps.HeapGuardPolicy.Fields.MmPoolGuard)))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Bits set in gMmMps.HeapGuardPoolType, but gMmMps.HeapGuardPolicy.Fields.MmPoolGuard is inactive. "
+      "No pool guards will be set.\n",
+      __func__
+      ));
+  }
+
+  if (gMmMps.HeapGuardPageType.Data &&
+      (!(gMmMps.HeapGuardPolicy.Fields.MmPageGuard)))
+  {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: - Bits are set in gMmMps.HeapGuardPageType, but gMmMps.HeapGuardPolicy.Fields.MmPageGuard is inactive. "
+      "No page guards will be set.\n",
+      __func__
+      ));
+  }
+}
+
+/**
+  Translates a memory type bitmask, ordered as defined by the memory protection PCDs
+  (UEFI spec memory type order in the low bits, OEM/OS reserved in the high bits), into
+  a MM_HEAP_GUARD_MEMORY_TYPES bitfield.
+
+  @param[in]  Bitmask   The PCD-style memory type bitmask to translate.
+
+  @return The equivalent MM_HEAP_GUARD_MEMORY_TYPES bitfield.
+**/
+STATIC
+MM_HEAP_GUARD_MEMORY_TYPES
+MmMemoryTypesFromBitmask (
+  IN UINT64  Bitmask
+  )
+{
+  MM_HEAP_GUARD_MEMORY_TYPES  MemoryTypes;
+
+  //
+  // Bits 0 - 14 (EfiReservedMemoryType through EfiPersistentMemory) map directly
+  // to the low bits of the bitfield. The OEM/OS reserved types live in the high
+  // bits of the PCD but immediately after EfiUnacceptedMemoryType in the bitfield.
+  //
+  MemoryTypes.Data               = (UINT32)(Bitmask & 0x7FFF);
+  MemoryTypes.Fields.OEMReserved = ((Bitmask & BIT62) != 0) ? 1 : 0;
+  MemoryTypes.Fields.OSReserved  = ((Bitmask & BIT63) != 0) ? 1 : 0;
+
+  return MemoryTypes;
+}
+
+/**
+  Populates the gMmMps global with the memory protection settings derived from the
+  platform memory protection PCDs. Used as a fallback when the Memory Protection
+  Settings HOB is not present.
+**/
+STATIC
+VOID
+PopulateMmMpsFromPcds (
+  VOID
+  )
+{
+  UINT8  NullMask;
+  UINT8  HeapGuardMask;
+
+  ZeroMem (&gMmMps, sizeof (gMmMps));
+
+  gMmMps.StructVersion = MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION;
+
+  NullMask                          = PcdGet8 (PcdNullPointerDetectionPropertyMask);
+  gMmMps.NullPointerDetectionPolicy = (NullMask & BIT1) ? TRUE : FALSE;
+
+  HeapGuardMask                             = PcdGet8 (PcdHeapGuardPropertyMask);
+  gMmMps.HeapGuardPolicy.Fields.MmPageGuard = (HeapGuardMask & BIT2) ? 1 : 0;
+  gMmMps.HeapGuardPolicy.Fields.MmPoolGuard = (HeapGuardMask & BIT3) ? 1 : 0;
+  gMmMps.HeapGuardPolicy.Fields.Direction   = (HeapGuardMask & BIT7) ? 1 : 0;
+
+  gMmMps.HeapGuardPoolType = MmMemoryTypesFromBitmask (PcdGet64 (PcdHeapGuardPoolType));
+  gMmMps.HeapGuardPageType = MmMemoryTypesFromBitmask (PcdGet64 (PcdHeapGuardPageType));
+
+  //
+  // Non-stop mode is only active when the corresponding MM protection is also enabled.
+  //
+  gMmMps.HeapGuardPolicy.Fields.NonStopMode = ((HeapGuardMask & (BIT6 | BIT3 | BIT2)) > BIT6) ? 1 : 0;
+  gMmMps.NullDetectionNonStopMode           = ((NullMask & (BIT6 | BIT1)) > BIT6) ? TRUE : FALSE;
+}
+
+/**
+  Abstraction layer for library constructor of Standalone MM and SMM instances.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+MmMemoryProtectionHobLibConstructorCommon (
+  VOID
+  )
+{
+  VOID                           *Ptr;
+  MM_MEMORY_PROTECTION_SETTINGS  *MmMpsHob;
+
+  Ptr = GetFirstGuidHob (&gMmMemoryProtectionSettingsGuid);
+
+  //
+  // Cache the Memory Protection Settings HOB entry
+  //
+  if (Ptr != NULL) {
+    MmMpsHob = (MM_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (Ptr);
+    if (MmMpsHob->StructVersion != (UINT8)MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "\nThe version number of the MM Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
+        MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,
+        MmMpsHob->StructVersion
+        ));
+      DEBUG ((DEBUG_ERROR, "This usually happens when the Memory Protection Settings version was incremented\n"));
+      DEBUG ((DEBUG_ERROR, "and all modules have not been rebuilt with the new version number. Less likely but\n"));
+      DEBUG ((DEBUG_ERROR, "also possible is the HOB entry was corrupted or the producer of the HOB entry\n"));
+      DEBUG ((DEBUG_ERROR, "did not set the StructVersion field to MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION.\n"));
+      ASSERT (FALSE);
+      ZeroMem (&gMmMps, sizeof (gMmMps));
+      return EFI_SUCCESS;
+    }
+
+    CopyMem (&gMmMps, MmMpsHob, sizeof (MM_MEMORY_PROTECTION_SETTINGS));
+    MmMemoryProtectionSettingsConsistencyCheck ();
+  } else {
+    DEBUG ((
+      DEBUG_INFO,
+      "MmMemoryProtectionHobLibConstructor - Unable to fetch memory protection HOB. \
+Falling back to memory protection PCDs\n"
+      ));
+    PopulateMmMpsFromPcds ();
+    MmMemoryProtectionSettingsConsistencyCheck ();
+  }
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.c
@@ -1,0 +1,37 @@
+/** @file
+  Library fills out gMmMps global
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiSmm.h>
+
+/**
+  Abstraction layer for library constructor of Standalone MM and SMM instances.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+MmMemoryProtectionHobLibConstructorCommon (
+  VOID
+  );
+
+/**
+  Library constructor of SMM instance.
+
+  @param  ImageHandle   The firmware allocated handle for the EFI image.
+  @param  SystemTable   A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+SmmMemoryProtectionHobLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return MmMemoryProtectionHobLibConstructorCommon ();
+}

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
@@ -1,0 +1,42 @@
+## @file
+# SMM library instance to support platform-specific global controls for all memory protections.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmMemoryProtectionHobLib
+  FILE_GUID                      = dc9666f4-917f-400d-8026-2b3beeeff195
+  MODULE_TYPE                    = DXE_SMM_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MmMemoryProtectionHobLib|SMM_CORE DXE_SMM_DRIVER
+  CONSTRUCTOR                    = SmmMemoryProtectionHobLibConstructor
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MmCommonMemoryProtectionHobLib.c
+  SmmMemoryProtectionHobLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  HobLib
+  DebugLib
+  BaseMemoryLib
+  PcdLib
+
+[Guids]
+  gMmMemoryProtectionSettingsGuid
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask            ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPoolType                ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPageType                ## CONSUMES

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.c
@@ -1,0 +1,37 @@
+/** @file
+  Library fills out gMmMps global
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiMm.h>
+
+/**
+  Abstraction layer for library constructor of Standalone MM and SMM instances.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+MmMemoryProtectionHobLibConstructorCommon (
+  VOID
+  );
+
+/**
+  Library constructor of Standalone MM instance.
+
+  @param  ImageHandle   The firmware allocated handle for the EFI image.
+  @param  SystemTable   A pointer to the EFI MM System Table.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+StandaloneMmMemoryProtectionHobLibConstructor (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return MmMemoryProtectionHobLibConstructorCommon ();
+}

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
@@ -1,0 +1,43 @@
+## @file
+# SMM library instance to support platform-specific global controls for all memory protections.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = StandaloneMmMemoryProtectionHobLib
+  FILE_GUID                      = C0A0D9C4-A249-483A-86EA-D73146D397B3
+  MODULE_TYPE                    = MM_CORE_STANDALONE
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MmMemoryProtectionHobLib|MM_CORE_STANDALONE MM_STANDALONE
+  CONSTRUCTOR                    = StandaloneMmMemoryProtectionHobLibConstructor
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  MmCommonMemoryProtectionHobLib.c
+  StandaloneMmMemoryProtectionHobLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  HobLib
+  DebugLib
+  BaseMemoryLib
+  PcdLib
+
+[Guids]
+  gMmMemoryProtectionSettingsGuid
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask            ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPoolType                ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPageType                ## CONSUMES

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -186,6 +186,14 @@
   #
   HobPrintLib|Include/Library/HobPrintLib.h
 
+  ## @libraryclass Provides a way to toggle DXE memory protection settings
+  #
+  DxeMemoryProtectionHobLib|Include/Library/DxeMemoryProtectionHobLib.h
+
+  ## @libraryclass Provides a way to toggle SMM memory protection settings
+  #
+  MmMemoryProtectionHobLib|Include/Library/MmMemoryProtectionHobLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h
@@ -427,6 +435,16 @@
   gNVMeEnableStartEventGroupGuid = { 0x4754469d, 0x6528, 0x4dfc, { 0x84, 0xaa, 0x8c, 0x8a, 0x03, 0xa2, 0x15, 0x8b } }
   # {da383315-906b-486f-80db-847f268451e4}
   gNVMeEnableCompleteEventGroupGuid = { 0xda383315, 0x906b, 0x486f, { 0x80, 0xdb, 0x84, 0x7f, 0x26, 0x84, 0x51, 0xe4 } }
+
+  ## DXE Memory Protection Settings Guid. Used to create and fetch the DXE memory protection settings HOB entry.
+  #
+  # Include/Guid/DxeMemoryProtectionSettings
+  gDxeMemoryProtectionSettingsGuid = { 0xE9DD2850, 0xB4D9, 0x4573, { 0xAA, 0x31, 0x80, 0xFF, 0x1C, 0x3E, 0xF5, 0x47 } }
+
+  ## SMM Memory Protection Settings Guid. Used to create and fetch the SMM memory protection settings HOB entry.
+  #
+  # Include/Guid/MmMemoryProtectionSettings
+  gMmMemoryProtectionSettingsGuid = { 0xF8DFE785, 0x98F5, 0x41B0, { 0x93, 0x7D, 0xE5, 0x84, 0x85, 0x5F, 0xD5, 0x62 } }
 
   ## Used (similar to Variable Services) to communicate policies to the enforcement engine.
   # {DA1B0D11-D1A7-46C4-9DC9-F3714875C6EB}

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -183,6 +183,14 @@
   #
   HobPrintLib|Include/Library/HobPrintLib.h
 
+  ## @libraryclass Provides a way to toggle DXE memory protection settings
+  #
+  DxeMemoryProtectionHobLib|Include/Library/DxeMemoryProtectionHobLib.h
+
+  ## @libraryclass Provides a way to toggle SMM memory protection settings
+  #
+  MmMemoryProtectionHobLib|Include/Library/MmMemoryProtectionHobLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h
@@ -424,6 +432,16 @@
   gNVMeEnableStartEventGroupGuid = { 0x4754469d, 0x6528, 0x4dfc, { 0x84, 0xaa, 0x8c, 0x8a, 0x03, 0xa2, 0x15, 0x8b } }
   # {da383315-906b-486f-80db-847f268451e4}
   gNVMeEnableCompleteEventGroupGuid = { 0xda383315, 0x906b, 0x486f, { 0x80, 0xdb, 0x84, 0x7f, 0x26, 0x84, 0x51, 0xe4 } }
+
+  ## DXE Memory Protection Settings Guid. Used to create and fetch the DXE memory protection settings HOB entry.
+  #
+  # Include/Guid/DxeMemoryProtectionSettings
+  gDxeMemoryProtectionSettingsGuid = { 0xE9DD2850, 0xB4D9, 0x4573, { 0xAA, 0x31, 0x80, 0xFF, 0x1C, 0x3E, 0xF5, 0x47 } }
+
+  ## SMM Memory Protection Settings Guid. Used to create and fetch the SMM memory protection settings HOB entry.
+  #
+  # Include/Guid/MmMemoryProtectionSettings
+  gMmMemoryProtectionSettingsGuid = { 0xF8DFE785, 0x98F5, 0x41B0, { 0x93, 0x7D, 0xE5, 0x84, 0x85, 0x5F, 0xD5, 0x62 } }
 
   ## Used (similar to Variable Services) to communicate policies to the enforcement engine.
   # {DA1B0D11-D1A7-46C4-9DC9-F3714875C6EB}

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -109,6 +109,16 @@
   IpmiCommandLib|MdeModulePkg/Library/BaseIpmiCommandLibNull/BaseIpmiCommandLibNull.inf
   SpiHcPlatformLib|MdeModulePkg/Library/BaseSpiHcPlatformLibNull/BaseSpiHcPlatformLibNull.inf
 
+
+[LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_CORE, LibraryClasses.common.UEFI_APPLICATION]
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+
+[LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER]
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
+
+[LibraryClasses.common.MM_CORE_STANDALONE, LibraryClasses.common.MM_STANDALONE]
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
+
 [LibraryClasses.EBC.PEIM]
   IoLib|MdePkg/Library/PeiIoLibCpuIo/PeiIoLibCpuIo.inf
 
@@ -210,7 +220,9 @@
   MdeModulePkg/Application/HelloWorld/HelloWorld.inf
   MdeModulePkg/Application/DumpDynPcd/DumpDynPcd.inf
   MdeModulePkg/Application/MemoryProfileInfo/MemoryProfileInfo.inf
-
+  MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
+  MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
   MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
   MdeModulePkg/Logo/Logo.inf
   MdeModulePkg/Logo/LogoDxe.inf

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -110,6 +110,16 @@
   IpmiCommandLib|MdeModulePkg/Library/BaseIpmiCommandLibNull/BaseIpmiCommandLibNull.inf
   SpiHcPlatformLib|MdeModulePkg/Library/BaseSpiHcPlatformLibNull/BaseSpiHcPlatformLibNull.inf
 
+
+[LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_CORE, LibraryClasses.common.UEFI_APPLICATION]
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+
+[LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER]
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
+
+[LibraryClasses.common.MM_CORE_STANDALONE, LibraryClasses.common.MM_STANDALONE]
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
+
 [LibraryClasses.EBC.PEIM]
   IoLib|MdePkg/Library/PeiIoLibCpuIo/PeiIoLibCpuIo.inf
 
@@ -211,7 +221,9 @@
   MdeModulePkg/Application/HelloWorld/HelloWorld.inf
   MdeModulePkg/Application/DumpDynPcd/DumpDynPcd.inf
   MdeModulePkg/Application/MemoryProfileInfo/MemoryProfileInfo.inf
-
+  MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
+  MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
   MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
   MdeModulePkg/Logo/Logo.inf
   MdeModulePkg/Logo/LogoDxe.inf

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -295,6 +295,7 @@
 
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
 
 [LibraryClasses.common.DXE_CORE]

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -199,6 +199,7 @@
 
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
 
 !include OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc

--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
+++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
@@ -198,6 +198,7 @@
 
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
 
 !include OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -229,6 +229,7 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
   XenPlatformLib|OvmfPkg/Library/XenPlatformLib/XenPlatformLib.inf
 
 !include OvmfPkg/Include/Dsc/ShellLibs.dsc.inc

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -320,6 +320,7 @@
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/PeiQemuFwCfgS3LibFwCfg.inf
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
 
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf

--- a/OvmfPkg/Bhyve/BhyveX64.dsc
+++ b/OvmfPkg/Bhyve/BhyveX64.dsc
@@ -228,6 +228,7 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
   XenPlatformLib|OvmfPkg/Library/XenPlatformLib/XenPlatformLib.inf
 
 !include OvmfPkg/Include/Dsc/ShellLibs.dsc.inc

--- a/OvmfPkg/Bhyve/PlatformPei/Platform.c
+++ b/OvmfPkg/Bhyve/PlatformPei/Platform.c
@@ -29,6 +29,7 @@
 #include <Library/PeimEntryPoint.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/PlatformInitLib.h>
+#include <Library/PlatformMemoryProtectionLib.h>
 #include <Library/ResourcePublicationLib.h>
 #include <Guid/MemoryTypeInformation.h>
 #include <Ppi/MasterBootMode.h>
@@ -572,6 +573,13 @@ InitializePlatform (
 {
   DEBUG ((DEBUG_INFO, "Platform PEIM Loaded\n"));
   BuildPlatformInfoHob ();
+
+  //
+  // Build the DXE memory protection settings HOB from fw_cfg. If no fw_cfg
+  // selector is present, no HOB is produced and the memory protection PCDs
+  // are used as a fallback.
+  //
+  PlatformBuildMemoryProtectionSettingsHob ();
 
   //
   // Initialize Local APIC Timer hardware and disable Local APIC Timer

--- a/OvmfPkg/Bhyve/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/Bhyve/PlatformPei/PlatformPei.inf
@@ -60,6 +60,7 @@
   PeiServicesLib
   PeiServicesTablePointerLib
   PcdLib
+  PlatformMemoryProtectionLib
   ResourcePublicationLib
 
 [Pcd]

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -246,6 +246,8 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 !include OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
 

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -247,6 +247,8 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 !include OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
 

--- a/OvmfPkg/CloudHv/CloudHvX64.dsc
+++ b/OvmfPkg/CloudHv/CloudHvX64.dsc
@@ -328,6 +328,7 @@
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
 
 [LibraryClasses.common.DXE_CORE]
   HobLib|MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf

--- a/OvmfPkg/Include/Library/PlatformMemoryProtectionLib.h
+++ b/OvmfPkg/Include/Library/PlatformMemoryProtectionLib.h
@@ -1,0 +1,48 @@
+/** @file
+  Library that builds the DXE and MM memory protection settings HOBs based on a
+  QEMU fw_cfg selector.
+
+  The fw_cfg file "opt/org.tianocore/MemoryProtection" contains the name of the
+  memory protection profile to apply. If the fw_cfg file is not present, no HOB
+  is produced and the memory protection PCDs are used as a fallback.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <Uefi/UefiBaseType.h>
+
+/**
+  Build the DXE memory protection settings HOB based on a QEMU fw_cfg selector.
+
+  The fw_cfg file "opt/org.tianocore/MemoryProtection" contains the name of the
+  memory protection profile to apply (e.g. "DEBUG" selects
+  DXE_MEMORY_PROTECTION_SETTINGS_DEBUG). If the fw_cfg file is not present, no
+  HOB is produced and the memory protection PCDs are used as a fallback.
+**/
+VOID
+EFIAPI
+PlatformBuildMemoryProtectionSettingsHob (
+  VOID
+  );
+
+/**
+  Build the MM (SMM / Standalone MM) memory protection settings HOB based on a
+  QEMU fw_cfg selector.
+
+  The fw_cfg file "opt/org.tianocore/MemoryProtection" contains the name of the
+  memory protection profile to apply (e.g. "DEBUG" selects
+  MM_MEMORY_PROTECTION_SETTINGS_DEBUG). If the fw_cfg file is not present, no
+  HOB is produced and the memory protection PCDs are used as a fallback.
+
+  This should only be called on platforms that use traditional SMM or
+  Standalone MM.
+**/
+VOID
+EFIAPI
+PlatformBuildMmMemoryProtectionSettingsHob (
+  VOID
+  );

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -203,6 +203,8 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
   Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibNull/DxeTcg2PhysicalPresenceLib.inf
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -249,6 +249,7 @@
   HobLib|EmbeddedPkg/Library/PrePiHobLib/PrePiHobLib.inf
   PrePiLib|EmbeddedPkg/Library/PrePiLib/PrePiLib.inf
   PeilessStartupLib|OvmfPkg/Library/PeilessStartupLib/PeilessStartupLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
   TdxMeasurementLib|OvmfPkg/IntelTdx/TdxMeasurementLib/SecPeiTdxMeasurementLib.inf
   TpmMeasurementLib|SecurityPkg/Library/SecTpmMeasurementLib/SecTpmMeasurementLib.inf

--- a/OvmfPkg/IntelTdx/IntelTdxX64.dsc
+++ b/OvmfPkg/IntelTdx/IntelTdxX64.dsc
@@ -205,6 +205,8 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
   Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibNull/DxeTcg2PhysicalPresenceLib.inf
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf

--- a/OvmfPkg/Library/PeilessStartupLib/PeilessStartup.c
+++ b/OvmfPkg/Library/PeilessStartupLib/PeilessStartup.c
@@ -20,6 +20,7 @@
 #include <Library/PrePiLib.h>
 #include <Library/PeilessStartupLib.h>
 #include <Library/PlatformInitLib.h>
+#include <Library/PlatformMemoryProtectionLib.h>
 #include <Library/TdxHelperLib.h>
 #include <Library/QemuFwCfgSimpleParserLib.h>
 #include <ConfidentialComputingGuestAttr.h>
@@ -121,6 +122,13 @@ InitializePlatform (
   }
 
   PlatformMiscInitialization (PlatformInfoHob);
+
+  //
+  // Build the DXE memory protection settings HOB from fw_cfg. If no fw_cfg
+  // selector is present, no HOB is produced and the memory protection PCDs
+  // are used as a fallback.
+  //
+  PlatformBuildMemoryProtectionSettingsHob ();
 
   return EFI_SUCCESS;
 }

--- a/OvmfPkg/Library/PeilessStartupLib/PeilessStartupLib.inf
+++ b/OvmfPkg/Library/PeilessStartupLib/PeilessStartupLib.inf
@@ -58,6 +58,7 @@
   QemuFwCfgSimpleParserLib
   PlatformInitLib
   MemDebugLogLib
+  PlatformMemoryProtectionLib
 
 [Guids]
   gEfiHobMemoryAllocModuleGuid

--- a/OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.c
+++ b/OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.c
@@ -1,0 +1,193 @@
+/** @file
+  Library that builds the DXE and MM memory protection settings HOBs based on a
+  QEMU fw_cfg selector.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/PlatformMemoryProtectionLib.h>
+#include <Library/QemuFwCfgLib.h>
+#include <Guid/DxeMemoryProtectionSettings.h>
+#include <Guid/MmMemoryProtectionSettings.h>
+
+//
+// Name of the QEMU fw_cfg file that selects the memory protection profile.
+//
+#define MEMORY_PROTECTION_FW_CFG_FILE_NAME  "opt/org.tianocore/MemoryProtection"
+
+/**
+  Read the memory protection profile name from the QEMU fw_cfg selector.
+
+  @param[out]  ProfileName  Buffer that receives the NULL-terminated profile
+                            name.
+  @param[in]   ProfileSize  Size, in bytes, of the ProfileName buffer.
+
+  @retval  EFI_SUCCESS          A profile name was read into ProfileName.
+  @retval  EFI_NOT_FOUND        The fw_cfg file is not present.
+  @retval  EFI_BAD_BUFFER_SIZE  The fw_cfg contents do not fit in ProfileName.
+**/
+STATIC
+EFI_STATUS
+GetMemoryProfileName (
+  OUT CHAR8  *ProfileName,
+  IN  UINTN  ProfileSize
+  )
+{
+  FIRMWARE_CONFIG_ITEM  FwCfgItem;
+  UINTN                 FwCfgSize;
+  EFI_STATUS            Status;
+
+  Status = QemuFwCfgFindFile (
+             MEMORY_PROTECTION_FW_CFG_FILE_NAME,
+             &FwCfgItem,
+             &FwCfgSize
+             );
+  if (EFI_ERROR (Status)) {
+    //
+    // No profile selected via fw_cfg.
+    //
+    return EFI_NOT_FOUND;
+  }
+
+  if ((FwCfgSize == 0) || (FwCfgSize >= ProfileSize)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: invalid MemoryProtection fw_cfg size %u\n",
+      __func__,
+      (UINT32)FwCfgSize
+      ));
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  QemuFwCfgSelectItem (FwCfgItem);
+  QemuFwCfgReadBytes (FwCfgSize, ProfileName);
+  ProfileName[FwCfgSize] = '\0';
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Build the DXE memory protection settings HOB based on a QEMU fw_cfg selector.
+
+  The fw_cfg file "opt/org.tianocore/MemoryProtection" contains the name of the
+  memory protection profile to apply (e.g. "DEBUG" selects
+  DXE_MEMORY_PROTECTION_SETTINGS_DEBUG). If the fw_cfg file is not present, no
+  HOB is produced and the memory protection PCDs are used as a fallback.
+**/
+VOID
+EFIAPI
+PlatformBuildMemoryProtectionSettingsHob (
+  VOID
+  )
+{
+  STATIC CONST struct {
+    CONST CHAR8                       *Name;
+    DXE_MEMORY_PROTECTION_SETTINGS    Settings;
+  } Profiles[] = {
+    { "DEBUG",            DXE_MEMORY_PROTECTION_SETTINGS_DEBUG                  },
+    { "RELEASE",          DXE_MEMORY_PROTECTION_SETTINGS_RELEASE                },
+    { "RELEASE.NOGUARDS", DXE_MEMORY_PROTECTION_SETTINGS_RELEASE_NO_PAGE_GUARDS },
+    { "OFF",              DXE_MEMORY_PROTECTION_SETTINGS_OFF                    },
+  };
+  EFI_STATUS  Status;
+  CHAR8       ProfileName[32];
+  UINTN       Index;
+
+  Status = GetMemoryProfileName (ProfileName, sizeof (ProfileName));
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (Profiles); Index++) {
+    if (AsciiStrCmp (ProfileName, Profiles[Index].Name) == 0) {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a: applying DXE memory protection profile %a\n",
+        __func__,
+        ProfileName
+        ));
+      BuildGuidDataHob (
+        &gDxeMemoryProtectionSettingsGuid,
+        (VOID *)&Profiles[Index].Settings,
+        sizeof (DXE_MEMORY_PROTECTION_SETTINGS)
+        );
+      return;
+    }
+  }
+
+  DEBUG ((
+    DEBUG_ERROR,
+    "%a: unknown memory protection profile '%a'\n",
+    __func__,
+    ProfileName
+    ));
+}
+
+/**
+  Build the MM (SMM / Standalone MM) memory protection settings HOB based on a
+  QEMU fw_cfg selector.
+
+  The fw_cfg file "opt/org.tianocore/MemoryProtection" contains the name of the
+  memory protection profile to apply (e.g. "DEBUG" selects
+  MM_MEMORY_PROTECTION_SETTINGS_DEBUG). If the fw_cfg file is not present, no
+  HOB is produced and the memory protection PCDs are used as a fallback.
+
+  The MM memory protection settings define only DEBUG and OFF profiles, so the
+  production ("RELEASE"/"RELEASE.NOGUARDS") and "OFF" selectors all
+  map to MM_MEMORY_PROTECTION_SETTINGS_OFF.
+**/
+VOID
+EFIAPI
+PlatformBuildMmMemoryProtectionSettingsHob (
+  VOID
+  )
+{
+  STATIC CONST struct {
+    CONST CHAR8                      *Name;
+    MM_MEMORY_PROTECTION_SETTINGS    Settings;
+  } Profiles[] = {
+    { "DEBUG",            MM_MEMORY_PROTECTION_SETTINGS_DEBUG },
+    { "RELEASE",          MM_MEMORY_PROTECTION_SETTINGS_OFF   },
+    { "RELEASE.NOGUARDS", MM_MEMORY_PROTECTION_SETTINGS_OFF   },
+    { "OFF",              MM_MEMORY_PROTECTION_SETTINGS_OFF   },
+  };
+  EFI_STATUS  Status;
+  CHAR8       ProfileName[32];
+  UINTN       Index;
+
+  Status = GetMemoryProfileName (ProfileName, sizeof (ProfileName));
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (Profiles); Index++) {
+    if (AsciiStriCmp (ProfileName, Profiles[Index].Name) == 0) {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a: applying MM memory protection profile %a\n",
+        __func__,
+        ProfileName
+        ));
+      BuildGuidDataHob (
+        &gMmMemoryProtectionSettingsGuid,
+        (VOID *)&Profiles[Index].Settings,
+        sizeof (MM_MEMORY_PROTECTION_SETTINGS)
+        );
+      return;
+    }
+  }
+
+  DEBUG ((
+    DEBUG_ERROR,
+    "%a: unknown memory protection profile '%a'\n",
+    __func__,
+    ProfileName
+    ));
+}

--- a/OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
+++ b/OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
@@ -1,0 +1,34 @@
+## @file
+#  Library that builds the DXE and MM memory protection settings HOBs based on a
+#  QEMU fw_cfg selector.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PlatformMemoryProtectionLib
+  FILE_GUID                      = CF9DCDD2-341B-43C3-97D7-0348FD3F9371
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PlatformMemoryProtectionLib
+
+[Sources]
+  PlatformMemoryProtectionLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  HobLib
+  QemuFwCfgLib
+
+[Guids]
+  gDxeMemoryProtectionSettingsGuid              ## SOMETIMES_PRODUCES
+  gMmMemoryProtectionSettingsGuid               ## SOMETIMES_PRODUCES

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -102,6 +102,7 @@
   TimerLib                         | UefiCpuPkg/Library/CpuTimerLib/BaseCpuTimerLib.inf
   PrintLib                         | MdePkg/Library/BasePrintLib/BasePrintLib.inf
   BaseMemoryLib                    | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  DxeMemoryProtectionHobLib        | MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
   # Networking Requirements
 !include NetworkPkg/NetworkLibs.dsc.inc

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -103,6 +103,7 @@
   TimerLib                         | UefiCpuPkg/Library/CpuTimerLib/BaseCpuTimerLib.inf
   PrintLib                         | MdePkg/Library/BasePrintLib/BasePrintLib.inf
   BaseMemoryLib                    | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  DxeMemoryProtectionHobLib        | MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
   # Networking Requirements
 !include NetworkPkg/NetworkLibs.dsc.inc

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -270,6 +270,7 @@
   PcdLib                           | MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   QemuFwCfgS3Lib                   | OvmfPkg/Library/QemuFwCfgS3Lib/PeiQemuFwCfgS3LibFwCfg.inf
   QemuFwCfgLib                     | OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioPeiLib.inf
+  PlatformMemoryProtectionLib      | OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   CpuMmuLib                        | UefiCpuPkg/Library/CpuMmuLib/CpuMmuLib.inf
   CpuMmuInitLib                    | OvmfPkg/LoongArchVirt/Library/CpuMmuInitLib/CpuMmuInitLib.inf
   MpInitLib                        | UefiCpuPkg/Library/MpInitLib/PeiMpInitLib.inf

--- a/OvmfPkg/LoongArchVirt/PlatformPei/Platform.c
+++ b/OvmfPkg/LoongArchVirt/PlatformPei/Platform.c
@@ -30,6 +30,7 @@
 #include <Library/PeimEntryPoint.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/PlatformHookLib.h>
+#include <Library/PlatformMemoryProtectionLib.h>
 #include <Library/QemuFwCfgLib.h>
 #include <Ppi/MasterBootMode.h>
 #include <Register/LoongArch64/Cpucfg.h>
@@ -537,6 +538,13 @@ InitializePlatform (
 
   AddFdtHob ();
   SetupTPMResources ((VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress));
+  //
+  // Build the DXE memory protection settings HOB from fw_cfg. If no fw_cfg
+  // selector is present, no HOB is produced and the memory protection PCDs
+  // are used as a fallback.
+  //
+  PlatformBuildMemoryProtectionSettingsHob ();
+
   //
   // Initialization MMU
   //

--- a/OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/LoongArchVirt/PlatformPei/PlatformPei.inf
@@ -54,6 +54,7 @@
   PeiServicesLib
   PlatformHookLib
   ResourcePublicationLib
+  PlatformMemoryProtectionLib
   QemuFwCfgLib
 
 [Pcd]

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -335,6 +335,7 @@
 
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf
   CcProbeLib|OvmfPkg/Library/CcProbeLib/SecPeiCcProbeLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
 
 [LibraryClasses.common.DXE_CORE]

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -232,6 +232,8 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
   Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibNull/DxeTcg2PhysicalPresenceLib.inf
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf

--- a/OvmfPkg/Microvm/MicrovmX64.dsc
+++ b/OvmfPkg/Microvm/MicrovmX64.dsc
@@ -233,6 +233,8 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
   Tcg2PhysicalPresenceLib|OvmfPkg/Library/Tcg2PhysicalPresenceLibNull/DxeTcg2PhysicalPresenceLib.inf
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf

--- a/OvmfPkg/OvmfPkg.dec
+++ b/OvmfPkg/OvmfPkg.dec
@@ -168,6 +168,12 @@
   #
   MapMmioLib|Include/Library/MapMmioLib.h
 
+  ##  @libraryclass  Build the DXE/MM memory protection settings HOB based on a
+  #                  QEMU fw_cfg selector, falling back to the memory
+  #                  protection PCDs when no fw_cfg selector is present.
+  #
+  PlatformMemoryProtectionLib|Include/Library/PlatformMemoryProtectionLib.h
+
 [Guids]
   gUefiOvmfPkgTokenSpaceGuid            = {0x93bb96af, 0xb9f2, 0x4eb8, {0x94, 0x62, 0xe0, 0xba, 0x74, 0x56, 0x42, 0x36}}
   gEfiXenInfoGuid                       = {0xd3b46f3b, 0xd441, 0x1244, {0x9a, 0x12, 0x0, 0x12, 0x27, 0x3f, 0xc1, 0x4d}}

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -238,6 +238,8 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 !include OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
 !include OvmfPkg/Include/Dsc/ShellLibs.dsc.inc

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -239,6 +239,8 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 !include OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
 !include OvmfPkg/Include/Dsc/ShellLibs.dsc.inc

--- a/OvmfPkg/OvmfPkgIa32X64.dsc
+++ b/OvmfPkg/OvmfPkgIa32X64.dsc
@@ -331,6 +331,7 @@
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
 
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -267,6 +267,8 @@
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
 
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+
 !include OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
 !include OvmfPkg/Include/Dsc/ShellLibs.dsc.inc
 !include OvmfPkg/Include/Dsc/OvmfTlsLibs.dsc.inc
@@ -504,6 +506,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   SmmCpuRendezvousLib|UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.SMM_CORE]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
@@ -521,6 +524,7 @@
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.MM_STANDALONE]
 !ifdef $(DEBUG_ON_SERIAL_PORT)
@@ -539,6 +543,7 @@
   MemLib|StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.MM_CORE_STANDALONE]
 !ifdef $(DEBUG_ON_SERIAL_PORT)
@@ -554,6 +559,7 @@
   StandaloneMmCoreEntryPoint|MdePkg/Library/DynamicStackCookieEntryPointLib/StandaloneMmCoreEntryPoint.inf
   HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
 
 ################################################################################
 #

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -266,6 +266,8 @@
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
 
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+
 !include OvmfPkg/Include/Dsc/OvmfTpmLibs.dsc.inc
 !include OvmfPkg/Include/Dsc/ShellLibs.dsc.inc
 !include OvmfPkg/Include/Dsc/OvmfTlsLibs.dsc.inc
@@ -501,6 +503,7 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
   SmmCpuRendezvousLib|UefiCpuPkg/Library/SmmCpuRendezvousLib/SmmCpuRendezvousLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.SMM_CORE]
   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
@@ -518,6 +521,7 @@
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.MM_STANDALONE]
 !ifdef $(DEBUG_ON_SERIAL_PORT)
@@ -536,6 +540,7 @@
   MemLib|StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
   DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.MM_CORE_STANDALONE]
 !ifdef $(DEBUG_ON_SERIAL_PORT)
@@ -551,6 +556,7 @@
   StandaloneMmCoreEntryPoint|MdePkg/Library/DynamicStackCookieEntryPointLib/StandaloneMmCoreEntryPoint.inf
   HobPrintLib|MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
 
 ################################################################################
 #

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -363,6 +363,7 @@
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   TimerLib|OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
 
 !if $(STANDALONE_MM_ENABLE) != TRUE

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -288,6 +288,7 @@
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/PeiQemuFwCfgS3LibFwCfg.inf
   PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgPeiLib.inf
+  PlatformMemoryProtectionLib|OvmfPkg/Library/PlatformMemoryProtectionLib/PlatformMemoryProtectionLib.inf
   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/PeiMemEncryptSevLib.inf
 
 [LibraryClasses.common.DXE_CORE]

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -216,6 +216,7 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
   XenHypercallLib|OvmfPkg/Library/XenHypercallLib/XenHypercallLib.inf
   XenPlatformLib|OvmfPkg/Library/XenPlatformLib/XenPlatformLib.inf
   XenIoMmioLib|OvmfPkg/Library/XenIoMmioLib/XenIoMmioLib.inf

--- a/OvmfPkg/OvmfXen.dsc
+++ b/OvmfPkg/OvmfXen.dsc
@@ -217,6 +217,7 @@
   S3BootScriptLib|MdeModulePkg/Library/PiDxeS3BootScriptLib/DxeS3BootScriptLib.inf
   SmbusLib|MdePkg/Library/BaseSmbusLibNull/BaseSmbusLibNull.inf
   OrderedCollectionLib|MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
   XenHypercallLib|OvmfPkg/Library/XenHypercallLib/XenHypercallLib.inf
   XenPlatformLib|OvmfPkg/Library/XenPlatformLib/XenPlatformLib.inf
   XenIoMmioLib|OvmfPkg/Library/XenIoMmioLib/XenIoMmioLib.inf

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -26,6 +26,7 @@
 #include <Library/PciLib.h>
 #include <Library/PeimEntryPoint.h>
 #include <Library/PeiServicesLib.h>
+#include <Library/PlatformMemoryProtectionLib.h>
 #include <Library/QemuFwCfgLib.h>
 #include <Library/QemuFwCfgS3Lib.h>
 #include <Library/QemuFwCfgSimpleParserLib.h>
@@ -358,7 +359,23 @@ InitializePlatform (
   EFI_STATUS             Status;
 
   DEBUG ((DEBUG_INFO, "Platform PEIM Loaded\n"));
+
   PlatformInfoHob = BuildPlatformInfoHob ();
+
+  //
+  // Build the DXE memory protection settings HOB from fw_cfg. This must run
+  // after the PlatformInfo HOB is built, because the PEI fw_cfg library keeps
+  // its availability state inside that HOB.
+  //
+  PlatformBuildMemoryProtectionSettingsHob ();
+
+  //
+  // On platforms that use traditional SMM or Standalone MM, also build the MM
+  // memory protection settings HOB from the same fw_cfg selector.
+  //
+  if (FeaturePcdGet (PcdSmmSmramRequire)) {
+    PlatformBuildMmMemoryProtectionSettingsHob ();
+  }
 
   if (TdIsEnabled ()) {
     TdxHelperBuildGuidHobForTdxMeasurement ();

--- a/OvmfPkg/PlatformPei/Platform.c
+++ b/OvmfPkg/PlatformPei/Platform.c
@@ -31,6 +31,7 @@
 #include <Library/QemuFwCfgSimpleParserLib.h>
 #include <Library/ResourcePublicationLib.h>
 #include <Ppi/MasterBootMode.h>
+#include <Guid/DxeMemoryProtectionSettings.h>
 #include <IndustryStandard/I440FxPiix4.h>
 #include <IndustryStandard/Microvm.h>
 #include <IndustryStandard/Pci22.h>
@@ -339,6 +340,86 @@ CompleteInitialization (
 }
 
 /**
+  Build the DXE memory protection settings HOB based on a QEMU fw_cfg selector.
+
+  The fw_cfg file "opt/org.tianocore/MemoryProfile" contains the name of the
+  memory protection profile to apply (e.g. "DEBUG" selects
+  DXE_MEMORY_PROTECTION_SETTINGS_DEBUG). If the fw_cfg file is not present, no
+  HOB is produced and the memory protection PCDs are used as a fallback.
+**/
+STATIC
+VOID
+MemoryProtectionInitialization (
+  VOID
+  )
+{
+  STATIC CONST struct {
+    CONST CHAR8                       *Name;
+    DXE_MEMORY_PROTECTION_SETTINGS    Settings;
+  } Profiles[] = {
+    { "DEBUG",                    DXE_MEMORY_PROTECTION_SETTINGS_DEBUG                    },
+    { "SHIP_MODE",                DXE_MEMORY_PROTECTION_SETTINGS_SHIP_MODE                },
+    { "SHIP_MODE_NO_PAGE_GUARDS", DXE_MEMORY_PROTECTION_SETTINGS_SHIP_MODE_NO_PAGE_GUARDS },
+    { "OFF",                      DXE_MEMORY_PROTECTION_SETTINGS_OFF                      },
+  };
+  FIRMWARE_CONFIG_ITEM  FwCfgItem;
+  UINTN                 FwCfgSize;
+  EFI_STATUS            Status;
+  CHAR8                 ProfileName[32];
+  UINTN                 Index;
+
+  Status = QemuFwCfgFindFile (
+             "opt/org.tianocore/MemoryProfile",
+             &FwCfgItem,
+             &FwCfgSize
+             );
+  if (EFI_ERROR (Status)) {
+    //
+    // No profile selected via fw_cfg; do not produce a HOB.
+    //
+    return;
+  }
+
+  if ((FwCfgSize == 0) || (FwCfgSize >= sizeof (ProfileName))) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: invalid MemoryProfile fw_cfg size %u\n",
+      __func__,
+      (UINT32)FwCfgSize
+      ));
+    return;
+  }
+
+  QemuFwCfgSelectItem (FwCfgItem);
+  QemuFwCfgReadBytes (FwCfgSize, ProfileName);
+  ProfileName[FwCfgSize] = '\0';
+
+  for (Index = 0; Index < ARRAY_SIZE (Profiles); Index++) {
+    if (AsciiStrCmp (ProfileName, Profiles[Index].Name) == 0) {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a: applying memory protection profile %a\n",
+        __func__,
+        ProfileName
+        ));
+      BuildGuidDataHob (
+        &gDxeMemoryProtectionSettingsGuid,
+        (VOID *)&Profiles[Index].Settings,
+        sizeof (DXE_MEMORY_PROTECTION_SETTINGS)
+        );
+      return;
+    }
+  }
+
+  DEBUG ((
+    DEBUG_ERROR,
+    "%a: unknown memory protection profile '%a'\n",
+    __func__,
+    ProfileName
+    ));
+}
+
+/**
   Perform Platform PEI initialization.
 
   @param  FileHandle      Handle of the file being invoked.
@@ -358,7 +439,15 @@ InitializePlatform (
   EFI_STATUS             Status;
 
   DEBUG ((DEBUG_INFO, "Platform PEIM Loaded\n"));
+
   PlatformInfoHob = BuildPlatformInfoHob ();
+
+  //
+  // Build the DXE memory protection settings HOB from fw_cfg. This must run
+  // after the PlatformInfo HOB is built, because the PEI fw_cfg library keeps
+  // its availability state inside that HOB.
+  //
+  MemoryProtectionInitialization ();
 
   if (TdIsEnabled ()) {
     TdxHelperBuildGuidHobForTdxMeasurement ();

--- a/OvmfPkg/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/PlatformPei/PlatformPei.inf
@@ -50,6 +50,7 @@
   gUefiOvmfPkgPlatformInfoGuid
   gGhcbApicIdsGuid
   gTcg800155PlatformIdEventHobGuid              ## SOMETIMES_PRODUCES
+  gDxeMemoryProtectionSettingsGuid              ## SOMETIMES_PRODUCES
 
 [LibraryClasses]
   BaseLib

--- a/OvmfPkg/PlatformPei/PlatformPei.inf
+++ b/OvmfPkg/PlatformPei/PlatformPei.inf
@@ -62,6 +62,7 @@
   PeiServicesLib
   PeiServicesTablePointerLib
   PeimEntryPoint
+  PlatformMemoryProtectionLib
   QemuFwCfgLib
   QemuFwCfgS3Lib
   QemuFwCfgSimpleParserLib

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -103,6 +103,7 @@
 
 [LibraryClasses.common]
   PlatformSecLib|OvmfPkg/RiscVVirt/Library/PlatformSecLib/PlatformSecLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
   # Virtio Support
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -104,6 +104,7 @@
 [LibraryClasses.common]
   GptLib|MdeModulePkg/Library/GptLib/GptLib.inf
   PlatformSecLib|OvmfPkg/RiscVVirt/Library/PlatformSecLib/PlatformSecLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
   # Virtio Support
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf

--- a/OvmfPkg/XenPlatformPei/Platform.c
+++ b/OvmfPkg/XenPlatformPei/Platform.c
@@ -27,6 +27,7 @@
 #include <Library/PciLib.h>
 #include <Library/PeimEntryPoint.h>
 #include <Library/PeiServicesLib.h>
+#include <Library/PlatformMemoryProtectionLib.h>
 #include <Library/QemuFwCfgS3Lib.h>
 #include <Library/ResourcePublicationLib.h>
 #include <Guid/MemoryTypeInformation.h>
@@ -492,6 +493,13 @@ InitializeXenPlatform (
   InstallClearCacheCallback ();
   AmdSevInitialize ();
   MiscInitialization ();
+
+  //
+  // Build the DXE memory protection settings HOB from fw_cfg. If no fw_cfg
+  // selector is present, no HOB is produced and the memory protection PCDs
+  // are used as a fallback.
+  //
+  PlatformBuildMemoryProtectionSettingsHob ();
 
   return EFI_SUCCESS;
 }

--- a/OvmfPkg/XenPlatformPei/XenPlatformPei.inf
+++ b/OvmfPkg/XenPlatformPei/XenPlatformPei.inf
@@ -57,6 +57,7 @@
   ResourcePublicationLib
   PeiServicesLib
   PeimEntryPoint
+  PlatformMemoryProtectionLib
   QemuFwCfgS3Lib
   MtrrLib
   MemEncryptSevLib

--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -337,7 +337,7 @@ CpuSetMemoryAttributes (
   // During memory attributes updating, new pages may be allocated to setup
   // smaller granularity of page table. Page allocation action might then cause
   // another calling of CpuSetMemoryAttributes() recursively, due to memory
-  // protection policy configured (such as PcdDxeNxMemoryProtectionPolicy).
+  // protection policy configured (such as the DXE NX Protection Policy).
   // Since this driver will always protect memory used as page table by itself,
   // there's no need to apply protection policy requested from memory service.
   // So it's safe to just return EFI_SUCCESS if this time of calling is caused

--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -334,7 +334,7 @@ CpuSetMemoryAttributes (
   // During memory attributes updating, new pages may be allocated to setup
   // smaller granularity of page table. Page allocation action might then cause
   // another calling of CpuSetMemoryAttributes() recursively, due to memory
-  // protection policy configured (such as PcdDxeNxMemoryProtectionPolicy).
+  // protection policy configured (such as the DXE NX Protection Policy).
   // Since this driver will always protect memory used as page table by itself,
   // there's no need to apply protection policy requested from memory service.
   // So it's safe to just return EFI_SUCCESS if this time of calling is caused

--- a/UefiCpuPkg/CpuDxe/CpuDxe.h
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.h
@@ -34,15 +34,10 @@
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/MpInitLib.h>
 #include <Library/TimerLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
 
 #include <Guid/IdleLoopEvent.h>
 #include <Guid/VectorHandoffTable.h>
-
-#define HEAP_GUARD_NONSTOP_MODE       \
-        ((PcdGet8 (PcdHeapGuardPropertyMask) & (BIT6|BIT4|BIT1|BIT0)) > BIT6)
-
-#define NULL_DETECTION_NONSTOP_MODE   \
-        ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & (BIT6|BIT0)) > BIT6)
 
 /**
   Flush CPU data cache. If the instruction cache is fully coherent

--- a/UefiCpuPkg/CpuDxe/CpuDxe.inf
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.inf
@@ -29,6 +29,7 @@
   CpuExceptionHandlerLib
   CpuLib
   DebugLib
+  DxeMemoryProtectionHobLib
   DxeServicesTableLib
   HobLib
   MemoryAllocationLib
@@ -89,8 +90,6 @@
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPteMemoryEncryptionAddressOrMask    ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask               ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask    ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTdxSharedBitMask                    ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList              ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize                    ## CONSUMES

--- a/UefiCpuPkg/CpuDxe/CpuMp.c
+++ b/UefiCpuPkg/CpuDxe/CpuMp.c
@@ -755,7 +755,7 @@ InitializeMpExceptionHandlers (
   // Enable non-stop mode for #PF triggered by Heap Guard or NULL Pointer
   // Detection.
   //
-  if (HEAP_GUARD_NONSTOP_MODE || NULL_DETECTION_NONSTOP_MODE) {
+  if (gDxeMps.HeapGuardPolicy.Fields.NonStopMode || gDxeMps.NullPointerDetectionPolicy.Fields.NonStopMode) {
     RegisterCpuInterruptHandler (EXCEPT_IA32_DEBUG, DebugExceptionHandler);
     RegisterCpuInterruptHandler (EXCEPT_IA32_PAGE_FAULT, PageFaultExceptionHandler);
   }

--- a/UefiCpuPkg/CpuDxe/CpuPageTable.c
+++ b/UefiCpuPkg/CpuDxe/CpuPageTable.c
@@ -1333,9 +1333,9 @@ PageFaultExceptionHandler (
 
   PFAddress = AsmReadCr2 () & ~EFI_PAGE_MASK;
   if (PFAddress < BASE_4KB) {
-    NonStopMode = NULL_DETECTION_NONSTOP_MODE ? TRUE : FALSE;
+    NonStopMode = gDxeMps.NullPointerDetectionPolicy.Fields.NonStopMode ? TRUE : FALSE;
   } else {
-    NonStopMode = HEAP_GUARD_NONSTOP_MODE ? TRUE : FALSE;
+    NonStopMode = gDxeMps.HeapGuardPolicy.Fields.NonStopMode ? TRUE : FALSE;
   }
 
   if (NonStopMode) {
@@ -1429,7 +1429,7 @@ InitializePageTableLib (
     EnableReadOnlyPageWriteProtect ();
   }
 
-  if (HEAP_GUARD_NONSTOP_MODE || NULL_DETECTION_NONSTOP_MODE) {
+  if (gDxeMps.HeapGuardPolicy.Fields.NonStopMode || gDxeMps.NullPointerDetectionPolicy.Fields.NonStopMode) {
     mPFEntryCount = (UINTN *)AllocateZeroPool (sizeof (UINTN) * mNumberOfProcessors);
     ASSERT (mPFEntryCount != NULL);
 

--- a/UefiCpuPkg/CpuDxe/LoongArch64/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/LoongArch64/CpuDxe.c
@@ -11,6 +11,7 @@
 #include "CpuMp.h"
 #include <Guid/IdleLoopEvent.h>
 #include <Library/CpuMmuLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
 #include <Library/TimerLib.h>
 #include <Register/LoongArch64/Csr.h>
 
@@ -495,7 +496,7 @@ InitializeCpu (
   // the first page read-protected after the CPU architectural protocol is
   // installed, matching the generic DXE NULL pointer protection semantics.
   //
-  if ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT0) != 0) {
+  if (gDxeMps.NullPointerDetectionPolicy.Fields.UefiNullDetection) {
     Status = CpuSetMemoryAttributes (&gCpu, 0, EFI_PAGE_SIZE, EFI_MEMORY_RP);
     ASSERT_EFI_ERROR (Status);
   }

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
@@ -61,6 +61,7 @@
   PcdLib
   SynchronizationLib
   UefiBootServicesTableLib
+  DxeMemoryProtectionHobLib
 
 [LibraryClasses.IA32, LibraryClasses.X64]
   AmdSvsmLib
@@ -86,7 +87,6 @@
   gProcessorResourceHobGuid                     ## SOMETIMES_CONSUMES  ## HOB
 
 [Pcd]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                      ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdGhcbBase                           ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdConfidentialComputingGuestAttr           ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber            ## CONSUMES

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -14,6 +14,7 @@
 #include <Library/DebugAgentLib.h>
 #include <Library/DxeServicesTableLib.h>
 #include <Library/CcExitLib.h>
+#include <Library/DxeMemoryProtectionHobLib.h>
 #include <Register/Amd/SevSnpMsr.h>
 #include <Register/Amd/Ghcb.h>
 
@@ -553,7 +554,7 @@ InitMpGlobalData (
     return;
   }
 
-  if (PcdGetBool (PcdCpuStackGuard)) {
+  if (gDxeMps.CpuStackGuard) {
     //
     // One extra page at the bottom of the stack is needed for Guard page.
     //

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/Ia32/PageTbl.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/Ia32/PageTbl.c
@@ -34,8 +34,8 @@ SmmInitPageTable (
   mPagingMode          = PagingPae;
 
   if (mSmmProfileEnabled ||
-      HEAP_GUARD_NONSTOP_MODE ||
-      NULL_DETECTION_NONSTOP_MODE)
+      gMmMps.HeapGuardPolicy.Fields.NonStopMode ||
+      gMmMps.NullDetectionNonStopMode)
   {
     //
     // Set own Page Fault entry instead of the default one, because SMM Profile
@@ -135,7 +135,7 @@ SmiPFHandler (
           );
       }
 
-      if (HEAP_GUARD_NONSTOP_MODE) {
+      if (gMmMps.HeapGuardPolicy.Fields.NonStopMode) {
         GuardPagePFHandler (SystemContext.SystemContextIa32->ExceptionData);
         goto Exit;
       }
@@ -164,7 +164,7 @@ SmiPFHandler (
     //
     // If NULL pointer was just accessed
     //
-    if (((PcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT1) != 0) &&
+    if (gMmMps.NullPointerDetectionPolicy &&
         (PFAddress < EFI_PAGE_SIZE))
     {
       DumpCpuContext (InterruptType, SystemContext);
@@ -173,7 +173,7 @@ SmiPFHandler (
         DumpModuleInfoByIp ((UINTN)SystemContext.SystemContextIa32->Eip);
         );
 
-      if (NULL_DETECTION_NONSTOP_MODE) {
+      if (gMmMps.NullDetectionNonStopMode) {
         GuardPagePFHandler (SystemContext.SystemContextIa32->ExceptionData);
         goto Exit;
       }

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -10,6 +10,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "PiSmmCpuCommon.h"
 
+#include <Library/MmMemoryProtectionHobLib.h>
+
 //
 // Slots for all MTRR( FIXED MTRR + VARIABLE MTRR + MTRR_LIB_IA32_MTRR_DEF_TYPE)
 //

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/NonMmramMapDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/NonMmramMapDxeSmm.c
@@ -341,7 +341,7 @@ UpdateUefiMemMapAttributes (
   //
   // [0, 4k] may be non-present.
   //
-  PreviousAddress = ((FixedPcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT1) != 0) ? BASE_4KB : 0;
+  PreviousAddress = gMmMps.NullPointerDetectionPolicy ? BASE_4KB : 0;
 
   //
   // NonMmram shall be non-executable after the SmmReadyToLock event occurs, regardless of whether

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuCommon.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuCommon.h
@@ -40,6 +40,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PcdLib.h>
 #include <Library/MtrrLib.h>
 #include <Library/SmmCpuPlatformHookLib.h>
+#include <Library/MmMemoryProtectionHobLib.h>
 #include <Library/MmServicesTableLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/DebugAgentLib.h>

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
@@ -84,6 +84,7 @@
   MtrrLib
   IoLib
   TimerLib
+  MmMemoryProtectionHobLib
   MmServicesTableLib
   MemoryAllocationLib
   DebugAgentLib
@@ -146,8 +147,6 @@
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmShadowStackSize               ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable                   ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPteMemoryEncryptionAddressOrMask    ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask    ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask               ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdControlFlowEnforcementPropertyMask        ## CONSUMES
 
 [FixedPcd]

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuStandaloneMm.inf
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuStandaloneMm.inf
@@ -68,6 +68,7 @@
   MtrrLib
   IoLib
   TimerLib
+  MmMemoryProtectionHobLib
   MmServicesTableLib
   MemoryAllocationLib
   DebugAgentLib
@@ -122,8 +123,6 @@
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmStackSize                     ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmCodeAccessCheckEnable         ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmShadowStackSize               ## SOMETIMES_CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask    ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask               ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdControlFlowEnforcementPropertyMask        ## CONSUMES
 
 [FixedPcd]

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmCpuMemoryManagement.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmCpuMemoryManagement.c
@@ -1331,7 +1331,7 @@ GenSmmPageTable (
     }
   }
 
-  if ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT1) != 0) {
+  if (gMmMps.NullPointerDetectionPolicy) {
     //
     // Mark [0, 4k] as non-present
     //
@@ -1486,12 +1486,10 @@ IfReadOnlyPageTableNeeded (
 {
   //
   // Don't mark page table memory as read-only if
-  //  - SMM heap guard feature enabled; or
-  //      BIT2: SMM page guard enabled
-  //      BIT3: SMM pool guard enabled
+  //  - SMM heap guard feature enabled or
   //  - SMM profile feature enabled
   //
-  if (((PcdGet8 (PcdHeapGuardPropertyMask) & (BIT3 | BIT2)) != 0) ||
+  if (((gMmMps.HeapGuardPolicy.Fields.MmPageGuard | gMmMps.HeapGuardPolicy.Fields.MmPoolGuard) != 0) ||
       mSmmProfileEnabled)
   {
     return FALSE;

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfile.c
@@ -253,8 +253,8 @@ DebugExceptionHandler (
   UINTN  PFEntry;
 
   if (!mSmmProfileStart &&
-      !HEAP_GUARD_NONSTOP_MODE &&
-      !NULL_DETECTION_NONSTOP_MODE)
+      !gMmMps.HeapGuardPolicy.Fields.NonStopMode &&
+      !gMmMps.NullDetectionNonStopMode)
   {
     return;
   }
@@ -619,7 +619,7 @@ SmmProfileUpdateMemoryAttributes (
   //
   // [0, 4k] may be non-present.
   //
-  PreviousAddress = ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT1) != 0) ? BASE_4KB : 0;
+  PreviousAddress = (gMmMps.NullPointerDetectionPolicy) ? BASE_4KB : 0;
 
   for (Index = 0; Index < mProtectionMemRangeCount; Index++) {
     MemoryAttrMask = 0;
@@ -1049,8 +1049,8 @@ InitSmmProfile (
   // Skip SMM profile initialization if feature is disabled
   //
   if (!mSmmProfileEnabled &&
-      !HEAP_GUARD_NONSTOP_MODE &&
-      !NULL_DETECTION_NONSTOP_MODE)
+      !gMmMps.HeapGuardPolicy.Fields.NonStopMode &&
+      !gMmMps.NullDetectionNonStopMode)
   {
     return;
   }

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfileInternal.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SmmProfileInternal.h
@@ -46,12 +46,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define MSR_DS_AREA  0x600
 
-#define HEAP_GUARD_NONSTOP_MODE      \
-        ((PcdGet8 (PcdHeapGuardPropertyMask) & (BIT6|BIT3|BIT2)) > BIT6)
-
-#define NULL_DETECTION_NONSTOP_MODE  \
-        ((PcdGet8 (PcdNullPointerDetectionPropertyMask) & (BIT6|BIT1)) > BIT6)
-
 typedef struct {
   EFI_PHYSICAL_ADDRESS    Base;
   EFI_PHYSICAL_ADDRESS    Top;

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
@@ -275,8 +275,8 @@ SmmInitPageTable (
   }
 
   if (mSmmProfileEnabled ||
-      HEAP_GUARD_NONSTOP_MODE ||
-      NULL_DETECTION_NONSTOP_MODE)
+      gMmMps.HeapGuardPolicy.Fields.NonStopMode ||
+      gMmMps.NullDetectionNonStopMode)
   {
     //
     // Set own Page Fault entry instead of the default one, because SMM Profile
@@ -778,7 +778,7 @@ SmiPFHandler (
           );
       }
 
-      if (HEAP_GUARD_NONSTOP_MODE) {
+      if (gMmMps.HeapGuardPolicy.Fields.NonStopMode) {
         GuardPagePFHandler (SystemContext.SystemContextX64->ExceptionData);
         goto Exit;
       }
@@ -807,7 +807,7 @@ SmiPFHandler (
     //
     // If NULL pointer was just accessed
     //
-    if (((PcdGet8 (PcdNullPointerDetectionPropertyMask) & BIT1) != 0) &&
+    if (gMmMps.NullPointerDetectionPolicy &&
         (PFAddress < EFI_PAGE_SIZE))
     {
       DumpCpuContext (InterruptType, SystemContext);
@@ -816,7 +816,7 @@ SmiPFHandler (
         DumpModuleInfoByIp ((UINTN)SystemContext.SystemContextX64->Rip);
         );
 
-      if (NULL_DETECTION_NONSTOP_MODE) {
+      if (gMmMps.NullDetectionNonStopMode) {
         GuardPagePFHandler (SystemContext.SystemContextX64->ExceptionData);
         goto Exit;
       }

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -248,13 +248,13 @@
 
 [PcdsFixedAtBuild]
   ## List of exception vectors which need switching stack.
-  #  This PCD will only take into effect if PcdCpuStackGuard is enabled.
+  #  This PCD will only take into effect if the CPU Stack Guard is enabled.
   #  By default exception #DD(8), #PF(14) are supported.
   # @Prompt Specify exception vectors which need switching stack.
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList|{0x08, 0x0E}|VOID*|0x30002000
 
   ## Size of good stack for an exception.
-  #  This PCD will only take into effect if PcdCpuStackGuard is enabled.
+  #  This PCD will only take into effect if the CPU Stack Guard is enabled.
   # @Prompt Specify size of good stack of exception which need switching stack.
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize|2048|UINT32|0x30002001
 
@@ -456,9 +456,8 @@
   #  and the memory occupied by page table is protected by page table itself as read-only.
   #  In X64 build, it cannot be enabled at the same time with SMM profile feature (PcdCpuSmmProfileEnable).
   #  In X64 build, it could not be enabled also at the same time with heap guard feature for SMM
-  #  (PcdHeapGuardPropertyMask in MdeModulePkg).
   #  In IA32 build, page table memory is not marked as read-only when either SMM profile feature (PcdCpuSmmProfileEnable)
-  #  or heap guard feature for SMM (PcdHeapGuardPropertyMask in MdeModulePkg) is enabled.
+  #  or heap guard feature for SMM is enabled.
   #   TRUE  - Access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock.<BR>
   #   FALSE - Access to any type of non-SMRAM memory after SmmReadyToLock is allowed.<BR>
   # @Prompt Access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock.

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -74,6 +74,7 @@
   HobLib|MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.inf
   MemoryAllocationLib|MdeModulePkg/Library/BaseMemoryAllocationLibNull/BaseMemoryAllocationLibNull.inf
   PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLib/PeiServicesTablePointerLib.inf
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.SEC]
   PlatformSecLib|UefiCpuPkg/Library/PlatformSecLibNull/PlatformSecLibNull.inf
@@ -107,10 +108,12 @@
   MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf
   MemoryAllocationLib|MdePkg/Library/SmmMemoryAllocationLib/SmmMemoryAllocationLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.MM_STANDALONE]
   MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
   SmmCpuFeaturesLib|UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.inf
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/StandaloneMmMemoryProtectionHobLib.inf
 
 [LibraryClasses.common.MM_STANDALONE, LibraryClasses.common.DXE_SMM_DRIVER]
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf

--- a/UefiCpuPkg/UefiCpuPkg.uni
+++ b/UefiCpuPkg/UefiCpuPkg.uni
@@ -169,16 +169,14 @@
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuApTargetCstate_HELP  #language en-US "Specifies the AP target C-state for Mwait during POST phase."
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmStaticPageTable_PROMPT  #language en-US "Use static page table for all memory in SMM."
-
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmStaticPageTable_HELP  #language en-US "Indicates if SMM uses static page table.\n"
                                                                                      "If enabled, SMM will not use on-demand paging. SMM will build static page table for all memory.\n"
                                                                                      "This flag only impacts X64 build, because SMM always builds static page table for IA32.\n"
                                                                                      "It could not be enabled at the same time with SMM profile feature (PcdCpuSmmProfileEnable).\n"
                                                                                      "It could not be enabled also at the same time with heap guard feature for SMM\n"
-                                                                                     "(PcdHeapGuardPropertyMask in MdeModulePkg).<BR><BR>\n"
+                                                                                     ".<BR><BR>\n"
                                                                                      "TRUE  - SMM uses static page table for all memory.<BR>\n"
                                                                                      "FALSE - SMM uses static page table for below 4G memory and use on-demand paging for above 4G memory.<BR>"
-
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmStmExceptionStackSize_PROMPT  #language en-US "STM exception stack size."
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmStmExceptionStackSize_HELP  #language en-US "Specifies buffer size in bytes for STM exception stack. The value should be a multiple of 4KB."
@@ -212,7 +210,6 @@
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdIsPowerOnReset_HELP  #language en-US "Indicates if the current boot is a power-on reset."
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmRestrictedMemoryAccess_PROMPT  #language en-US "Access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock."
-
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmRestrictedMemoryAccess_HELP  #language en-US "Indicate access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock.<BR><BR>\n"
                                                                                             "MMIO access is always allowed regardless of the value of this PCD.<BR>\n"
                                                                                             "Loose of such restriction is only required by RAS components in X64 platforms.<BR>\n"
@@ -221,12 +218,11 @@
                                                                                             "and the memory occupied by page table is protected by page table itself as read-only.<BR>\n"
                                                                                             "In X64 build, it cannot be enabled at the same time with SMM profile feature (PcdCpuSmmProfileEnable).<BR>\n"
                                                                                             "In X64 build, it could not be enabled also at the same time with heap guard feature for SMM<BR>\n"
-                                                                                            "(PcdHeapGuardPropertyMask in MdeModulePkg).<BR>\n"
+                                                                                            ".<BR>\n"
                                                                                             "In IA32 build, page table memory is not marked as read-only when either SMM profile feature (PcdCpuSmmProfileEnable)<BR>\n"
-                                                                                            "or heap guard feature for SMM (PcdHeapGuardPropertyMask in MdeModulePkg) is enabled.<BR>\n"
+                                                                                            "or heap guard feature for SMM is enabled.<BR>\n"
                                                                                             "TRUE  - Access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock.<BR>\n"
                                                                                             "FALSE - Access to any type of non-SMRAM memory after SmmReadyToLock is allowed.<BR>"
-
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuFeaturesCapability_PROMPT  #language en-US "Processor feature capabilities."
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuFeaturesCapability_HELP  #language en-US "Indicates processor feature capabilities, each bit corresponding to a specific feature."
@@ -268,16 +264,14 @@
                                                                                         "1 - ToPA(Table of physical address) scheme.<BR>\n"
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuStackSwitchExceptionList_PROMPT  #language en-US "Specify exception vectors which need switching stack."
-
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuStackSwitchExceptionList_HELP  #language en-US "List of exception vectors which need switching stack.\n"
-                                                                                           "This PCD will only take into effect if PcdCpuStackGuard is enabled.n"
+                                                                                           "This PCD will only take into effect if the CPU Stack Guard is enabled.n"
                                                                                            "By default exception #DD(8), #PF(14) are supported.n"
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuKnownGoodStackSize_PROMPT  #language en-US "Specify size of good stack of exception which need switching stack."
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuKnownGoodStackSize_HELP  #language en-US "Size of good stack for an exception.\n"
-                                                                                     "This PCD will only take into effect if PcdCpuStackGuard is enabled.\n"
-
+                                                                                     "This PCD will only take into effect if the CPU Stack Guard is enabled.\n"
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuCoreCrystalClockFrequency_PROMPT  #language en-US "Specifies CPUID Leaf 0x15 Time Stamp Counter and Nominal Core Crystal Clock Frequency."
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuCoreCrystalClockFrequency_HELP  #language en-US "Specifies CPUID Leaf 0x15 Time Stamp Counter and Nominal Core Crystal Clock Frequency.<BR><BR>\n"

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -399,6 +399,8 @@
   MmSaveStateLib|UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveStateLib.inf
   SmmCpuSyncLib|UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.inf
 
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+
 [LibraryClasses.common]
 !if $(BOOTSPLASH_IMAGE)
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
@@ -551,6 +553,7 @@
   PerformanceLib|MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
 !endif
 !endif
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 [LibraryClasses.X64.DXE_SMM_DRIVER]
 !if $(SMM_SUPPORT) == TRUE
@@ -575,6 +578,7 @@
   FlashDeviceLib|UefiPayloadPkg/Library/FlashDeviceLib/FlashDeviceLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
 !endif
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 ################################################################################
 #

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -401,6 +401,8 @@
   MmSaveStateLib|UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveStateLib.inf
   SmmCpuSyncLib|UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.inf
 
+  DxeMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.inf
+
 [LibraryClasses.common]
 !if $(BOOTSPLASH_IMAGE)
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
@@ -554,6 +556,7 @@
   PerformanceLib|MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
 !endif
 !endif
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 [LibraryClasses.X64.DXE_SMM_DRIVER]
 !if $(SMM_SUPPORT) == TRUE
@@ -578,6 +581,7 @@
   FlashDeviceLib|UefiPayloadPkg/Library/FlashDeviceLib/FlashDeviceLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
 !endif
+  MmMemoryProtectionHobLib|MdeModulePkg/Library/MemoryProtectionHobLib/SmmMemoryProtectionHobLib.inf
 
 ################################################################################
 #


### PR DESCRIPTION
# Description

This PR adds a memory protections HOB to provide runtime configuration of memory protection settings instead of the fixed at build PCDs. This allows new scenarios, such as platforms failing to boot due to a memory protection being tripped, resetting and disabling a specific memory protection to boot, etc.

Note: This PR is put up as a discussion topic following some offline discussions. There are additional pieces to this, such as the exception persistence library allowing platforms to see what failed on the last boot and update memory protections accordingly. I've left those out for now to discuss the design points here. Also, I've updated OvmfPkg X64 to use the HOB but currently left ArmVirtPkg only using the PCDs, to demonstrate the compatibility. I can update ArmVirtPkg as part of this PR if it moves forward.

- [ x ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Shipping in platforms for a few years, tested on OVMF and ArmVirt to ensure the new logic of using the PCDs if the HOB is not present is valid.

## Integration Instructions

This is marked a breaking change because of the addition of the two memory protection HOB libraries (one for DXE, one for MM). These need to be added to platform DSCs. However, if one of the proposals for eliminating this kind of breaking change moves forward, it will not be a breaking change.

Platforms are expected over time to transition the use of the memory protection PCDs to filling in the memory protection HOB fields explicitly.