### PR TITLE
4594_arm_cca_secure_boot_v1_s4: Add RHI session transport support

### DIFF
--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -68,6 +68,7 @@
   DynamicPlatRepoLib|DynamicTablesPkg/Library/Common/DynamicPlatRepoLib/DynamicPlatRepoLib.inf
 
   ArmMonitorLib|ArmVirtPkg/Library/ArmVirtMonitorLib/ArmVirtMonitorLib.inf
+  ArmCcaRhiHostSessionLib|ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.inf
 
 [LibraryClasses.common.SEC, LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM]
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf

--- a/ArmVirtPkg/ArmVirtPkg.dec
+++ b/ArmVirtPkg/ArmVirtPkg.dec
@@ -28,6 +28,7 @@
 [LibraryClasses]
   ArmCcaInitPeiLib|Include/Library/ArmCcaInitPeiLib.h
   ArmCcaLib|Include/Library/ArmCcaLib.h
+  ArmCcaRhiHostSessionLib|Include/Library/ArmCcaRhiHostSessionLib.h
   ArmCcaRsiLib|Include/Library/ArmCcaRsiLib.h
   ArmVirtMemInfoLib|Include/Library/ArmVirtMemInfoLib.h
 

--- a/ArmVirtPkg/Include/Library/ArmCcaRhiHostSessionLib.h
+++ b/ArmVirtPkg/Include/Library/ArmCcaRhiHostSessionLib.h
@@ -42,6 +42,23 @@
 #define ARM_CCA_RHI_SESSION_CONNECTION_MODE_BLOCKING      BIT0
 #define ARM_CCA_RHI_SESSION_CONNECTION_MODE_NON_BLOCKING  BIT1
 
+/** A type defining the RHI session ID.
+*/
+typedef UINT64 ARM_CCA_RHI_SESSION_ID;
+
+/** An enum defining the RHI session states.
+*/
+typedef enum ArmCcaRhiSessionState {
+  RhiSessionStateUnconnected,                ///< Session not connected
+  RhiSessionStateConnectionInProgress,       ///< Connection in progress
+  RhiSessionStateConnectionEstablished,      ///< Connection established
+  RhiSessionStateIoInProgress,               ///< IO in progress
+  RhiSessionStateIoComplete,                 ///< IO completed
+  RhiSessionStateBufferSizeDetermined,       ///< Buffer size determined
+  RhiSessionStateConnectionCloseInProgress,  ///< Connection close in progress
+  RhiSessionStateMax
+} ARM_CCA_RHI_SESSION_STATE;
+
 /**
   Get the RHI Host Session protocol version information.
 
@@ -72,4 +89,53 @@ EFIAPI
 ArmCcaRhiSessionFeatures (
   OUT UINT64  *AbiSupportBitmap,
   OUT UINT64  *ConnectionModeBitmap
+  );
+
+/**
+  Open a session with the host.
+
+  @param[in]      ConnectionMode  The requested connection mode, must be either
+                                  Blocking or Non-Blocking.
+  @param[in, out] SessionId       On first invocation, SessionId is passed as
+                                  zero and the ABI allocates a Session Id and
+                                  returns.
+                                  If the connection mode is Non-Blocking, the
+                                  SessionState may be returned as
+                                  RhiConnectionInProgress and the
+                                  caller is expected to call this function again
+                                  with the Session ID that was returned in the
+                                  first invocation.
+  @param[out]     SessionState    State of the session.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_UNSUPPORTED         The requested connection mode is not
+                                  supported.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionOpen (
+  IN      UINT64                     ConnectionMode,
+  IN OUT  ARM_CCA_RHI_SESSION_ID     *SessionId,
+  OUT     ARM_CCA_RHI_SESSION_STATE  *SessionState OPTIONAL
+  );
+
+/**
+  Close a session with the host.
+
+  @param[in]    SessionId         Id of the session to close.
+  @param[out]   SessionState      State of the session.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionClose (
+  IN    ARM_CCA_RHI_SESSION_ID     SessionId,
+  OUT   ARM_CCA_RHI_SESSION_STATE  *SessionState OPTIONAL
   );

--- a/ArmVirtPkg/Include/Library/ArmCcaRhiHostSessionLib.h
+++ b/ArmVirtPkg/Include/Library/ArmCcaRhiHostSessionLib.h
@@ -139,3 +139,55 @@ ArmCcaRhiSessionClose (
   IN    ARM_CCA_RHI_SESSION_ID     SessionId,
   OUT   ARM_CCA_RHI_SESSION_STATE  *SessionState OPTIONAL
   );
+
+/**
+  Transmit data on previously opened communication channel.
+
+  @param[in]      SessionId     The session ID for the communication channel.
+  @param[in]      Data          Realm IPA for buffer containing data.
+  @param[in, out] DataLen       Length of data to send in bytes on input and
+                                Length of data transmitted on return.
+  @param[in]      Offset        Offset in buffer from which to send data.
+  @param[out]     SessionState  State of the session.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_PROTOCOL_ERROR      A protocol error was detected.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionSend (
+  IN      ARM_CCA_RHI_SESSION_ID     SessionId,
+  IN      UINT8                      *Data,
+  IN OUT  UINTN                      *DataLen,
+  IN      UINTN                      Offset,
+  OUT     ARM_CCA_RHI_SESSION_STATE  *SessionState OPTIONAL
+  );
+
+/**
+  Receive data on previously opened communication channel.
+
+  @param[in]      SessionId     The session ID for the communication channel.
+  @param[in]      Data          Realm IPA for buffer used to receive data.
+  @param[in, out] DataLen       Size of receiving data buffer.
+  @param[in]      Offset        Offset in buffer where received data is to be
+                                written.
+  @param[out]     SessionState  State of the session.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_PROTOCOL_ERROR      A protocol error was detected.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionReceive (
+  IN      ARM_CCA_RHI_SESSION_ID     SessionId,
+  IN      UINT8                      *Data,
+  IN OUT  UINTN                      *DataLen,
+  IN      UINTN                      Offset,
+  OUT     ARM_CCA_RHI_SESSION_STATE  *SessionState OPTIONAL
+  );

--- a/ArmVirtPkg/Include/Library/ArmCcaRhiHostSessionLib.h
+++ b/ArmVirtPkg/Include/Library/ArmCcaRhiHostSessionLib.h
@@ -1,0 +1,75 @@
+/** @file
+  Library that implements the Realm Host Interface Host Session protocol.
+
+  Copyright (c) 2024 - 2026, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Rhi or RHI   - Realm Host Interface
+    - Rsi or RSI   - Realm Service Interface
+    - IPA          - Intermediate Physical Address
+    - RIPAS        - Realm IPA state
+
+  @par Reference(s):
+   - Realm Management Monitor (RMM) Specification, version 1.0-rel0
+     (https://developer.arm.com/documentation/den0137/)
+   - Realm Host Interface (RHI) Specification, version 1.0-bet0
+     (https://developer.arm.com/documentation/den0148/)
+**/
+
+#pragma once
+
+/**
+  Macros defining the RHI Session ABIs.
+*/
+#define ARM_CCA_RHI_SESSION_ABI_MASK               0xFULL
+#define ARM_CCA_RHI_SESSION_ABI_OPEN_SUPPORTED     BIT0
+#define ARM_CCA_RHI_SESSION_ABI_CLOSE_SUPPORTED    BIT1
+#define ARM_CCA_RHI_SESSION_ABI_SEND_SUPPORTED     BIT2
+#define ARM_CCA_RHI_SESSION_ABI_RECEIVE_SUPPORTED  BIT3
+
+#define ARM_CCA_RHI_SESSION_MANDATORY_ABIS  (           \
+          ARM_CCA_RHI_SESSION_ABI_OPEN_SUPPORTED      | \
+          ARM_CCA_RHI_SESSION_ABI_CLOSE_SUPPORTED     | \
+          ARM_CCA_RHI_SESSION_ABI_SEND_SUPPORTED      | \
+          ARM_CCA_RHI_SESSION_ABI_RECEIVE_SUPPORTED     \
+          )
+
+/**
+  Macros defining the connection mode of the RHI Session.
+*/
+#define ARM_CCA_RHI_SESSION_CONNECTION_MODE_MASK          0x3ULL
+#define ARM_CCA_RHI_SESSION_CONNECTION_MODE_BLOCKING      BIT0
+#define ARM_CCA_RHI_SESSION_CONNECTION_MODE_NON_BLOCKING  BIT1
+
+/**
+  Get the RHI Host Session protocol version information.
+
+  @param[out] ProtocolVersion       The version of the protocol.
+
+  @retval RETURN_UNSUPPORTED         RHI Host Session protocol not supported.
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionVersion (
+  OUT UINT64  *ProtocolVersion
+  );
+
+/**
+  Perform RHI Host Session protocol feature discovery.
+
+  @param[out] AbiSupportBitmap      A bitmap of supported ABI calls.
+  @param[out] ConnectionModeBitmap  A bitmap of supported Connection modes.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionFeatures (
+  OUT UINT64  *AbiSupportBitmap,
+  OUT UINT64  *ConnectionModeBitmap
+  );

--- a/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.c
+++ b/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.c
@@ -222,3 +222,166 @@ exit_handler:
   FreeAlignedPages (Args, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)));
   return Status;
 }
+
+/**
+  Open a session with the host.
+
+  @param[in]      ConnectionMode  The requested connection mode, must be either
+                                  Blocking or Non-Blocking.
+  @param[in, out] SessionId       On first invocation, SessionId is passed as
+                                  zero and the ABI allocates a Session Id and
+                                  returns.
+                                  If the connection mode is Non-Blocking, the
+                                  SessionState may be returned as
+                                  RhiConnectionInProgress and the
+                                  caller is expected to call this function again
+                                  with the Session ID that was returned in the
+                                  first invocation.
+  @param[out]     SessionState    State of the session.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_UNSUPPORTED         The requested connection mode is not
+                                     supported.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_PROTOCOL_ERROR      A protocol error was detected.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionOpen (
+  IN      UINT64                     ConnectionMode,
+  IN OUT  ARM_CCA_RHI_SESSION_ID     *SessionId,
+  OUT     ARM_CCA_RHI_SESSION_STATE  *SessionState OPTIONAL
+  )
+{
+  RETURN_STATUS               Status;
+  ARM_CCA_RSI_HOST_CALL_ARGS  *Args;
+
+  if (SessionId == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  if ((ConnectionMode != ARM_CCA_RHI_SESSION_CONNECTION_MODE_BLOCKING) &&
+      (ConnectionMode != ARM_CCA_RHI_SESSION_CONNECTION_MODE_NON_BLOCKING))
+  {
+    return RETURN_UNSUPPORTED;
+  }
+
+  // invalid_session_id: 0 not passed on initial call or
+  // unknown SessionID passed (NON_BLOCKING)
+  if ((ConnectionMode == ARM_CCA_RHI_SESSION_CONNECTION_MODE_BLOCKING) &&
+      (*SessionId != 0))
+  {
+    return RETURN_NO_MAPPING;
+  }
+
+  Args = AllocateAlignedPages (
+           EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)),
+           ARM_CCA_REALM_GRANULE_SIZE
+           );
+  if (Args == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (Args, sizeof (ARM_CCA_RSI_HOST_CALL_ARGS));
+  Args->Gprs0 = ARM_CCA_FID_RHI_SESSION_OPEN;
+  Args->Gprs1 = *SessionId;
+  Args->Gprs2 = ConnectionMode;
+
+  Status = ArmCcaRsiHostCall (Args);
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_OPEN, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  Status = ArmCcaRhiSessionReturnCodeToEfiStatus (
+             (ARM_CCA_RHI_SESSION_RETURN_STATUS)Args->Gprs0
+             );
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_OPEN, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  if (*SessionId == 0) {
+    *SessionId = Args->Gprs1;
+  } else if (*SessionId != Args->Gprs1) {
+    Status = RETURN_PROTOCOL_ERROR;
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  if (SessionState != NULL) {
+    *SessionState = Args->Gprs2;
+  }
+
+exit_handler:
+  FreeAlignedPages (Args, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)));
+  return Status;
+}
+
+/**
+  Close a session with the host.
+
+  @param[in]    SessionId         Id of the session to close.
+  @param[out]   SessionState      State of the session.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionClose (
+  IN    ARM_CCA_RHI_SESSION_ID     SessionId,
+  OUT   ARM_CCA_RHI_SESSION_STATE  *SessionState   OPTIONAL
+  )
+{
+  RETURN_STATUS               Status;
+  ARM_CCA_RSI_HOST_CALL_ARGS  *Args;
+
+  if (SessionId == 0) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Args = AllocateAlignedPages (
+           EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)),
+           ARM_CCA_REALM_GRANULE_SIZE
+           );
+  if (Args == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (Args, sizeof (ARM_CCA_RSI_HOST_CALL_ARGS));
+  Args->Gprs0 = ARM_CCA_FID_RHI_SESSION_CLOSE;
+  Args->Gprs1 = SessionId;
+
+  Status = ArmCcaRsiHostCall (Args);
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_CLOSE, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  Status = ArmCcaRhiSessionReturnCodeToEfiStatus (
+             (ARM_CCA_RHI_SESSION_RETURN_STATUS)Args->Gprs0
+             );
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_CLOSE, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  ASSERT (SessionId == Args->Gprs1);
+
+  if (SessionState != NULL) {
+    *SessionState = Args->Gprs2;
+  }
+
+exit_handler:
+  FreeAlignedPages (Args, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)));
+  return Status;
+}

--- a/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.c
+++ b/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.c
@@ -1,0 +1,165 @@
+/** @file
+  Library that implements the Realm Host Interface Host Session protocol.
+
+  Copyright (c) 2024 - 2026, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Glossary:
+    - Rhi or RHI   - Realm Host Interface
+    - Rsi or RSI   - Realm Service Interface
+    - IPA          - Intermediate Physical Address
+    - RIPAS        - Realm IPA state
+
+  @par Reference(s):
+   - Realm Management Monitor (RMM) Specification, version 1.0-rel0
+     (https://developer.arm.com/documentation/den0137/)
+   - Realm Host Interface (RHI) Specification, version 1.0-bet0
+     (https://developer.arm.com/documentation/den0148/)
+**/
+
+#include <Base.h>
+
+#include <IndustryStandard/ArmStdSmc.h>
+#include <Library/ArmCcaRsiLib.h>
+#include <Library/ArmLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/ArmCcaRhiHostSessionLib.h>
+
+STATIC CONST CHAR8  *ArmCcaRhiSessionCmds[] = {
+  "ARM_CCA_FID_RHI_SESSION_VERSION",
+  "ARM_CCA_FID_RHI_SESSION_FEATURES",
+  "ARM_CCA_FID_RHI_SESSION_OPEN",
+  "ARM_CCA_FID_RHI_SESSION_CLOSE",
+  "ARM_CCA_FID_RHI_SESSION_SEND",
+  "ARM_CCA_FID_RHI_SESSION_RECEIVE",
+};
+
+/** A macro to print the RSI Session Error and call arguments.
+
+  @param[in] RhiFid   Fid for the RHI protocol call.
+  @param[in] Status   The status code returned by the RSI Host Call.
+  @param[in] Args     Pointer to the Host Call arguments.
+*/
+#define ARM_CCA_RHI_PRINT_ERROR(Fid, Status, Args)                        \
+          DEBUG ((                                                        \
+            DEBUG_ERROR,                                                  \
+            "Error: RsiHost Call %a Returned %r, "                        \
+            "Args: Gprs0 = 0x%lx, Gprs1 = 0x%lx, "                        \
+            "Gprs2 = 0x%lx, Gprs3 = 0x%lx\n",                             \
+            ArmCcaRhiSessionCmds[Fid - ARM_CCA_FID_RHI_SESSION_VERSION],  \
+            Status,                                                       \
+            Args->Gprs0,                                                  \
+            Args->Gprs1,                                                  \
+            Args->Gprs2,                                                  \
+            Args->Gprs3                                                   \
+            ));
+
+/**
+  Get the RHI Host Session protocol version information.
+
+  @param[out] ProtocolVersion       The version of the protocol.
+
+  @retval RETURN_UNSUPPORTED         RHI Host Session protocol not supported.
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionVersion (
+  OUT UINT64  *ProtocolVersion
+  )
+{
+  RETURN_STATUS               Status;
+  ARM_CCA_RSI_HOST_CALL_ARGS  *Args;
+
+  if (ProtocolVersion == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Args = AllocateAlignedPages (
+           EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)),
+           ARM_CCA_REALM_GRANULE_SIZE
+           );
+  if (Args == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (Args, sizeof (ARM_CCA_RSI_HOST_CALL_ARGS));
+  Args->Gprs0 = ARM_CCA_FID_RHI_SESSION_VERSION;
+
+  Status = ArmCcaRsiHostCall (Args);
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_VERSION, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  if (Args->Gprs0 == ARM_SMC_MM_RET_NOT_SUPPORTED) {
+    Status = EFI_UNSUPPORTED;
+  } else {
+    // Protocol version
+    *ProtocolVersion = Args->Gprs0;
+  }
+
+exit_handler:
+  FreeAlignedPages (Args, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)));
+  return Status;
+}
+
+/**
+  Perform RHI Host Session protocol feature discovery.
+
+  @param[out] AbiSupportBitmap      A bitmap of supported ABI calls.
+  @param[out] ConnectionModeBitmap  A bitmap of supported Connection modes.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionFeatures (
+  OUT UINT64  *AbiSupportBitmap,
+  OUT UINT64  *ConnectionModeBitmap
+  )
+{
+  RETURN_STATUS               Status;
+  ARM_CCA_RSI_HOST_CALL_ARGS  *Args;
+
+  if ((AbiSupportBitmap == NULL) ||
+      (ConnectionModeBitmap == NULL))
+  {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Args = AllocateAlignedPages (
+           EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)),
+           ARM_CCA_REALM_GRANULE_SIZE
+           );
+  if (Args == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (Args, sizeof (ARM_CCA_RSI_HOST_CALL_ARGS));
+  Args->Gprs0 = ARM_CCA_FID_RHI_SESSION_FEATURES;
+
+  Status = ArmCcaRsiHostCall (Args);
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_FEATURES, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  // ABI call support bitmap
+  *AbiSupportBitmap = Args->Gprs0;
+
+  // Connection Mode support bitmap
+  *ConnectionModeBitmap = Args->Gprs1 & ARM_CCA_RHI_SESSION_CONNECTION_MODE_MASK;
+
+exit_handler:
+  FreeAlignedPages (Args, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)));
+  return Status;
+}

--- a/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.c
+++ b/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.c
@@ -56,6 +56,65 @@ STATIC CONST CHAR8  *ArmCcaRhiSessionCmds[] = {
             Args->Gprs3                                                   \
             ));
 
+/** An enum defining the RHI command return status.
+*/
+typedef enum ArmCcaRhiSessionReturnStatus {
+  RhiSessionStatusSuccess,                     ///< Success
+  RhiSessionStatusPeerNotAvailable,            ///< Peer not available
+  RhiSessionStatusInvalidStateForOperation,    ///< Invalid state for operation
+  RhiSessionStatusInvalidSessionId,            ///< Invalid Session ID
+  RhiSessionStatusConnectionTypeNotSupported,  ///< Connection type not supported
+  RhiSessionStatusAccessFailed,                ///< Buffer not readable/writable or address not granule aligned
+  RhiSessionStatusMax
+} ARM_CCA_RHI_SESSION_RETURN_STATUS;
+
+/**
+  Return EFI Status code corresponding to RHI Host Session Return Code.
+
+  @param[in]     ReturnCode    Return Code.
+
+  @retval RETURN_SUCCESS             Success.
+  @retval RETURN_NOT_FOUND           Peer not available.
+  @retval RETURN_PROTOCOL_ERROR      Invalid state for operation.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_UNSUPPORTED         The requested connection mode is not
+                                  supported.
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_ABORTED             Invalid return code.
+**/
+STATIC
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionReturnCodeToEfiStatus (
+  IN  ARM_CCA_RHI_SESSION_RETURN_STATUS  ReturnCode
+  )
+{
+  switch (ReturnCode) {
+    case RhiSessionStatusSuccess:
+      return RETURN_SUCCESS;
+
+    case RhiSessionStatusPeerNotAvailable:
+      return RETURN_NOT_FOUND;
+
+    case RhiSessionStatusInvalidStateForOperation:
+      return RETURN_PROTOCOL_ERROR;
+
+    case RhiSessionStatusInvalidSessionId:
+      return RETURN_NO_MAPPING;
+
+    case RhiSessionStatusConnectionTypeNotSupported:
+      return RETURN_UNSUPPORTED;
+
+    case RhiSessionStatusAccessFailed:
+      return RETURN_INVALID_PARAMETER;
+
+    case RhiSessionStatusMax:
+    default:
+      ASSERT (0);
+      return RETURN_ABORTED;
+  }
+}
+
 /**
   Get the RHI Host Session protocol version information.
 

--- a/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.c
+++ b/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.c
@@ -213,7 +213,7 @@ ArmCcaRhiSessionFeatures (
   }
 
   // ABI call support bitmap
-  *AbiSupportBitmap = Args->Gprs0;
+  *AbiSupportBitmap = Args->Gprs0 & ARM_CCA_RHI_SESSION_ABI_MASK;
 
   // Connection Mode support bitmap
   *ConnectionModeBitmap = Args->Gprs1 & ARM_CCA_RHI_SESSION_CONNECTION_MODE_MASK;
@@ -380,6 +380,171 @@ ArmCcaRhiSessionClose (
   if (SessionState != NULL) {
     *SessionState = Args->Gprs2;
   }
+
+exit_handler:
+  FreeAlignedPages (Args, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)));
+  return Status;
+}
+
+/**
+  Transmit data on previously opened communication channel.
+
+  @param[in]      SessionId     The session ID for the communication channel.
+  @param[in]      Data          Realm IPA for buffer containing data.
+  @param[in, out] DataLen       Length of data to send in bytes on input and
+                                Length of data transmitted on return.
+  @param[in]      Offset        Offset in buffer from which to send data.
+  @param[out]     SessionState  State of the session.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_PROTOCOL_ERROR      A protocol error was detected.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionSend (
+  IN      ARM_CCA_RHI_SESSION_ID     SessionId,
+  IN      UINT8                      *Data,
+  IN OUT  UINTN                      *DataLen,
+  IN      UINTN                      Offset,
+  OUT     ARM_CCA_RHI_SESSION_STATE  *SessionState OPTIONAL
+  )
+{
+  RETURN_STATUS               Status;
+  ARM_CCA_RSI_HOST_CALL_ARGS  *Args;
+
+  if ((SessionId == 0)  ||
+      (Data == NULL)    ||
+      (DataLen == NULL) ||
+      (*DataLen == 0)   ||
+      (!IS_ALIGNED (Data, ARM_CCA_REALM_GRANULE_SIZE)))
+  {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Args = AllocateAlignedPages (
+           EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)),
+           ARM_CCA_REALM_GRANULE_SIZE
+           );
+  if (Args == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (Args, sizeof (ARM_CCA_RSI_HOST_CALL_ARGS));
+  Args->Gprs0 = ARM_CCA_FID_RHI_SESSION_SEND;
+  Args->Gprs1 = SessionId;
+  Args->Gprs2 = (UINT64)(UINT64 *)Data;
+  Args->Gprs3 = *DataLen;
+  Args->Gprs4 = Offset;
+
+  Status = ArmCcaRsiHostCall (Args);
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_SEND, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  Status = ArmCcaRhiSessionReturnCodeToEfiStatus (
+             (ARM_CCA_RHI_SESSION_RETURN_STATUS)Args->Gprs0
+             );
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_SEND, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  ASSERT (SessionId == Args->Gprs1);
+
+  if (SessionState != NULL) {
+    *SessionState = Args->Gprs2;
+  }
+
+  *DataLen = Args->Gprs3;
+
+exit_handler:
+  FreeAlignedPages (Args, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)));
+  return Status;
+}
+
+/**
+  Receive data on previously opened communication channel.
+
+  @param[in]      SessionId     The session ID for the communication channel.
+  @param[in]      Data          Realm IPA for buffer used to receive data.
+  @param[in, out] DataLen       Size of receiving data buffer.
+  @param[in]      Offset        Offset in buffer where received data is to be
+                                written.
+  @param[out]     SessionState  State of the session.
+
+  @retval RETURN_INVALID_PARAMETER   A parameter was invalid.
+  @retval RETURN_OUT_OF_RESOURCES    Insufficient memory.
+  @retval RETURN_NO_MAPPING          An invalid session ID was provided.
+  @retval RETURN_PROTOCOL_ERROR      A protocol error was detected.
+  @retval RETURN_SUCCESS             Success.
+**/
+RETURN_STATUS
+EFIAPI
+ArmCcaRhiSessionReceive (
+  IN      ARM_CCA_RHI_SESSION_ID     SessionId,
+  IN      UINT8                      *Data,
+  IN OUT  UINTN                      *DataLen,
+  IN      UINTN                      Offset,
+  OUT     ARM_CCA_RHI_SESSION_STATE  *SessionState OPTIONAL
+  )
+{
+  RETURN_STATUS               Status;
+  ARM_CCA_RSI_HOST_CALL_ARGS  *Args;
+
+  if ((SessionId == 0)  ||
+      (Data == NULL)    ||
+      (DataLen == NULL) ||
+      (*DataLen == 0)   ||
+      (!IS_ALIGNED (Data, ARM_CCA_REALM_GRANULE_SIZE)))
+  {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Args = AllocateAlignedPages (
+           EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)),
+           ARM_CCA_REALM_GRANULE_SIZE
+           );
+  if (Args == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (Args, sizeof (ARM_CCA_RSI_HOST_CALL_ARGS));
+
+  Args->Gprs0 = ARM_CCA_FID_RHI_SESSION_RECEIVE;
+  Args->Gprs1 = SessionId;
+  Args->Gprs2 = (UINT64)(UINT64 *)Data;
+  Args->Gprs3 = (UINT64)*DataLen;
+  Args->Gprs4 = Offset;
+
+  Status = ArmCcaRsiHostCall (Args);
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_RECEIVE, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  Status = ArmCcaRhiSessionReturnCodeToEfiStatus (
+             (ARM_CCA_RHI_SESSION_RETURN_STATUS)Args->Gprs0
+             );
+  if (RETURN_ERROR (Status)) {
+    ARM_CCA_RHI_PRINT_ERROR (ARM_CCA_FID_RHI_SESSION_RECEIVE, Status, Args);
+    ASSERT (0);
+    goto exit_handler;
+  }
+
+  ASSERT (SessionId == Args->Gprs1);
+
+  if (SessionState != NULL) {
+    *SessionState = Args->Gprs2;
+  }
+
+  *DataLen = Args->Gprs3;
 
 exit_handler:
   FreeAlignedPages (Args, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_RSI_HOST_CALL_ARGS)));

--- a/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.inf
+++ b/ArmVirtPkg/Library/ArmCcaRhiHostSessionLib/ArmCcaRhiHostSessionLib.inf
@@ -1,0 +1,32 @@
+## @file
+#  Library that implements the Arm CCA RHI Host Session protocol interfaces.
+#
+#  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = ArmCcaRhiHostSessionLib
+  FILE_GUID                      = CC712FC2-B6D6-44BF-BA27-EE95CCB6C459
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ArmCcaRhiHostSessionLib
+
+[Sources]
+  ArmCcaRhiHostSessionLib.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  ArmVirtPkg/ArmVirtPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  ArmLib
+  ArmCcaRsiLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib

--- a/MdePkg/Include/IndustryStandard/ArmStdSmc.h
+++ b/MdePkg/Include/IndustryStandard/ArmStdSmc.h
@@ -13,6 +13,8 @@
 *    (https://developer.arm.com/documentation/den0098/latest/)
 *  - [3] Realm Management Monitor (RMM) Specification, version 1.0-rel0
 *    (https://developer.arm.com/documentation/den0137/)
+*  - Realm Host Interface (RHI) Specification, version 1.0-bet0
+*    (https://developer.arm.com/documentation/den0148/)
 *
 *  @par Glossary:
 *    - TRNG - True Random Number Generator
@@ -263,3 +265,14 @@
 #define ARM_CCA_FID_RSI_MEASUREMENT_READ            0xC4000192
 #define ARM_CCA_FID_RSI_REALM_CONFIG                0xC4000196
 #define ARM_CCA_FID_RSI_VERSION                     0xC4000190
+
+/*
+ * Arm CCA FIDs for Realm Host Interface (RHI) Host Session protocol
+ * calls as specified by the Realm Host Interface (RHI) Specification.
+ */
+#define ARM_CCA_FID_RHI_SESSION_VERSION   0xC5000040
+#define ARM_CCA_FID_RHI_SESSION_FEATURES  0xC5000041
+#define ARM_CCA_FID_RHI_SESSION_OPEN      0xC5000042
+#define ARM_CCA_FID_RHI_SESSION_CLOSE     0xC5000043
+#define ARM_CCA_FID_RHI_SESSION_SEND      0xC5000044
+#define ARM_CCA_FID_RHI_SESSION_RECEIVE   0xC5000045


### PR DESCRIPTION
# Description

Introduce Realm Host Interface (RHI) session support required by Arm CCA Boot Sync.

Arm CCA Boot Sync requires the Realm guest firmware to communicate with a host-side service during early boot. Since the Realm guest firmware does not have networking support at this stage, the communication is performed using Realm Host Calls routed through the RHI Host Session protocol.

This PR adds the RHI Host Session protocol function identifiers and introduces an ArmVirtPkg RHI Session library that provides helper interfaces to:

* Open an RHI session.
* Close an RHI session.
* Convert RHI session protocol errors to EFI status codes.
* Send data over an RHI session.
* Receive data over an RHI session.

This provides the transport layer required by the subsequent Arm CCA Boot Sync protocol implementation.

Note: This PR is a subset of the PR that tracks the enablement of secure boot support for Arm CCA https://github.com/tianocore/edk2/pull/12625

* [ ] Breaking change?

  * **Breaking change** - Does this PR cause a break in build or boot behavior?
  * Examples: Does it add a new library class or move a module to a different repo.
  * If checked, follow the [[Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md)](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
* [ ] Impacts security?

  * **Security** - Does this PR have a direct security impact?
  * Examples: Crypto algorithm change or buffer overflow fix.
* [ ] Includes tests?

  * **Tests** - Does this PR include any explicit test code?
  * Examples: Unit tests or integration tests.

## How This Was Tested

Tested using full end-to-end Arm CCA Boot Sync flow in a local environment that incorporates the PR https://github.com/tianocore/edk2/pull/12224.

## Integration Instructions

This PR is part of the Arm CCA Secure Boot / Boot Sync enablement series.

This series depends on the prerequisite Arm CCA guest firmware enablement PR https://github.com/tianocore/edk2/pull/12224 and the earlier Arm CCA Secure Boot sub-series that add host unit test support and cryptographic interfaces required by Boot Sync.

No special integration steps are required.