### PR TITLE
NetworkPkg: Add null pointer check in NET_LIST_FOR_EACH_SAFE macro

### DIFF
--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -634,7 +634,7 @@ PseudoRandomU32 (
 //
 #define NET_LIST_FOR_EACH_SAFE(Entry, NextEntry, ListHead) \
   for(Entry = (ListHead)->ForwardLink, NextEntry = Entry->ForwardLink; \
-      Entry != (ListHead); \
+      Entry != (ListHead) && Entry != NULL && NextEntry != NULL; \
       Entry = NextEntry, NextEntry = Entry->ForwardLink \
      )
 


### PR DESCRIPTION
If GetVariable returns EFI_ACCESS_DENIED in Ip4Dxe or Ip6Dxe, the list entries may not be properly initialized. When NET_LIST_FOR_EACH_SAFE subsequently traverses such a list, the uninitialized ForwardLink/ BackLink pointers can cause an assert or fault.

Add null pointer guards for Entry and NextEntry in the loop condition to prevent the assert when the list entries are uninitialized.

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)