### PR TITLE
3945_arm_cca_v5_s2a: Refactor the virtual memory map configuration for QEMU guest firmware

### DIFF
--- a/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoLib.c
+++ b/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoLib.c
@@ -10,14 +10,16 @@
 #include <Uefi.h>
 #include <Pi/PiMultiPhase.h>
 #include <Library/ArmLib.h>
+#include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/FdtSerialPortAddressLib.h>
+#include <Library/FdtLib.h>
 
 // Number of Virtual Memory Map Descriptors
-#define MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS  (4)
+#define MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS  (5)
 
 /** A macro to trace the memory map.
 **/
@@ -100,6 +102,75 @@ GetUartBase (
 }
 
 /**
+  Get the QEMU fw_cfg MMIO region from the device tree.
+
+  @param[in]  DeviceTreeBase        Base address of the Device Tree.
+  @param[out] FwCfgBase             Base address of the fw_cfg MMIO region.
+  @param[out] FwCfgSize             Size of the fw_cfg MMIO region.
+
+  @retval RETURN_INVALID_PARAMETER  Device Tree Base address is invalid.
+  @retval RETURN_NOT_FOUND          No fw_cfg MMIO node has been found.
+  @retval RETURN_SUCCESS            FwCfgBase and FwCfgSize have been populated.
+**/
+STATIC
+RETURN_STATUS
+EFIAPI
+GetFwCfgMmioRegion (
+  IN  VOID    *DeviceTreeBase,
+  OUT UINT64  *FwCfgBase,
+  OUT UINT64  *FwCfgSize
+  )
+{
+  RETURN_STATUS  Status;
+  INT32          Len;
+  INT32          Node;
+  INT32          Prev;
+  CONST CHAR8    *Type;
+  CONST UINT64   *Reg;
+
+  if (DeviceTreeBase == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Status = RETURN_NOT_FOUND;
+  for (Prev = 0; ; Prev = Node) {
+    Node = FdtNextNode (DeviceTreeBase, Prev, NULL);
+    if (Node < 0) {
+      break;
+    }
+
+    //
+    // Check for memory node
+    //
+    Type = FdtGetProp (DeviceTreeBase, Node, "compatible", &Len);
+    if ((Type != NULL) &&
+        (AsciiStrnCmp (Type, "qemu,fw-cfg-mmio", Len) == 0))
+    {
+      //
+      // Get the 'reg' property of this node. For now, we will assume
+      // two 8 byte quantities for base and size, respectively.
+      //
+      Reg = FdtGetProp (DeviceTreeBase, Node, "reg", &Len);
+      if ((Reg != 0) && (Len == (2 * sizeof (UINT64)))) {
+        *FwCfgBase = SwapBytes64 (ReadUnaligned64 ((VOID *)&Reg[0]));
+        *FwCfgSize = SwapBytes64 (ReadUnaligned64 ((VOID *)&Reg[1]));
+        Status     = RETURN_SUCCESS;
+        break;
+      } else {
+        DEBUG ((
+          DEBUG_ERROR,
+          "%a: Failed to parse FDT QemuCfg node\n",
+          __func__
+          ));
+        break;
+      }
+    }
+  } // for
+
+  return Status;
+}
+
+/**
   Return the Virtual Memory Map of your platform
 
   This Virtual Memory Map is used by MemoryInitPei Module to initialize the MMU
@@ -125,6 +196,8 @@ ArmVirtGetMemoryMap (
   UINT64                        MappingBase;
   UINT64                        MappingSize;
   UINT64                        UartBase;
+  UINT64                        FwCfgBase;
+  UINT64                        FwCfgSize;
 
   ASSERT (VirtualMemoryMap != NULL);
 
@@ -144,6 +217,15 @@ ArmVirtGetMemoryMap (
 
   RetStatus = GetUartBase (DeviceTreeBase, &UartBase);
   if (RETURN_ERROR (RetStatus) || (UartBase == 0)) {
+    ASSERT_RETURN_ERROR (RetStatus);
+    return;
+  }
+
+  RetStatus = GetFwCfgMmioRegion (DeviceTreeBase, &FwCfgBase, &FwCfgSize);
+  if (RETURN_ERROR (RetStatus) ||
+      (FwCfgBase == 0) ||
+      (FwCfgSize == 0))
+  {
     ASSERT_RETURN_ERROR (RetStatus);
     return;
   }
@@ -190,6 +272,18 @@ ArmVirtGetMemoryMap (
   VirtualMemoryTable[Idx].Length       = MappingSize;
   VirtualMemoryTable[Idx].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_DEVICE;
   LOG_MEM_MAP ("Serial Port");
+  Idx++;
+
+  // Map the fw_cfg MMIO region
+  MappingBase = FwCfgBase & ~(UINT64)EFI_PAGE_MASK;
+  MappingSize = EFI_PAGES_TO_SIZE (
+                  EFI_SIZE_TO_PAGES (FwCfgBase - MappingBase + FwCfgSize)
+                  );
+  VirtualMemoryTable[Idx].PhysicalBase = MappingBase;
+  VirtualMemoryTable[Idx].VirtualBase  = MappingBase;
+  VirtualMemoryTable[Idx].Length       = MappingSize;
+  VirtualMemoryTable[Idx].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_DEVICE;
+  LOG_MEM_MAP ("FwCfg");
   Idx++;
 
   // End of Table

--- a/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoLib.c
+++ b/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoLib.c
@@ -1,6 +1,7 @@
 /** @file
 
   Copyright (c) 2014-2017, Linaro Limited. All rights reserved.
+  Copyright (c) 2026, Arm Limited. All rights reserved
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -13,18 +14,25 @@
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/FdtSerialPortAddressLib.h>
 
 // Number of Virtual Memory Map Descriptors
-#define MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS  5
+#define MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS  (4)
 
-//
-// mach-virt's core peripherals such as the UART, the GIC and the RTC are
-// all mapped in the 'miscellaneous device I/O' region, which we just map
-// in its entirety rather than device by device. Note that it does not
-// cover any of the NOR flash banks or PCI resource windows.
-//
-#define MACH_VIRT_PERIPH_BASE  0x08000000
-#define MACH_VIRT_PERIPH_SIZE  SIZE_128MB
+/** A macro to trace the memory map.
+**/
+#define LOG_MEM_MAP(Txt)                                        \
+          DEBUG ((                                              \
+            DEBUG_INFO,                                         \
+            "%02d\t%-*a\t0x%08lx\t0x%08lx\t0x%08lx\t0x%08lx\n", \
+            Idx,                                                \
+            16,                                                 \
+            Txt,                                                \
+            VirtualMemoryTable[Idx].PhysicalBase,               \
+            VirtualMemoryTable[Idx].VirtualBase,                \
+            VirtualMemoryTable[Idx].Length,                     \
+            VirtualMemoryTable[Idx].Attributes                  \
+            ));
 
 /**
   Default library constructor that obtains the memory size from a PCD.
@@ -49,6 +57,49 @@ QemuVirtMemInfoLibConstructor (
 }
 
 /**
+  Get the serial port base address to be used for the serial console output.
+
+  @param[in]  DeviceTreeBase        Base address of the Device Tree.
+  @param[out] UartBase              Base address of the Uart.
+
+  @retval RETURN_INVALID_PARAMETER  Device Tree Base address is invalid.
+  @retval RETURN_NOT_FOUND          No enabled console port has been found.
+  @retval RETURN_SUCCESS            BaseAddress has been populated.
+**/
+STATIC
+RETURN_STATUS
+EFIAPI
+GetUartBase (
+  IN  VOID    *DeviceTreeBase,
+  OUT UINT64  *UartBase
+  )
+{
+  RETURN_STATUS     RetStatus;
+  FDT_SERIAL_PORTS  Ports;
+
+  if (DeviceTreeBase == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  RetStatus = FdtSerialGetPorts (DeviceTreeBase, "arm,pl011", &Ports);
+  if (RETURN_ERROR (RetStatus)) {
+    return RetStatus;
+  }
+
+  //
+  // Default to the first port found, but (if there are multiple ports) allow
+  // the "/chosen" node to override it. Note that if FdtSerialGetConsolePort()
+  // fails, it does not modify UartBase.
+  //
+  *UartBase = Ports.BaseAddress[0];
+  if (Ports.NumberOfPorts > 1) {
+    FdtSerialGetConsolePort (DeviceTreeBase, UartBase);
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
   Return the Virtual Memory Map of your platform
 
   This Virtual Memory Map is used by MemoryInitPei Module to initialize the MMU
@@ -66,14 +117,34 @@ ArmVirtGetMemoryMap (
   OUT ARM_MEMORY_REGION_DESCRIPTOR  **VirtualMemoryMap
   )
 {
+  RETURN_STATUS                 RetStatus;
   ARM_MEMORY_REGION_DESCRIPTOR  *VirtualMemoryTable;
   VOID                          *MemorySizeHob;
+  UINTN                         Idx;
+  VOID                          *DeviceTreeBase;
+  UINT64                        MappingBase;
+  UINT64                        MappingSize;
+  UINT64                        UartBase;
 
   ASSERT (VirtualMemoryMap != NULL);
+
+  Idx = 0;
 
   MemorySizeHob = GetFirstGuidHob (&gArmVirtSystemMemorySizeGuid);
   ASSERT (MemorySizeHob != NULL);
   if (MemorySizeHob == NULL) {
+    return;
+  }
+
+  DeviceTreeBase = (VOID *)(UINTN)PcdGet64 (PcdDeviceTreeInitialBaseAddress);
+  if (DeviceTreeBase == NULL) {
+    ASSERT (0);
+    return;
+  }
+
+  RetStatus = GetUartBase (DeviceTreeBase, &UartBase);
+  if (RETURN_ERROR (RetStatus) || (UartBase == 0)) {
+    ASSERT_RETURN_ERROR (RetStatus);
     return;
   }
 
@@ -87,38 +158,44 @@ ArmVirtGetMemoryMap (
     return;
   }
 
-  // System DRAM
-  VirtualMemoryTable[0].PhysicalBase = PcdGet64 (PcdSystemMemoryBase);
-  VirtualMemoryTable[0].VirtualBase  = VirtualMemoryTable[0].PhysicalBase;
-  VirtualMemoryTable[0].Length       = *(UINT64 *)GET_GUID_HOB_DATA (MemorySizeHob);
-  VirtualMemoryTable[0].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK;
-
   DEBUG ((
     DEBUG_INFO,
-    "%a: Dumping System DRAM Memory Map:\n"
-    "\tPhysicalBase: 0x%lX\n"
-    "\tVirtualBase: 0x%lX\n"
-    "\tLength: 0x%lX\n",
-    __func__,
-    VirtualMemoryTable[0].PhysicalBase,
-    VirtualMemoryTable[0].VirtualBase,
-    VirtualMemoryTable[0].Length
+    "Idx\tRegion          \tPhysical Base\tVirtual Base\t"
+    "Length          Attributes\n"
     ));
 
-  // Memory mapped peripherals (UART, RTC, GIC, virtio-mmio, etc)
-  VirtualMemoryTable[1].PhysicalBase = MACH_VIRT_PERIPH_BASE;
-  VirtualMemoryTable[1].VirtualBase  = MACH_VIRT_PERIPH_BASE;
-  VirtualMemoryTable[1].Length       = MACH_VIRT_PERIPH_SIZE;
-  VirtualMemoryTable[1].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_DEVICE;
+  // System DRAM
+  VirtualMemoryTable[Idx].PhysicalBase = PcdGet64 (PcdSystemMemoryBase);
+  VirtualMemoryTable[Idx].VirtualBase  = VirtualMemoryTable[Idx].PhysicalBase;
+  VirtualMemoryTable[Idx].Length       = *(UINT64 *)GET_GUID_HOB_DATA (MemorySizeHob);
+  VirtualMemoryTable[Idx].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK;
+  LOG_MEM_MAP ("System DRAM");
+  Idx++;
 
   // Map the FV region as normal executable memory
-  VirtualMemoryTable[2].PhysicalBase = PcdGet64 (PcdFvBaseAddress);
-  VirtualMemoryTable[2].VirtualBase  = VirtualMemoryTable[2].PhysicalBase;
-  VirtualMemoryTable[2].Length       = FixedPcdGet32 (PcdFvSize);
-  VirtualMemoryTable[2].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK_RO;
+  VirtualMemoryTable[Idx].PhysicalBase = PcdGet64 (PcdFvBaseAddress);
+  VirtualMemoryTable[Idx].VirtualBase  = VirtualMemoryTable[Idx].PhysicalBase;
+  VirtualMemoryTable[Idx].Length       = FixedPcdGet32 (PcdFvSize);
+  VirtualMemoryTable[Idx].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK_RO;
+  LOG_MEM_MAP ("FV Region");
+  Idx++;
+
+  // Map the UART
+  MappingBase = UartBase & ~(UINT64)EFI_PAGE_MASK;
+  MappingSize = EFI_PAGES_TO_SIZE (
+                  EFI_SIZE_TO_PAGES (UartBase - MappingBase + EFI_PAGE_SIZE)
+                  );
+  VirtualMemoryTable[Idx].PhysicalBase = MappingBase;
+  VirtualMemoryTable[Idx].VirtualBase  = MappingBase;
+  VirtualMemoryTable[Idx].Length       = MappingSize;
+  VirtualMemoryTable[Idx].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_DEVICE;
+  LOG_MEM_MAP ("Serial Port");
+  Idx++;
 
   // End of Table
-  ZeroMem (&VirtualMemoryTable[3], sizeof (ARM_MEMORY_REGION_DESCRIPTOR));
+  ZeroMem (&VirtualMemoryTable[Idx], sizeof (ARM_MEMORY_REGION_DESCRIPTOR));
+
+  ASSERT ((Idx + 1) <= MAX_VIRTUAL_MEMORY_MAP_DESCRIPTORS);
 
   *VirtualMemoryMap = VirtualMemoryTable;
 }

--- a/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoLib.inf
+++ b/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoLib.inf
@@ -25,11 +25,15 @@
   EmbeddedPkg/EmbeddedPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
   ArmLib
+  BaseLib
   BaseMemoryLib
   DebugLib
+  FdtLib
+  FdtSerialPortAddressLib
   MemoryAllocationLib
 
 [Guids]
@@ -39,6 +43,7 @@
   gArmTokenSpaceGuid.PcdFvBaseAddress
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gArmTokenSpaceGuid.PcdSystemMemorySize
+  gUefiOvmfPkgTokenSpaceGuid.PcdDeviceTreeInitialBaseAddress
 
 [FixedPcd]
   gArmTokenSpaceGuid.PcdFvSize

--- a/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoPeiLib.inf
+++ b/ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoPeiLib.inf
@@ -34,6 +34,7 @@
   BaseMemoryLib
   DebugLib
   FdtLib
+  FdtSerialPortAddressLib
   MemoryAllocationLib
 
 [Guids]


### PR DESCRIPTION
# Refactor the virtual memory map configuration for QEMU guest firmware

Refactor the virtual memory map configuration for QEMU guest firmware so that `QemuVirtMemInfoLib` initially maps only the regions required during early boot:

* System memory
* Firmware volume
* Serial port

The serial port mapping is retained because it is required for debug logging before the corresponding DXE driver is loaded. Memory mappings for the remaining devices are expected to be configured by their respective drivers or by probe libraries when the devices are discovered.

Additionally, obtain the QEMU `fw_cfg` MMIO region from the device tree and add it to the PEI virtual memory map. This ensures that the `fw_cfg` selector and data registers are mapped as device memory before the PEI instance of `QemuFwCfgLib` is initialised.

Without this mapping, `PlatformPei` can trigger a synchronous exception when it accesses the `fw_cfg` selector while reading the `opt/org.tianocore/DebugLevel` setting.

Note:
1. This PR follows the changes similar to the PR https://github.com/tianocore/edk2/pull/12379
2. This PR is a sub PR series of PR https://github.com/tianocore/edk2/pull/12224

* [ ] Breaking change?

  * **Breaking change** - Does this PR cause a break in build or boot behavior?
  * Examples: Does it add a new library class or move a module to a different repo.
  * If checked, follow the [[Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md)](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
* [ ] Impacts security?

  * **Security** - Does this PR have a direct security impact?
  * Examples: Crypto algorithm change or buffer overflow fix.
* [ ] Includes tests?

  * **Tests** - Does this PR include any explicit test code?
  * Examples: Unit tests or integration tests.

## How This Was Tested

* Built tested the ArmVirtQemu and ArmVirtQemuKernel firmware.
* Tested by running edk2 CI

## Integration Instructions

N/A
