### PR TITLE
MdeModulePkg/Logo: Add FV-file-based platform logo driver

### DIFF
--- a/MdeModulePkg/Logo/LogoFvFile.c
+++ b/MdeModulePkg/Logo/LogoFvFile.c
@@ -1,0 +1,219 @@
+/** @file
+  Logo DXE driver that loads the platform logo from a firmware volume file.
+
+  Installs EDKII_PLATFORM_LOGO_PROTOCOL by loading a BMP image from a
+  FREEFORM FFS file via GetSectionFromAnyFv(). No HII framework dependency.
+
+  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Library/BmpSupportLib.h>
+#include <Library/DebugLib.h>
+#include <Library/DxeServicesLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Protocol/GraphicsOutput.h>
+#include <Protocol/PlatformLogo.h>
+
+STATIC EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *mLogoBitmap = NULL;
+STATIC UINTN                          mLogoWidth   = 0;
+STATIC UINTN                          mLogoHeight  = 0;
+
+/**
+  Return the platform logo image.
+
+  @param[in]      This       Protocol instance pointer.
+  @param[in, out] Instance   On input, the index of the logo to return.
+                             On output, incremented to the next index.
+  @param[out]     Image      Returned logo image data. Caller frees Bitmap.
+  @param[out]     Attribute  Display attribute for the logo.
+  @param[out]     OffsetX    X offset from the display attribute origin.
+  @param[out]     OffsetY    Y offset from the display attribute origin.
+
+  @retval EFI_SUCCESS            Logo returned.
+  @retval EFI_NOT_FOUND          No logo at the requested index.
+  @retval EFI_INVALID_PARAMETER  A required output pointer is NULL.
+  @retval EFI_OUT_OF_RESOURCES   Insufficient memory.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+LogoFvFileGetImage (
+  IN     EDKII_PLATFORM_LOGO_PROTOCOL           *This,
+  IN OUT UINT32                                 *Instance,
+  OUT    EFI_IMAGE_INPUT                        *Image,
+  OUT    EDKII_PLATFORM_LOGO_DISPLAY_ATTRIBUTE  *Attribute,
+  OUT    INTN                                   *OffsetX,
+  OUT    INTN                                   *OffsetY
+  )
+{
+  UINTN  BitmapSize;
+
+  if ((Instance == NULL) || (Image == NULL) ||
+      (Attribute == NULL) || (OffsetX == NULL) || (OffsetY == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (*Instance >= 1) {
+    return EFI_NOT_FOUND;
+  }
+
+  (*Instance)++;
+
+  *Attribute    = EdkiiPlatformLogoDisplayAttributeCenter;
+  *OffsetX      = 0;
+  *OffsetY      = 0;
+  BitmapSize    = mLogoWidth * mLogoHeight * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL);
+  Image->Flags  = 0;
+  Image->Width  = (UINT16)mLogoWidth;
+  Image->Height = (UINT16)mLogoHeight;
+  Image->Bitmap = AllocateCopyPool (BitmapSize, mLogoBitmap);
+  if (Image->Bitmap == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  return EFI_SUCCESS;
+}
+
+STATIC EDKII_PLATFORM_LOGO_PROTOCOL  mPlatformLogo = {
+  LogoFvFileGetImage
+};
+
+/**
+  Load raw BMP data from a FREEFORM FFS file in the firmware volume.
+
+  @param[in]  LogoGuid     GUID of the FREEFORM FFS file (RAW section = BMP).
+  @param[out] BmpData      Pointer to the allocated BMP data buffer.
+  @param[out] BmpDataSize  Size of the BMP data buffer in bytes.
+
+  @retval EFI_SUCCESS  BMP data loaded into BmpData and BmpDataSize.
+  @retval other        File not found in the firmware volume.
+**/
+STATIC
+EFI_STATUS
+LoadLogoFromFv (
+  IN  CONST EFI_GUID  *LogoGuid,
+  OUT VOID            **BmpData,
+  OUT UINTN           *BmpDataSize
+  )
+{
+  return GetSectionFromAnyFv (
+           LogoGuid,
+           EFI_SECTION_RAW,
+           0,
+           BmpData,
+           BmpDataSize
+           );
+}
+
+/**
+  Entry point for the LogoFvFileDxe driver.
+
+  Skips installation if gEdkiiPlatformLogoProtocolGuid is already present.
+  Loads the logo BMP from the FV file identified by PcdLogoFile and installs
+  the protocol. If the logo cannot be found or decoded, boot continues without
+  a logo.
+
+  @param[in] ImageHandle  Handle for this driver image.
+  @param[in] SystemTable  Pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS          Protocol installed, or no logo found.
+  @retval EFI_ALREADY_STARTED  Protocol already installed by another driver.
+  @retval other                Protocol installation failed.
+**/
+EFI_STATUS
+EFIAPI
+LogoFvFileDxeInitialize (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                     Status;
+  VOID                           *ExistingLogo;
+  VOID                           *BmpData;
+  UINTN                          BmpDataSize;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *GopBlt;
+  UINTN                          GopBltSize;
+  UINTN                          PixelHeight;
+  UINTN                          PixelWidth;
+  EFI_HANDLE                     Handle;
+
+  Status = gBS->LocateProtocol (
+                  &gEdkiiPlatformLogoProtocolGuid,
+                  NULL,
+                  &ExistingLogo
+                  );
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "%a: already installed, skipping.\n", __func__));
+    return EFI_ALREADY_STARTED;
+  }
+
+  Status = LoadLogoFromFv (PcdGetPtr (PcdLogoFile), &BmpData, &BmpDataSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: logo not found (Status=%r). "
+      "Add FILE FREEFORM = <PcdLogoFile GUID> { SECTION RAW = <logo.bmp> } to the FDF.\n",
+      __func__,
+      Status
+      ));
+    return EFI_SUCCESS;
+  }
+
+  //
+  // TranslateBmpToGopBlt() treats a non-NULL *GopBlt as a caller-supplied
+  // buffer to reuse. Initialise to NULL/0 so it always allocates a fresh one.
+  //
+  GopBlt     = NULL;
+  GopBltSize = 0;
+
+  Status = TranslateBmpToGopBlt (
+             BmpData,
+             BmpDataSize,
+             &GopBlt,
+             &GopBltSize,
+             &PixelHeight,
+             &PixelWidth
+             );
+  FreePool (BmpData);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "%a: BMP decode failed (Status=%r).\n", __func__, Status));
+    return EFI_SUCCESS;
+  }
+
+  mLogoBitmap = GopBlt;
+  mLogoWidth  = PixelWidth;
+  mLogoHeight = PixelHeight;
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: logo loaded %u x %u.\n",
+    __func__,
+    mLogoWidth,
+    mLogoHeight
+    ));
+
+  Handle = NULL;
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &Handle,
+                  &gEdkiiPlatformLogoProtocolGuid,
+                  &mPlatformLogo,
+                  NULL
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: install failed (Status=%r).\n", __func__, Status));
+    FreePool (mLogoBitmap);
+    mLogoBitmap = NULL;
+    mLogoWidth  = 0;
+    mLogoHeight = 0;
+  }
+
+  return Status;
+}

--- a/MdeModulePkg/Logo/LogoFvFileDxe.inf
+++ b/MdeModulePkg/Logo/LogoFvFileDxe.inf
@@ -1,0 +1,70 @@
+## @file
+#  Logo DXE driver that loads the platform logo from a firmware volume file.
+#
+#  Installs EDKII_PLATFORM_LOGO_PROTOCOL by loading a BMP from a FREEFORM FFS
+#  file via GetSectionFromAnyFv(). No HII framework dependency.
+#
+#  Usage:
+#    1. Add this driver to the platform FDF:
+#         INF MdeModulePkg/Logo/LogoFvFileDxe.inf
+#
+#    2. Add a FILE FREEFORM block for the logo BMP in the platform FDF:
+#         FILE FREEFORM = <PcdLogoFile GUID> {
+#           SECTION RAW = <path/to/logo.bmp>
+#         }
+#
+#    3. Default logo: PcdLogoFile defaults to 7BB28B99-61BB-11D5-9A5D-0090273FC14D
+#         (FILE_GUID of MdeModulePkg/Logo/Logo.inf, TianoCore logo).
+#
+#    4. Custom logo: override PcdLogoFile in the platform DSC with the GUID
+#         of the custom FREEFORM block.
+#
+#  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = LogoFvFileDxe
+  MODULE_UNI_FILE                = LogoFvFileDxe.uni
+  FILE_GUID                      = FFD4698A-6353-4BEE-BD4B-5CCF995D09A2
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+
+  ENTRY_POINT                    = LogoFvFileDxeInitialize
+
+#
+#  VALID_ARCHITECTURES           = AARCH64
+#
+
+[Sources]
+  LogoFvFile.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  BmpSupportLib
+  DebugLib
+  DxeServicesLib
+  MemoryAllocationLib
+  PcdLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+
+[Protocols]
+  gEdkiiPlatformLogoProtocolGuid     ## PRODUCES
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdLogoFile   ## CONSUMES
+
+[Depex]
+  TRUE
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  LogoFvFileDxeExtra.uni
+

--- a/MdeModulePkg/Logo/LogoFvFileDxe.uni
+++ b/MdeModulePkg/Logo/LogoFvFileDxe.uni
@@ -1,0 +1,13 @@
+// /** @file
+// Logo DXE driver that loads the platform logo from a firmware volume file.
+//
+// Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_MODULE_ABSTRACT             #language en-US "Logo DXE driver that loads the platform logo from a firmware volume file"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "Installs EDKII_PLATFORM_LOGO_PROTOCOL by loading a BMP from a FREEFORM FFS file. Set PcdOemLogoEnabled and PcdLogoFile to select the OEM logo."

--- a/MdeModulePkg/Logo/LogoFvFileDxeExtra.uni
+++ b/MdeModulePkg/Logo/LogoFvFileDxeExtra.uni
@@ -1,0 +1,14 @@
+// /** @file
+// LogoFvFileDxe Localized Strings and Content
+//
+// Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+// Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US
+"Logo FV File DXE Driver"
+

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2256,6 +2256,21 @@
   # @Prompt Capsule On Disk Temp Relocation file name in PEI phase
   gEfiMdeModulePkgTokenSpaceGuid.PcdCoDRelocationFileName|L"Cod.tmp"|VOID*|0x30001048
 
+  ## Specifies the FILE_GUID of the FREEFORM FFS file that contains the
+  #  platform logo BMP image as a RAW section. LogoFvFileDxe uses this GUID
+  #  to locate the logo at runtime via GetSectionFromAnyFv().
+  #  The default value is the FILE_GUID of MdeModulePkg/Logo/Logo.inf
+  #  (TianoCore logo). Platforms override this PCD in their DSC to supply a
+  #  custom logo without modifying or forking the driver.
+  #
+  #  NOTE: The platform FDF must include a FILE FREEFORM block matching this
+  #  GUID, otherwise no logo is displayed. For the default TianoCore logo:
+  #    FILE FREEFORM = 7BB28B99-61BB-11D5-9A5D-0090273FC14D {
+  #      SECTION RAW = MdeModulePkg/Logo/Logo.bmp
+  #    }
+  # @Prompt Platform logo firmware volume file GUID.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdLogoFile|{ 0x99, 0x8B, 0xB2, 0x7B, 0xBB, 0x61, 0xD5, 0x11, 0x9A, 0x5D, 0x00, 0x90, 0x27, 0x3F, 0xC1, 0x4D }|VOID*|0x30001049
+
   ## This PCD hold a list GUIDs for the ImageTypeId to indicate the
   #  FMP capsule is a system FMP.
   # @Prompt A list of system FMP ImageTypeId GUIDs

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -5,8 +5,9 @@
 # Copyright (c) 2007 - 2024, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
 # Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
 #
-#    SPDX-License-Identifier: BSD-2-Clause-Patent
+# SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 
@@ -214,6 +215,7 @@
   MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
   MdeModulePkg/Logo/Logo.inf
   MdeModulePkg/Logo/LogoDxe.inf
+  MdeModulePkg/Logo/LogoFvFileDxe.inf
   MdeModulePkg/Library/BaseSortLib/BaseSortLib.inf
   MdeModulePkg/Library/BootDiscoveryPolicyUiLib/BootDiscoveryPolicyUiLib.inf
   MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManagerUiLib.inf


### PR DESCRIPTION
# Description

Add `LogoFvFileDxe`, a new DXE driver that installs `EDKII_PLATFORM_LOGO_PROTOCOL` by loading a BMP image from a `FREEFORM` FFS RAW section in the Firmware Volume.

The new Dxe, Enables platform logo provisioning through a firmware volume FREEFORM FFS file, allowing OEMs and platform integrators to customize boot logos without modifying or forking the logo driver.

The logo is selected through PcdLogoFile and loaded at runtime from the firmware volume. Platforms only need to package their own logo BMP inside a FREEFORM FFS file and provide its GUID in the platform DSC.


- [ ] Breaking change?
 No.
Additive only; existing `LogoDxe` is unaffected


- [ ] Impacts security?
No


- [ ] Includes tests?
Logo verification on Qualcomm AARCH64 platforms

## How This Was Tested
Built and booted on Qualcomm AARCH64 platforms with both the default TianoCore logo and a custom Snapdragon OEM logo BMP

## Integration Instructions

- Add LogoFvFileDxe to the platform DSC/FDF.
- Package a BMP image in a FREEFORM FFS file.
- Configure PcdLogoFile to reference the GUID of that FREEFORM file.
- Build and boot the platform.

In this example a custom logo is used:

- __Custom logo BMP path:__ `<PlatformPkg>/Logo/CustomLogo.bmp`
- __Custom logo GUID:__ `AABBCCDD-EEFF-1122-3344-556677889900`

__Platform `.dsc` — add to `[Components]` with PCD override:__

```javascript
MdeModulePkg/Logo/LogoFvFileDxe.inf {
  <PcdsFixedAtBuild>
    gEfiMdeModulePkgTokenSpaceGuid.PcdLogoFile|{ \
      0xDD, 0xCC, 0xBB, 0xAA, 0xFF, 0xEE, 0x22, 0x11, \
      0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00 }
}
```

__Platform `.fdf` — add the driver INF and the custom FREEFORM file block:__

```javascript
# Boot logo driver (FV-file based, no HII dependency)
INF MdeModulePkg/Logo/LogoFvFileDxe.inf

# Custom OEM logo BMP — GUID must match PcdLogoFile override in the DSC
FILE FREEFORM = AABBCCDD-EEFF-1122-3344-556677889900 {
  SECTION RAW = <PlatformPkg>/Logo/CustomLogo.bmp
}
```
