### PR TITLE
Unaccepted Memory Hotplug

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -95,6 +95,7 @@ GCD_ATTRIBUTE_CONVERSION_ENTRY  mAttributeConversionTable[] = {
   { EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE,           EFI_MEMORY_MORE_RELIABLE, TRUE  },
   { EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE,         EFI_MEMORY_SP,            TRUE  },
   { EFI_RESOURCE_ATTRIBUTE_HOT_PLUGGABLE,           EFI_MEMORY_HOT_PLUGGABLE, TRUE  },
+  { EFI_RESOURCE_ATTRIBUTE_UNACCEPTED_HOT_PLUG,     EFI_MEMORY_UHP,           TRUE  },
   { 0,                                              0,                        FALSE }
 };
 

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -2250,7 +2250,8 @@ CoreGetMemoryMap (
       MemoryMap->NumberOfPages = RShiftU64 ((MergeGcdMapEntry.EndAddress - MergeGcdMapEntry.BaseAddress + 1), EFI_PAGE_SHIFT);
       MemoryMap->Attribute     = MergeGcdMapEntry.Attributes |
                                  (MergeGcdMapEntry.Capabilities & (EFI_MEMORY_RP | EFI_MEMORY_WP | EFI_MEMORY_XP | EFI_MEMORY_RO |
-                                                                   EFI_MEMORY_UC | EFI_MEMORY_UCE | EFI_MEMORY_WC | EFI_MEMORY_WT | EFI_MEMORY_WB));
+                                                                   EFI_MEMORY_UC | EFI_MEMORY_UCE | EFI_MEMORY_WC | EFI_MEMORY_WT |
+                                                                   EFI_MEMORY_WB | EFI_MEMORY_UHP));
       MemoryMap->Type = EfiUnacceptedMemoryType;
 
       //

--- a/MdePkg/Include/Pi/PiHob.h
+++ b/MdePkg/Include/Pi/PiHob.h
@@ -291,6 +291,7 @@ typedef UINT32 EFI_RESOURCE_ATTRIBUTE_TYPE;
 #define EFI_RESOURCE_ATTRIBUTE_ENCRYPTED        0x04000000
 #define EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE  0x08000000
 #define EFI_RESOURCE_ATTRIBUTE_HOT_PLUGGABLE    0x10000000
+#define EFI_RESOURCE_ATTRIBUTE_UNACCEPTED_HOT_PLUG    0x20000000
 //
 // Physical memory relative reliability attribute. This
 // memory provides higher reliability relative to other

--- a/MdePkg/Include/Uefi/UefiSpec.h
+++ b/MdePkg/Include/Uefi/UefiSpec.h
@@ -115,6 +115,15 @@ typedef enum {
 #define EFI_MEMORY_HOT_PLUGGABLE  0x0000000000100000
 
 //
+// If this flag is set, unaccepted memory regions are capable of having memory
+// dynamically added or removed from the platform. This attribute serves as a
+// hint to the OS prior to ACPI subsystem initialization when unaccepted table
+// sizes are determined. This allows for unaccepted memory to be allocated and
+// accepted when it becomes available post ACPI hotplug.
+//
+#define EFI_MEMORY_UHP  0x0000000000200000ULL
+
+//
 // Runtime memory attribute
 //
 #define EFI_MEMORY_RUNTIME  0x8000000000000000ULL

--- a/OvmfPkg/AmdSevDxe/AmdSevDxe.c
+++ b/OvmfPkg/AmdSevDxe/AmdSevDxe.c
@@ -119,7 +119,13 @@ AcceptAllMemory (
     CONST EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *Desc;
 
     Desc = &AllDescMap[Index];
-    if (Desc->GcdMemoryType != EfiGcdMemoryTypeUnaccepted) {
+    //
+    // Skip unaccepted memory regions reserved for future memory hot-add.
+    // These have no backing memory yet, so they must not be validated here;
+    // they are left as unaccepted for a UHP-aware OS to handle after hot-add.
+    //
+    if ((Desc->GcdMemoryType != EfiGcdMemoryTypeUnaccepted) ||
+        (Desc->Capabilities & EFI_MEMORY_UHP)) {
       continue;
     }
 

--- a/OvmfPkg/Include/Library/PlatformInitLib.h
+++ b/OvmfPkg/Include/Library/PlatformInitLib.h
@@ -41,6 +41,8 @@ typedef struct {
 
   UINT32                   LowMemory;
   UINT64                   FirstNonAddress;
+  UINT64                   HotPlugMemoryStart;
+  UINT64                   HotPlugMemoryEnd;
   UINT8                    PhysMemAddressWidth;
   UINT32                   Uc32Base;
   UINT32                   Uc32Size;

--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -157,6 +157,32 @@ PlatformGetFirstNonAddressCB (
 }
 
 /**
+  Store the top of the cold-plugged RAM above 4GB in
+  PlatformInfoHob->HotPlugMemoryStart.
+
+  This is the highest exclusive end address among the >=4GB RAM entries, which
+  is where the QEMU memory hotplug window begins.
+**/
+STATIC
+VOID
+PlatformGetHotPlugMemoryStartCB (
+  IN     EFI_E820_ENTRY64       *E820Entry,
+  IN OUT EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
+  )
+{
+  UINT64  Candidate;
+
+  if (E820Entry->Type != EfiAcpiAddressRangeMemory) {
+    return;
+  }
+
+  Candidate = E820Entry->BaseAddr + E820Entry->Length;
+  if (PlatformInfoHob->HotPlugMemoryStart < Candidate) {
+    PlatformInfoHob->HotPlugMemoryStart = Candidate;
+  }
+}
+
+/**
   Store the low memory size in PlatformInfoHob->LowMemory.
 
   The first memory block with base address zero is considered "low memory".
@@ -658,6 +684,74 @@ PlatformGetFirstNonAddress (
   return;
 }
 
+/**
+  Detect the QEMU memory hotplug window, if any, and record it in
+  PlatformInfoHob->HotPlugMemoryStart / HotPlugMemoryEnd.
+
+  The window spans from the top of the cold-plugged RAM above 4GB up to the
+  absolute, exclusive end address reported by the "etc/reserved-memory-end"
+  fw_cfg file.
+**/
+STATIC
+VOID
+PlatformGetHotPlugMemory (
+  IN OUT  EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
+  )
+{
+  EFI_STATUS            Status;
+  FIRMWARE_CONFIG_ITEM  FwCfgItem;
+  UINTN                 FwCfgSize;
+  UINT64                HotPlugMemoryEnd;
+
+  PlatformInfoHob->HotPlugMemoryStart = 0;
+  PlatformInfoHob->HotPlugMemoryEnd   = 0;
+
+  //
+  // The "etc/reserved-memory-end" fw_cfg file is present only when QEMU has
+  // configured a memory hotplug area. Its absence means there is no window.
+  //
+  Status = QemuFwCfgFindFile ("etc/reserved-memory-end", &FwCfgItem, &FwCfgSize);
+  if (EFI_ERROR (Status) || (FwCfgSize != sizeof HotPlugMemoryEnd)) {
+    return;
+  }
+
+  QemuFwCfgSelectItem (FwCfgItem);
+  QemuFwCfgReadBytes (FwCfgSize, &HotPlugMemoryEnd);
+
+  //
+  // Find the top of the cold-plugged RAM above 4GB; this is where the hotplug
+  // window starts. Prefer the QEMU E820 map (which can express addresses
+  // >= 4GB+1TB) and fall back to the CMOS-reported size above 4GB.
+  //
+  PlatformInfoHob->HotPlugMemoryStart = BASE_4GB;
+  Status                              = PlatformScanE820 (
+                                          PlatformGetHotPlugMemoryStartCB,
+                                          PlatformInfoHob
+                                          );
+  if (EFI_ERROR (Status)) {
+    PlatformInfoHob->HotPlugMemoryStart = BASE_4GB +
+                                          PlatformGetSystemMemorySizeAbove4gb ();
+  }
+
+  //
+  // Drop an empty window.
+  //
+  if (HotPlugMemoryEnd <= PlatformInfoHob->HotPlugMemoryStart) {
+    PlatformInfoHob->HotPlugMemoryStart = 0;
+    return;
+  }
+
+  PlatformInfoHob->HotPlugMemoryEnd = HotPlugMemoryEnd;
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%a: HotPlugMemory [0x%Lx, 0x%Lx)\n",
+    __func__,
+    PlatformInfoHob->HotPlugMemoryStart,
+    PlatformInfoHob->HotPlugMemoryEnd
+    ));
+}
+
 /*
  * Use CPUID to figure physical address width.
  *
@@ -1108,6 +1202,8 @@ PlatformAddressWidthInitialization (
     //
     PlatformGetFirstNonAddress (PlatformInfoHob);
   }
+
+  PlatformGetHotPlugMemory (PlatformInfoHob);
 
   PlatformSetupPagingLevel (PlatformInfoHob);
 

--- a/OvmfPkg/PlatformPei/AmdSev.c
+++ b/OvmfPkg/PlatformPei/AmdSev.c
@@ -120,7 +120,7 @@ AmdSevSnpGetApicIds (
 STATIC
 VOID
 AmdSevSnpInitialize (
-  VOID
+  IN EFI_HOB_PLATFORM_INFO  *PlatformInfoHob
   )
 {
   EFI_PEI_HOB_POINTERS         Hob;
@@ -159,6 +159,19 @@ AmdSevSnpInitialize (
           );
       }
     }
+  }
+
+  //
+  // Describe the memory hotplug window as unaccepted memory and tag it with
+  // EFI_RESOURCE_ATTRIBUTE_UNACCEPTED_HOT_PLUG
+  //
+  if (PlatformInfoHob->HotPlugMemoryEnd > PlatformInfoHob->HotPlugMemoryStart) {
+    BuildResourceDescriptorHob (
+      EFI_RESOURCE_MEMORY_UNACCEPTED,
+      EFI_RESOURCE_ATTRIBUTE_UNACCEPTED_HOT_PLUG,
+      PlatformInfoHob->HotPlugMemoryStart,
+      PlatformInfoHob->HotPlugMemoryEnd - PlatformInfoHob->HotPlugMemoryStart
+      );
   }
 
   //
@@ -450,7 +463,7 @@ AmdSevInitialize (
   // is because the system RAM must be validated before it is made shared.
   // The AmdSevSnpInitialize() validates the system RAM.
   //
-  AmdSevSnpInitialize ();
+  AmdSevSnpInitialize (PlatformInfoHob);
 
   //
   // Set Memory Encryption Mask PCD


### PR DESCRIPTION
# Description

This is a Code First draft PR (tracking issue: #12810) that implements a new UEFI memory attribute, `EFI_MEMORY_UHP`, and a corresponding PI resource-HOB attribute, `EFI_RESOURCE_ATTRIBUTE_UNACCEPTED_HOT_PLUG`, to describe unaccepted memory that belongs to a confidential-computing guest's memory hot-plug window (memory that is unaccepted, reserved for future hot-add, and not backed by pages yet).

Confidential-computing guests (e.g. AMD's SEV-SNP, Intel's TDX) boot with memory in an unaccepted state that must be accepted/validated before use. Today firmware can only describe a hot-plug window as ordinary unaccepted memory, so the OS cannot distinguish present-but-unvalidated memory (safe to accept on demand) from reserved-for-future-hot-add memory (no backing pages yet, where acceptance must be deferred). Accepting the latter early is invalid. This hint lets a UHP-aware OS size its unaccepted-memory tracking correctly and defer acceptance until ACPI hot-add.

Design rationale, backward-compatibility analysis, and alternatives are in the TianoCore RFC: <link to tianocore-wiki.github.io RFC PR>.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Validated on QEMU with an AMD SEV-SNP guest (no automated test code in this series):
- Booted an SEV-SNP guest with `-m <N>,slots=<Y>,maxmem=<M>` (M > N) and verified the UEFI memory map contains an `EfiUnacceptedMemoryType` descriptor covering `[top-of-RAM, reserved memory-end)` with `EFI_MEMORY_UHP` set.
- Hot-added a DIMM via the QEMU monitor (`object_add memory-backend-memfd` + `device_add pc-dimm`) and confirmed a UHP-aware OS accepts and onlines it without attempting to accept the empty window beforehand; hot-removed via `device_del` / `object_del`.
- Without these changes when memory is hot-added into the guest via ACPI, the guest will experience a crash since unaccepted/unvalidated pages will be touched.

Reference UHP-aware OS prototype: [pratiksampat/unaccepted_memory_hotplug-attr](https://github.com/pratiksampat/linux/tree/unaccepted_memory_hotplug-attr)

## Integration Instructions
N/A
