### PR TITLE
IntelFsp2WrapperPkg: Fix markdownlint errors

### DIFF
--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.ci.yaml
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.ci.yaml
@@ -95,7 +95,7 @@
 
     ## options defined .pytool/Plugin/MarkdownLintCheck
     "MarkdownLintCheck": {
-        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "AuditOnly": False,          # If True, log all errors and then mark as skipped
         "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/IntelFsp2WrapperPkg/Readme.md
+++ b/IntelFsp2WrapperPkg/Readme.md
@@ -2,6 +2,8 @@
 
 This package provides the component to use an FSP binary.
 
-Source Repository: https://github.com/tianocore/edk2/tree/master/IntelFsp2WrapperPkg
+Source Repository: [tianocore/edk2 IntelFsp2WrapperPkg](https://github.com/tianocore/edk2/tree/master/IntelFsp2WrapperPkg)
 
-A whitepaper to describe the IntelFsp2WrapperPkg: https://firmware.intel.com/sites/default/files/A_Tour_Beyond_BIOS_Using_the_Intel_Firmware_Support_Package_with_the_EFI_Developer_Kit_II_%28FSP2.0%29.pdf
+A whitepaper to describe the IntelFsp2WrapperPkg: [A Tour Beyond BIOS with FSP 2.0][fsp2-whitepaper]
+
+[fsp2-whitepaper]: https://firmware.intel.com/sites/default/files/A_Tour_Beyond_BIOS_Using_the_Intel_Firmware_Support_Package_with_the_EFI_Developer_Kit_II_%28FSP2.0%29.pdf


### PR DESCRIPTION


# Description
Fixing all markdown lint errors found by running markdownlint-cli.

Verified that rendering still shows valid information.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Ran markdownlint over IntelFsp2WrapperPkg, addressed issues reported

## Integration Instructions
No Integration necessary.