### PR TITLE
OvmfPkg/PlatformCI: Upgrade QEMU choco package version to 2026.5.1

### DIFF
--- a/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS.yml
+++ b/OvmfPkg/PlatformCI/.azurepipelines/Windows-VS.yml
@@ -92,7 +92,7 @@ jobs:
         run_flags: $(Run.Flags)
         usePythonVersion: ${{ variables.default_python_version }}
         extra_install_step:
-        - powershell: choco install qemu --version=2023.7.25; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+        - powershell: choco install qemu --version=2026.5.1; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
           displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
           condition: and(gt(variables.pkg_count, 0), succeeded())
 


### PR DESCRIPTION
# Description

The qemu chocolatey package version `2023.7.25` pinned in
`OvmfPkg/PlatformCI/.azurepipelines/Windows-VS.yml` is no longer available
on the Chocolatey community feed. The "Install QEMU and Set QEMU on path"
step therefore fails and every `OvmfPkg - Windows VS - PR` run aborts
before building anything:

```
Failures
 - qemu - qemu not installed. The package was not found with the source(s) listed.
 Source(s): 'https://community.chocolatey.org/api/v2/'
 NOTE: When you specify explicit sources, it overrides default sources.
If the package version is a prerelease and you didn't specify `--pre`,
 the package may not be found.
Version was specified as '2023.7.25'. It is possible that version
 does not exist for 'qemu' at the source specified.
Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 assistance.
```

Upgrade the pin to `2026.5.1`, the latest version currently published on
the feed. This is the same failure mode and fix as #1697.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Queried the Chocolatey community feed API and confirmed that `2023.7.25`
  is no longer listed for the `qemu` package and that `2026.5.1` is the
  latest published version.
- The `OvmfPkg - Windows VS - PR` pipeline run on this PR exercises the
  change directly: it installs QEMU `2026.5.1` and runs the OVMF boot
  tests with it.

## Integration Instructions

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
