### PR TITLE
Correct the Arm CPER error info type and increment the structure revision

### DIFF
--- a/MdePkg/Include/Guid/Cper.h
+++ b/MdePkg/Include/Guid/Cper.h
@@ -1026,10 +1026,10 @@ typedef union {
 ///
 /// The type of error that occurred in ARM Processor Error section.
 ///@{
-#define EFI_ARM_PROC_ERROR_INFO_TYPE_CACHE       0x00
-#define EFI_ARM_PROC_ERROR_INFO_TYPE_TLB         0x01
-#define EFI_ARM_PROC_ERROR_INFO_TYPE_BUS         0x02
-#define EFI_ARM_PROC_ERROR_INFO_TYPE_MICRO_ARCH  0x03
+#define EFI_ARM_PROC_ERROR_INFO_TYPE_CACHE       BIT0
+#define EFI_ARM_PROC_ERROR_INFO_TYPE_TLB         BIT1
+#define EFI_ARM_PROC_ERROR_INFO_TYPE_BUS         BIT2
+#define EFI_ARM_PROC_ERROR_INFO_TYPE_MICRO_ARCH  BIT3
 
 ///
 /// The flags to define the error atrributes in ARM Processor Error Information
@@ -1041,7 +1041,7 @@ typedef union {
 #define EFI_ARM_PROC_ERROR_INFO_FLAG_OVERFLOW_FLAG              BIT3
 ///@}
 
-#define EFI_ARM_PROCESSOR_ERROR_INFO_STRUCTURE_REVISION  0
+#define EFI_ARM_PROCESSOR_ERROR_INFO_STRUCTURE_REVISION  1
 
 ///
 /// ARM Processor Error Information Structure

--- a/MdePkg/Include/Guid/Cper.h
+++ b/MdePkg/Include/Guid/Cper.h
@@ -1026,10 +1026,10 @@ typedef union {
 ///
 /// The type of error that occurred in ARM Processor Error section.
 ///@{
-#define EFI_ARM_PROC_ERROR_INFO_TYPE_CACHE       0x00
-#define EFI_ARM_PROC_ERROR_INFO_TYPE_TLB         0x01
-#define EFI_ARM_PROC_ERROR_INFO_TYPE_BUS         0x02
-#define EFI_ARM_PROC_ERROR_INFO_TYPE_MICRO_ARCH  0x03
+#define EFI_ARM_PROC_ERROR_INFO_TYPE_CACHE       BIT0
+#define EFI_ARM_PROC_ERROR_INFO_TYPE_TLB         BIT1
+#define EFI_ARM_PROC_ERROR_INFO_TYPE_BUS         BIT2
+#define EFI_ARM_PROC_ERROR_INFO_TYPE_MICRO_ARCH  BIT3
 
 ///
 /// The flags to define the error atrributes in ARM Processor Error Information

--- a/MdePkg/Include/Guid/Cper.h
+++ b/MdePkg/Include/Guid/Cper.h
@@ -1041,8 +1041,7 @@ typedef union {
 #define EFI_ARM_PROC_ERROR_INFO_FLAG_OVERFLOW_FLAG              BIT3
 ///@}
 
-#define EFI_ARM_PROCESSOR_ERROR_INFO_STRUCTURE_REVISION  0
-
+#define EFI_ARM_PROCESSOR_ERROR_INFO_STRUCTURE_REVISION  1  // [CODE FIRST] 12708
 ///
 /// ARM Processor Error Information Structure
 ///


### PR DESCRIPTION
The values of EFI_ARM_PROC_ERROR_INFO_TYPE have been corrected to BIT positions constants BIT0, BIT1 etc as per the definition in the UEFI specification

The revision of the table error processor information structure is incremented to 1 for backward compatibility.
See issue: https://github.com/tianocore/edk2/issues/12708

Reference: https://uefi.org/specs/UEFI/2.10/Apx_N_Common_Platform_Error_Record.html#arm-processor-error-information-structure

# Description

The values of EFI_ARM_PROC_ERROR_INFO_TYPE_* have been corrected and due to this change for backward compatibility the  revision of the table error processor information structure is incremented to 1

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
N/A

## Integration Instructions
Implementations may check for revision of the table before referring the new (corrected) values of EFI_ARM_PROC_ERROR_INFO_TYPE_*

