### PR TITLE
Add a logo display attribute using Microsoft guidelines

### DIFF
--- a/MdeModulePkg/Include/Protocol/PlatformLogo.h
+++ b/MdeModulePkg/Include/Protocol/PlatformLogo.h
@@ -28,7 +28,12 @@ typedef enum {
   EdkiiPlatformLogoDisplayAttributeCenterBottom,
   EdkiiPlatformLogoDisplayAttributeLeftBottom,
   EdkiiPlatformLogoDisplayAttributeCenterLeft,
-  EdkiiPlatformLogoDisplayAttributeCenter
+  EdkiiPlatformLogoDisplayAttributeCenter,
+  //
+  // Use Microsoft's guidance at:
+  // https://learn.microsoft.com/en-us/windows-hardware/drivers/bringup/boot-screen-components
+  //
+  EdkiiPlatformLogoDisplayAttributeMicrosoft
 } EDKII_PLATFORM_LOGO_DISPLAY_ATTRIBUTE;
 
 /**

--- a/MdeModulePkg/Library/BootLogoLib/BootLogoLib.c
+++ b/MdeModulePkg/Library/BootLogoLib/BootLogoLib.c
@@ -171,6 +171,14 @@ BootLogoEnableLogo (
         DestX = SizeOfX - Image.Width;
         DestY = SizeOfY - Image.Height;
         break;
+      case EdkiiPlatformLogoDisplayAttributeMicrosoft:
+        //
+        // Microsoft's guidance places the center of the logo at 38.2% of the
+        // display height.
+        //
+        DestX = MAX (0, ((INTN)SizeOfX - (INTN)Image.Width) / 2);
+        DestY = MAX (0, (INTN)SizeOfY * 382 / 1000 - (INTN)Image.Height / 2);
+        break;
 
       default:
         ASSERT (FALSE);


### PR DESCRIPTION
# Description

Microsoft's [boot screen components guideline for OEMs](https://learn.microsoft.com/en-us/windows-hardware/drivers/bringup/boot-screen-components#position-the-logo-during-post) specifies that the boot logo's center should be placed 38.2% from the screen's top edge.

To follow the specification, the embedded logo should be at most 40% of the screen's height and width.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

OvmfXen on XCP-ng 8.3 (via backports)

## Integration Instructions

To use, specify `EdkiiPlatformLogoDisplayAttributeMicrosoft` in the `LOGO_ENTRY` list.
