### PR TITLE
NetworkPkg: Fix multiple security vulnerabilities in DHCP/PXE/HTTP Boot

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootClient.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootClient.c
@@ -1779,6 +1779,7 @@ ERROR_6:
   }
 
   HttpBootFreeCache (Cache);
+  Cache = NULL;
 
 ERROR_5:
   if (ResponseData != NULL) {

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
@@ -280,6 +280,9 @@ HttpBootParseDhcp4Packet (
 
   Offer   = &Cache4->Packet.Offer;
   Options = Cache4->OptList;
+  if (Offer->Length < sizeof (EFI_DHCP4_HEADER) + 4) {
+    return EFI_DEVICE_ERROR;
+  }
 
   //
   // Parse DHCPv4 options in this offer, and store the pointers.
@@ -617,6 +620,10 @@ HttpBootDhcp4CallBack (
   }
 
   Private = (HTTP_BOOT_PRIVATE_DATA *)Context;
+
+  if (Packet->Length < sizeof (EFI_DHCP4_HEADER) + 4) {
+    return EFI_SUCCESS;
+  }
 
   //
   // Override the Maximum DHCP Message Size.

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
@@ -353,8 +353,16 @@ HttpBootParseDhcp4Packet (
     // RFC 2132, Section 9.5 does not strictly state Bootfile name (option 67) is null
     // terminated string. So force to append null terminated character at the end of string.
     //
+    if (Options[HTTP_BOOT_DHCP4_TAG_INDEX_BOOTFILE]->Length == 0) {
+      return EFI_DEVICE_ERROR;
+    }
+
     Ptr8  =  (UINT8 *)&Options[HTTP_BOOT_DHCP4_TAG_INDEX_BOOTFILE]->Data[0];
     Ptr8 += Options[HTTP_BOOT_DHCP4_TAG_INDEX_BOOTFILE]->Length;
+    if (Ptr8 > (UINT8 *)Offer->Dhcp4.Option + GET_OPTION_BUFFER_LEN (Offer)) {
+      return EFI_DEVICE_ERROR;
+    }
+
     if (*(Ptr8 - 1) != '\0') {
       *Ptr8 = '\0';
     }

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
@@ -199,7 +199,15 @@ HttpBootParseDhcp4Options (
     if (Option->OpCode == DHCP4_TAG_PAD) {
       Offset++;
     } else {
+      if (Offset + Option->Length + 2 > Length) {
+        return NULL;
+      }
+
       Offset += Option->Length + 2;
+    }
+
+    if (Offset >= Length) {
+      return NULL;
     }
 
     Option = (EFI_DHCP4_PACKET_OPTION *)(Buffer + Offset);

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
@@ -280,6 +280,9 @@ HttpBootParseDhcp4Packet (
 
   Offer   = &Cache4->Packet.Offer;
   Options = Cache4->OptList;
+  if (Offer->Length < sizeof (EFI_DHCP4_HEADER) + sizeof (Offer->Dhcp4.Magik)) {
+    return EFI_DEVICE_ERROR;
+  }
 
   //
   // Parse DHCPv4 options in this offer, and store the pointers.
@@ -617,6 +620,10 @@ HttpBootDhcp4CallBack (
   }
 
   Private = (HTTP_BOOT_PRIVATE_DATA *)Context;
+
+  if (Packet->Length < sizeof (EFI_DHCP4_HEADER) + sizeof (Packet->Dhcp4.Magik)) {
+    return EFI_SUCCESS;
+  }
 
   //
   // Override the Maximum DHCP Message Size.

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp4.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp4.h
@@ -164,7 +164,7 @@ typedef union {
    sizeof (EFI_DHCP4_PACKET_OPTION) + (Opt)->Length - 1)
 
 #define GET_OPTION_BUFFER_LEN(Pkt) \
-  ((Pkt)->Length - sizeof (EFI_DHCP4_HEADER) - 4)
+  ((Pkt)->Length - sizeof (EFI_DHCP4_HEADER) - sizeof ((Pkt)->Dhcp4.Magik))
 
 #define DEFAULT_CLASS_ID_DATA  "HTTPClient:Arch:xxxxx:UNDI:003000"
 #define DEFAULT_UNDI_TYPE      1

--- a/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
+++ b/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
@@ -1184,6 +1184,8 @@ HttpParseMessageBody (
     switch (Parser->State) {
       case BodyParserStateMax:
         return EFI_ABORTED;
+      case BodyParserComplete:
+        return EFI_SUCCESS;
 
       case BodyParserBodyIdentity:
         //

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -90,7 +90,7 @@ PxeBcParseVendorOptions (
   UINT32                   *BitMap;
   UINT8                    VendorOptionLen;
   EFI_DHCP4_PACKET_OPTION  *PxeOption;
-  UINT8                    Offset;
+  UINT32                   Offset;
 
   BitMap          = VendorOption->BitMap;
   VendorOptionLen = Dhcp4Option->Length;
@@ -194,7 +194,11 @@ PxeBcParseVendorOptions (
     if (PxeOption->OpCode == DHCP4_TAG_PAD) {
       Offset++;
     } else {
-      Offset = (UINT8)(Offset + PxeOption->Length + 2);
+      if (Offset + (UINT32)PxeOption->Length + 2 > VendorOptionLen) {
+        break;
+      }
+
+      Offset += (UINT32)PxeOption->Length + 2;
     }
 
     PxeOption = (EFI_DHCP4_PACKET_OPTION *)(Dhcp4Option->Data + Offset);

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -545,8 +545,16 @@ PxeBcParseDhcp4Packet (
     // RFC 2132, Section 9.5 does not strictly state Bootfile name (option 67) is null
     // terminated string. So force to append null terminated character at the end of string.
     //
+    if (Options[PXEBC_DHCP4_TAG_INDEX_BOOTFILE]->Length == 0) {
+      return EFI_DEVICE_ERROR;
+    }
+
     Ptr8  =  (UINT8 *)&Options[PXEBC_DHCP4_TAG_INDEX_BOOTFILE]->Data[0];
     Ptr8 += Options[PXEBC_DHCP4_TAG_INDEX_BOOTFILE]->Length;
+    if (Ptr8 > (UINT8 *)Offer->Dhcp4.Option + GET_OPTION_BUFFER_LEN (Offer)) {
+      return EFI_DEVICE_ERROR;
+    }
+
     if (*(Ptr8 - 1) != '\0') {
       *Ptr8 = '\0';
     }

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -105,38 +105,52 @@ PxeBcParseVendorOptions (
     //
     switch (PxeOption->OpCode) {
       case PXEBC_VENDOR_TAG_MTFTP_IP:
+        if (PxeOption->Length >= sizeof (EFI_IPv4_ADDRESS)) {
+          CopyMem (&VendorOption->MtftpIp, PxeOption->Data, sizeof (EFI_IPv4_ADDRESS));
+        }
 
-        CopyMem (&VendorOption->MtftpIp, PxeOption->Data, sizeof (EFI_IPv4_ADDRESS));
         break;
 
       case PXEBC_VENDOR_TAG_MTFTP_CPORT:
+        if (PxeOption->Length >= sizeof (VendorOption->MtftpCPort)) {
+          CopyMem (&VendorOption->MtftpCPort, PxeOption->Data, sizeof (VendorOption->MtftpCPort));
+        }
 
-        CopyMem (&VendorOption->MtftpCPort, PxeOption->Data, sizeof (VendorOption->MtftpCPort));
         break;
 
       case PXEBC_VENDOR_TAG_MTFTP_SPORT:
+        if (PxeOption->Length >= sizeof (VendorOption->MtftpSPort)) {
+          CopyMem (&VendorOption->MtftpSPort, PxeOption->Data, sizeof (VendorOption->MtftpSPort));
+        }
 
-        CopyMem (&VendorOption->MtftpSPort, PxeOption->Data, sizeof (VendorOption->MtftpSPort));
         break;
 
       case PXEBC_VENDOR_TAG_MTFTP_TIMEOUT:
+        if (PxeOption->Length >= sizeof (VendorOption->MtftpTimeout)) {
+          VendorOption->MtftpTimeout = *PxeOption->Data;
+        }
 
-        VendorOption->MtftpTimeout = *PxeOption->Data;
         break;
 
       case PXEBC_VENDOR_TAG_MTFTP_DELAY:
+        if (PxeOption->Length >= sizeof (VendorOption->MtftpDelay)) {
+          VendorOption->MtftpDelay = *PxeOption->Data;
+        }
 
-        VendorOption->MtftpDelay = *PxeOption->Data;
         break;
 
       case PXEBC_VENDOR_TAG_DISCOVER_CTRL:
+        if (PxeOption->Length >= sizeof (VendorOption->DiscoverCtrl)) {
+          VendorOption->DiscoverCtrl = *PxeOption->Data;
+        }
 
-        VendorOption->DiscoverCtrl = *PxeOption->Data;
         break;
 
       case PXEBC_VENDOR_TAG_DISCOVER_MCAST:
+        if (PxeOption->Length >= sizeof (EFI_IPv4_ADDRESS)) {
+          CopyMem (&VendorOption->DiscoverMcastIp, PxeOption->Data, sizeof (EFI_IPv4_ADDRESS));
+        }
 
-        CopyMem (&VendorOption->DiscoverMcastIp, PxeOption->Data, sizeof (EFI_IPv4_ADDRESS));
         break;
 
       case PXEBC_VENDOR_TAG_BOOT_SERVERS:
@@ -158,10 +172,12 @@ PxeBcParseVendorOptions (
         break;
 
       case PXEBC_VENDOR_TAG_MCAST_ALLOC:
+        if (PxeOption->Length >= sizeof (EFI_IPv4_ADDRESS) + sizeof (VendorOption->McastIpBlock) + sizeof (VendorOption->McastIpRange)) {
+          CopyMem (&VendorOption->McastIpBase, PxeOption->Data, sizeof (EFI_IPv4_ADDRESS));
+          CopyMem (&VendorOption->McastIpBlock, PxeOption->Data + 4, sizeof (VendorOption->McastIpBlock));
+          CopyMem (&VendorOption->McastIpRange, PxeOption->Data + 6, sizeof (VendorOption->McastIpRange));
+        }
 
-        CopyMem (&VendorOption->McastIpBase, PxeOption->Data, sizeof (EFI_IPv4_ADDRESS));
-        CopyMem (&VendorOption->McastIpBlock, PxeOption->Data + 4, sizeof (VendorOption->McastIpBlock));
-        CopyMem (&VendorOption->McastIpRange, PxeOption->Data + 6, sizeof (VendorOption->McastIpRange));
         break;
 
       case PXEBC_VENDOR_TAG_CREDENTIAL_TYPES:
@@ -171,9 +187,11 @@ PxeBcParseVendorOptions (
         break;
 
       case PXEBC_VENDOR_TAG_BOOT_ITEM:
+        if (PxeOption->Length >= sizeof (VendorOption->BootSrvType) + sizeof (VendorOption->BootSrvLayer)) {
+          CopyMem (&VendorOption->BootSrvType, PxeOption->Data, sizeof (VendorOption->BootSrvType));
+          CopyMem (&VendorOption->BootSrvLayer, PxeOption->Data + 2, sizeof (VendorOption->BootSrvLayer));
+        }
 
-        CopyMem (&VendorOption->BootSrvType, PxeOption->Data, sizeof (VendorOption->BootSrvType));
-        CopyMem (&VendorOption->BootSrvLayer, PxeOption->Data + 2, sizeof (VendorOption->BootSrvLayer));
         break;
 
       default:

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.h
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.h
@@ -134,7 +134,7 @@ typedef enum {
    sizeof (EFI_DHCP4_PACKET_OPTION) + (Opt)->Length - 1)
 
 #define GET_OPTION_BUFFER_LEN(Pkt) \
-  ((Pkt)->Length - sizeof (EFI_DHCP4_HEADER) - 4)
+  ((Pkt)->Length - sizeof (EFI_DHCP4_HEADER) - sizeof ((Pkt)->Dhcp4.Magik))
 
 #define GET_NEXT_BOOT_SVR_ENTRY(Ent) \
   (PXEBC_BOOT_SVR_ENTRY *) ((UINT8 *) Ent + sizeof (*(Ent)) + \

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
@@ -545,12 +545,18 @@ PxeBcExtractBootFileUrl (
     //
     while (*BootFileNamePtr != '\0') {
       if (*BootFileNamePtr == '%') {
-        TmpChar               = *(BootFileNamePtr+ 3);
-        *(BootFileNamePtr+ 3) = '\0';
-        *BootFileName         = (UINT8)AsciiStrHexToUintn ((CHAR8 *)(BootFileNamePtr + 1));
-        BootFileName++;
-        *(BootFileNamePtr+ 3) = TmpChar;
-        BootFileNamePtr      += 3;
+        if ((*(BootFileNamePtr + 1) == '\0') || (*(BootFileNamePtr + 2) == '\0')) {
+          *BootFileName = *BootFileNamePtr;
+          BootFileName++;
+          BootFileNamePtr++;
+        } else {
+          TmpChar               = *(BootFileNamePtr + 3);
+          *(BootFileNamePtr+ 3) = '\0';
+          *BootFileName         = (UINT8)AsciiStrHexToUintn ((CHAR8 *)(BootFileNamePtr + 1));
+          BootFileName++;
+          *(BootFileNamePtr+ 3) = TmpChar;
+          BootFileNamePtr      += 3;
+        }
       } else {
         *BootFileName = *BootFileNamePtr;
         BootFileName++;


### PR DESCRIPTION
## Overview

This PR addresses 9 critical security vulnerabilities discovered in NetworkPkg's DHCP, PXE Boot, and HTTP Boot option parsing code. These issues include out-of-bounds reads/writes, integer overflow, infinite loop, and double-free conditions that can be exploited by a malicious DHCP server.

**Note:** This PR supersedes the previously auto-closed PR #12344, which was closed due to inactivity after 60 days of no updates.

## Security Fixes Included

1. **HttpBootDxe: Fix double-free in HttpBootGetBootFile error path**
   - Prevents double-free vulnerability when boot file retrieval fails
   
2. **DxeHttpLib: Fix infinite loop in HttpParseMessageBody**
   - Adds proper loop termination conditions to prevent infinite loops during HTTP message parsing

3. **UefiPxeBcDxe: Fix OOB access in DHCPv6 URL percent-decoding**
   - Validates buffer boundaries during URL percent-decoding to prevent out-of-bounds reads
   
4. **UefiPxeBcDxe: Fix OOB write via BOOTFILE option in PxeBcParseDhcp4Packet**
   - Adds length validation for BOOTFILE option to prevent buffer overflow

5. **UefiPxeBcDxe: Fix UINT8 Offset overflow in PxeBcParseVendorOptions**
   - Prevents integer overflow by using proper type casting and bounds checking

6. **UefiPxeBcDxe: Add length validation to PXE vendor option handlers**
   - Implements comprehensive length validation for all PXE vendor options to prevent malformed packet exploitation

7. **HttpBootDxe: Fix OOB write via BOOTFILE option in HttpBootParseDhcp4Packet**
   - Mirrors the fix in UefiPxeBcDxe for HTTP boot scenarios

8. **HttpBootDxe: Fix OOB read in HttpBootParseDhcp4Options**
   - Adds proper boundary checks during DHCP option parsing

9. **HttpBootDxe: Fix OOB write via GET_OPTION_BUFFER_LEN underflow**
   - Prevents buffer underflow when calculating option buffer lengths

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>  
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>  
Cc: Michael D Kinney <michael.d.kinney@intel.com>

Signed-off-by: Abuthahir M <abuthahirm@ami.com>