### PR TITLE
MdePkg, ManageabilityPkg: Support separate IPMI KCS command address

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -72,7 +72,48 @@ None
 
 ### edk2-stable202608: Behavioral Breaking Changes
 
-None
+#### Breaking Change: Separate IPMI KCS command/status address
+
+**Status**: Deprecation Active
+**Tracking Issue**: [tianocore/edk2#12805](https://github.com/tianocore/edk2/issues/12805)
+**Type**: Behavioral - Changed default behavior
+
+**What changed**: The IPMI KCS command/status register address is no longer
+derived from `PcdIpmiKcsIoBaseAddress + 1`. The new
+`PcdIpmiKcsIoCommandAddress` specifies the address independently and defaults
+to `0xCA3`. The data register PCD continues to default to `0xCA2`. The IPMI
+ACPI device also moves from the platform-specific `\_SB.PC00.LPC0.IPMC`
+namespace to `\_SB.IPMC`. `BmcAcpi` now consumes both KCS address PCDs as
+FixedAtBuild, consistent with the other IPMI KCS modules in `ManageabilityPkg`.
+
+**Why it changed**: Some KCS interfaces use non-contiguous data and
+command/status registers, such as `0x62` and `0x66`. Describing both addresses
+explicitly also keeps the ACPI resource declaration consistent with the
+addresses used by the IPMI transport drivers.
+
+**What replaces it**: Configure `PcdIpmiKcsIoBaseAddress` for the data register
+and `PcdIpmiKcsIoCommandAddress` for the command/status register.
+
+**How to migrate**: Platforms that override `PcdIpmiKcsIoBaseAddress` must also
+set `PcdIpmiKcsIoCommandAddress` in their DSC. For example:
+
+```text
+gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress|0x62
+gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress|0x66
+```
+
+References in platform ASL or tooling to `\_SB.PC00.LPC0.IPMC` must be updated
+to `\_SB.IPMC`. Platforms that build `BmcAcpi` with these PCDs as
+PatchableInModule must resolve them as FixedAtBuild instead.
+
+**Breaking conditions**: The address change affects platforms that override
+`PcdIpmiKcsIoBaseAddress` and do not configure the new command/status address
+PCD. The namespace change affects platforms with absolute references to the
+former `\_SB.PC00.LPC0.IPMC` path. The PCD access change affects platforms
+that use `BmcAcpi` without the standard IPMI stack and resolve either KCS
+address PCD as PatchableInModule.
+
+**Companion PR**: N/A
 
 ### edk2-stable202608: Build-System Breaking Changes
 

--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/BaseManageabilityTransportKcs.inf
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/BaseManageabilityTransportKcs.inf
@@ -2,6 +2,7 @@
 # KCS instance of Manageability Transport Library
 #
 # Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -41,5 +42,5 @@
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress                        # Used as default KCS I/O base adddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress
   gManageabilityPkgTokenSpaceGuid.PcdKcsStatusCheckTimeout                 # Use the predefined timeout value in micro seconds
-

--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/Dxe/DxeManageabilityTransportKcs.inf
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/Dxe/DxeManageabilityTransportKcs.inf
@@ -2,6 +2,7 @@
 # KCS instance of Manageability Transport Library
 #
 # Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -41,5 +42,5 @@
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress                        # Used as default KCS I/O base adddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress
   gManageabilityPkgTokenSpaceGuid.PcdKcsStatusCheckTimeout                 # Use the predefined timeout value in micro seconds
-

--- a/ManageabilityPkg/Library/ManageabilityTransportKcsLib/ManageabilityTransportKcs.c
+++ b/ManageabilityPkg/Library/ManageabilityTransportKcsLib/ManageabilityTransportKcs.c
@@ -3,6 +3,7 @@
   KCS instance of Manageability Transport Library
 
   Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -68,8 +69,8 @@ KcsTransportInit (
     mKcsHardwareInfo.IoBaseAddress.IoAddress16    = PcdGet16 (PcdIpmiKcsIoBaseAddress);
     mKcsHardwareInfo.IoDataInAddress.IoAddress16  = mKcsHardwareInfo.IoBaseAddress.IoAddress16 + IPMI_KCS_DATA_IN_REGISTER_OFFSET;
     mKcsHardwareInfo.IoDataOutAddress.IoAddress16 = mKcsHardwareInfo.IoBaseAddress.IoAddress16 + IPMI_KCS_DATA_OUT_REGISTER_OFFSET;
-    mKcsHardwareInfo.IoCommandAddress.IoAddress16 = mKcsHardwareInfo.IoBaseAddress.IoAddress16 + IPMI_KCS_COMMAND_REGISTER_OFFSET;
-    mKcsHardwareInfo.IoStatusAddress.IoAddress16  = mKcsHardwareInfo.IoBaseAddress.IoAddress16 + IPMI_KCS_STATUS_REGISTER_OFFSET;
+    mKcsHardwareInfo.IoCommandAddress.IoAddress16 = PcdGet16 (PcdIpmiKcsIoCommandAddress);
+    mKcsHardwareInfo.IoStatusAddress.IoAddress16  = PcdGet16 (PcdIpmiKcsIoCommandAddress);
   } else {
     mKcsHardwareInfo.MemoryMap        = ((MANAGEABILITY_TRANSPORT_KCS_HARDWARE_INFO *)HardwareInfo.Kcs)->MemoryMap;
     mKcsHardwareInfo.IoBaseAddress    = ((MANAGEABILITY_TRANSPORT_KCS_HARDWARE_INFO *)HardwareInfo.Kcs)->IoBaseAddress;

--- a/ManageabilityPkg/Universal/IpmiBmcAcpi/BmcAcpi.c
+++ b/ManageabilityPkg/Universal/IpmiBmcAcpi/BmcAcpi.c
@@ -2,6 +2,7 @@
   IPMI BMC ACPI driver to update APCI SSDT table.
 
   Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -126,8 +127,6 @@ UpdateDeviceSsdtTable (
 {
   EFI_ACPI_DESCRIPTION_HEADER  *TableHeader;
   UINT64                       TempOemTableId;
-  UINT8                        *DataPtr;
-  EFI_ACPI_IO_PORT_DESCRIPTOR  *IoRsc;
 
   TableHeader = (EFI_ACPI_DESCRIPTION_HEADER *)Table;
 
@@ -139,33 +138,6 @@ UpdateDeviceSsdtTable (
   CopyMem (&TableHeader->OemTableId, &TempOemTableId, sizeof (UINT64));
   TableHeader->CreatorId       = EFI_ACPI_CREATOR_ID;
   TableHeader->CreatorRevision = EFI_ACPI_CREATOR_REVISION;
-
-  //
-  // Update IO(Decode16, 0xCA2, 0xCA2, 0, 2)
-  //
-  DEBUG ((DEBUG_MANAGEABILITY_INFO, "UpdateDeviceSsdtTable - IPMI\n"));
-  for (DataPtr = (UINT8 *)(Table + 1);
-       DataPtr < (UINT8 *)((UINT8 *)Table + Table->Length - 4);
-       DataPtr++)
-  {
-    if (CompareMem (DataPtr, "_CRS", 4) == 0) {
-      DataPtr += 4; // Skip _CRS
-      ASSERT (*DataPtr == AML_BUFFER_OP);
-      DataPtr++;  // Skip AML_BUFFER_OP
-      ASSERT ((*DataPtr & (BIT7|BIT6)) == 0);
-      DataPtr++;  // Skip PkgLength - 0xD
-      ASSERT ((*DataPtr) == AML_BYTE_PREFIX);
-      DataPtr++;  // Skip BufferSize OpCode
-      DataPtr++;  // Skip BufferSize - 0xA
-      IoRsc = (VOID *)DataPtr;
-      ASSERT (IoRsc->Header.Bits.Type == ACPI_SMALL_ITEM_FLAG);
-      ASSERT (IoRsc->Header.Bits.Name == ACPI_SMALL_IO_PORT_DESCRIPTOR_NAME);
-      ASSERT (IoRsc->Header.Bits.Length == sizeof (EFI_ACPI_IO_PORT_DESCRIPTOR) - sizeof (ACPI_SMALL_RESOURCE_HEADER));
-      DEBUG ((DEBUG_MANAGEABILITY_INFO, "IPMI IO Base in ASL update - 0x%04x <= 0x%04x\n", IoRsc->BaseAddressMin, PcdGet16 (PcdIpmiKcsIoBaseAddress)));
-      IoRsc->BaseAddressMin = PcdGet16 (PcdIpmiKcsIoBaseAddress);
-      IoRsc->BaseAddressMax = PcdGet16 (PcdIpmiKcsIoBaseAddress);
-    }
-  }
 
   return EFI_SUCCESS;
 }

--- a/ManageabilityPkg/Universal/IpmiBmcAcpi/BmcAcpi.inf
+++ b/ManageabilityPkg/Universal/IpmiBmcAcpi/BmcAcpi.inf
@@ -2,6 +2,7 @@
 # This is IPMI BMC ACPI module.
 #
 # Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -35,8 +36,11 @@
   gEfiFirmwareVolume2ProtocolGuid
   gEfiAcpiTableProtocolGuid
 
-[Pcd]
+[FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress
+
+[Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemId
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemTableId
 

--- a/ManageabilityPkg/Universal/IpmiBmcAcpi/BmcSsdt/BmcSsdt.asl
+++ b/ManageabilityPkg/Universal/IpmiBmcAcpi/BmcSsdt/BmcSsdt.asl
@@ -2,6 +2,7 @@
   BMC ACPI SSDT.
 
 Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -18,9 +19,7 @@ DefinitionBlock (
     )
 {
 
-  External(\_SB.PC00.LPC0, DeviceObj)
-
-  Scope (\_SB.PC00.LPC0)
+  Scope (\_SB)
   {
     #include "IpmiOprRegions.asi"
   }

--- a/ManageabilityPkg/Universal/IpmiBmcAcpi/BmcSsdt/IpmiOprRegions.asi
+++ b/ManageabilityPkg/Universal/IpmiBmcAcpi/BmcSsdt/IpmiOprRegions.asi
@@ -2,6 +2,7 @@
   IPMI ACPI SSDT.
 
 Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -42,8 +43,8 @@ Device(IPMC)
     // Return the x86 resources consumed by BMC
     Name(_CRS, ResourceTemplate()
     {
-        // Uses 8-bit ports 0xCA2-0xCA5
-        IO(Decode16, 0xCA2, 0xCA2, 0, 2)
+        IO(Decode16, FixedPcdGet16 (PcdIpmiKcsIoBaseAddress), FixedPcdGet16 (PcdIpmiKcsIoBaseAddress), 0, 1)
+        IO(Decode16, FixedPcdGet16 (PcdIpmiKcsIoCommandAddress), FixedPcdGet16 (PcdIpmiKcsIoCommandAddress), 0, 1)
     })
 
     Name(_HID, "IPI0001")           // IPMI device
@@ -54,5 +55,3 @@ Device(IPMC)
 
 
 } // end of  Device(IPMC)
-
-

--- a/ManageabilityPkg/Universal/IpmiProtocol/Common/IpmiProtocolCommon.h
+++ b/ManageabilityPkg/Universal/IpmiProtocol/Common/IpmiProtocolCommon.h
@@ -4,6 +4,7 @@
 
   Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
   Copyright (c) 2024, Ampere Computing LLC. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -18,8 +19,8 @@
 #define IPMI_KCS_BASE_ADDRESS  PcdGet16 (PcdIpmiKcsIoBaseAddress)
 #define IPMI_KCS_REG_DATA_IN   IPMI_KCS_BASE_ADDRESS + IPMI_KCS_DATA_IN_REGISTER_OFFSET
 #define IPMI_KCS_REG_DATA_OUT  IPMI_KCS_BASE_ADDRESS + IPMI_KCS_DATA_OUT_REGISTER_OFFSET
-#define IPMI_KCS_REG_COMMAND   IPMI_KCS_BASE_ADDRESS + IPMI_KCS_COMMAND_REGISTER_OFFSET
-#define IPMI_KCS_REG_STATUS    IPMI_KCS_BASE_ADDRESS + IPMI_KCS_STATUS_REGISTER_OFFSET
+#define IPMI_KCS_REG_COMMAND   PcdGet16 (PcdIpmiKcsIoCommandAddress)
+#define IPMI_KCS_REG_STATUS    IPMI_KCS_REG_COMMAND
 
 ///
 /// IPMI SSIF hardware information.

--- a/ManageabilityPkg/Universal/IpmiProtocol/Dxe/IpmiProtocolDxe.inf
+++ b/ManageabilityPkg/Universal/IpmiProtocol/Dxe/IpmiProtocolDxe.inf
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) 2024, Ampere Computing LLC. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -48,6 +49,7 @@
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress   # Used as default KCS I/O base adddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequesterAddress
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialResponderAddress

--- a/ManageabilityPkg/Universal/IpmiProtocol/Pei/IpmiPpiPei.inf
+++ b/ManageabilityPkg/Universal/IpmiProtocol/Pei/IpmiPpiPei.inf
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) 2024, Ampere Computing LLC. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -49,6 +50,7 @@
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress   # Used as default KCS I/O base adddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequesterAddress
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialResponderAddress

--- a/ManageabilityPkg/Universal/IpmiProtocol/Smm/IpmiProtocolSmm.inf
+++ b/ManageabilityPkg/Universal/IpmiProtocol/Smm/IpmiProtocolSmm.inf
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -48,6 +49,7 @@
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress   # Used as default KCS I/O base adddress
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequesterAddress
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialResponderAddress

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2467,10 +2467,16 @@
   # @Prompt Memory Address of GuidedExtractHandler Table.
   gEfiMdePkgTokenSpaceGuid.PcdGuidedExtractHandlerTableAddress|0x1000000|UINT64|0x30001015
 
-  ## This value is the IPMI KCS Interface I/O base address used to transmit IPMI commands.
-  #  The value of 0xca2 is the default I/O base address defined in IPMI specification.
+  ## This value is the IPMI KCS data register I/O address.
+  #  The IPMI specification defines 0xca2 as the default byte-aligned KCS I/O base address.
   # @Prompt IPMI KCS Interface I/O Base Address
   gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress|0xca2|UINT16|0x00000031
+
+  ## This value is the IPMI KCS command/status register I/O address.
+  #  The default value of 0xca3 corresponds to the IPMI-defined default KCS I/O
+  #  base address of 0xca2 with the byte-aligned command/status register at base + 1.
+  # @Prompt IPMI KCS Command/Status Register I/O Address
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress|0xca3|UINT16|0x00000038
 
   ## This is SMBus slave address for the SSIF to the BMC.
   #  The recommended value defined by IPMI specification is 0x20 (section 12.12).


### PR DESCRIPTION
# Description

The IPMI specification defines `0xCA2` as the default byte-aligned KCS I/O base address and places the command/status register at `base + 1`, resulting in the default `0xCA3` address. Some platforms instead expose the data and command/status registers at non-contiguous ports, such as `0x62` and `0x66`.

Add `PcdIpmiKcsIoCommandAddress` so the command/status address can be configured independently. Use it throughout the IPMI protocol and KCS transport implementations.

All existing IPMI KCS protocol and transport modules in `ManageabilityPkg` consume the KCS address PCDs as FixedAtBuild. Align `BmcAcpi.inf` with those modules by declaring both KCS address PCDs as `FixedPcd`. This avoids mixed PCD access methods within the package and allows the SSDT to consume the addresses directly through `FixedPcdGet16()`, eliminating runtime AML resource patching. The ACPI OEM ID and OEM table ID PCDs remain generic `[Pcd]` inputs.

Describe the data and command/status ports as separate one-byte ACPI I/O resources so both contiguous and non-contiguous layouts are represented correctly. The IPMI ACPI device is also moved from the platform-specific `\_SB.PC00.LPC0.IPMC` namespace to `\_SB.IPMC`.

The default `0xCA2/0xCA3` behavior remains unchanged.

This is a conditional behavioral breaking change:

- Platforms overriding `PcdIpmiKcsIoBaseAddress` must also configure `PcdIpmiKcsIoCommandAddress`.
- Platforms building `BmcAcpi` independently with these PCDs resolved as PatchableInModule must change them to FixedAtBuild.
- Absolute references to `\_SB.PC00.LPC0.IPMC` must be updated to `\_SB.IPMC`.

- [x] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Built `ManageabilityPkg` for X64 DEBUG with VS2022.
- Built `BmcAcpi` with FixedAtBuild addresses `0x62` and `0x66`.
- Verified the generated SSDT contains separate one-byte I/O descriptors for `0x62` and `0x66`.
- Passed `PatchCheck.py` for both package-scoped commits.

## Integration Instructions

Tracking issue: https://github.com/tianocore/edk2/issues/12805

Platforms using the default KCS addresses require no changes. Platforms using different addresses must configure both PCDs as FixedAtBuild:

```text
[PcdsFixedAtBuild]
  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress|0x62
  gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoCommandAddress|0x66
```

Update platform ASL or tooling references from `\_SB.PC00.LPC0.IPMC` to `\_SB.IPMC`.

Maintainer action: assign the tracking issue to the `edk2-stable202608` milestone; the author account does not have permission to update upstream issue milestones.

Closes #12805