### PR TITLE
Add markdownlint plugin

### DIFF
--- a/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
+++ b/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
@@ -1,0 +1,180 @@
+# @file MarkdownLintCheck.py
+#
+# An edk2-pytool based plugin wrapper for markdownlint
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+import logging
+from io import StringIO
+import os
+from typing import List
+from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
+from edk2toollib.utility_functions import RunCmd
+from edk2toolext.environment.var_dict import VarDict
+from edk2toolext.environment import version_aggregator
+
+
+class MarkdownLintCheck(ICiBuildPlugin):
+    """
+    A CiBuildPlugin that uses the markdownlint-cli node module to scan the files
+    from the package being tested for linter errors.
+
+    The linter config file (.markdownlint.yaml) must be present in one of the defined
+    locations otherwise the test will be skipped.  These locations were picked to also
+    align with how editors and tools will find the config file.
+
+    1st priority location - At the package root
+    2nd Priority location - At the workspace root of the build (suggested location unless override needed)
+
+    Configuration options:
+    "MarkdownLintCheck": {
+        "AuditOnly": False,          # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
+    }
+    """
+
+    CONFIG_FILE_NAME = ".markdownlint.yaml"
+
+    def GetTestName(self, packagename: str, environment: VarDict) -> tuple:
+        """ Provide the testcase name and classname for use in reporting
+
+            Args:
+              packagename: string containing name of package to build
+              environment: The VarDict for the test to run in
+            Returns:
+                a tuple containing the testcase name and the classname
+                (testcasename, classname)
+                testclassname: a descriptive string for the testcase can include whitespace
+                classname: should be patterned <packagename>.<plugin>.<optionally any unique condition>
+        """
+        return ("Lint Markdown files in " + packagename, packagename + ".markdownlint")
+
+    ##
+    # External function of plugin.  This function is used to perform the task of the CiBuild Plugin
+    #
+    #   - package is the edk2 path to package.  This means workspace/packagepath relative.
+    #   - edk2path object configured with workspace and packages path
+    #   - PkgConfig Object (dict) for the pkg
+    #   - EnvConfig Object
+    #   - Plugin Manager Instance
+    #   - Plugin Helper Obj Instance
+    #   - Junit Logger
+    #   - output_stream the StringIO output stream from this plugin via logging
+
+    def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream=None):
+        abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+            packagename)
+
+        if abs_pkg_path is None:
+            tc.SetSkipped()
+            tc.LogStdError("No package {0}".format(packagename))
+            return -1
+
+        # check for node
+        return_buffer = StringIO()
+        ret = RunCmd("node", "--version", outstream=return_buffer)
+        if ret != 0:
+            tc.SetSkipped()
+            tc.LogStdError("NodeJs not installed. Test can't run")
+            logging.warning("NodeJs not installed. Test can't run")
+            return -1
+        node_version = return_buffer.getvalue().strip()  # format vXX.XX.XX
+        tc.LogStdOut(f"Node version: {node_version}")
+
+        # Check for markdownlint-cli
+        return_buffer = StringIO()
+        ret = RunCmd("markdownlint", "--version", outstream=return_buffer)
+        if ret != 0:
+            tc.SetSkipped()
+            tc.LogStdError("markdownlint not installed.  Test can't run")
+            logging.warning("markdownlint not installed.  Test can't run")
+            return -1
+        mdl_version = return_buffer.getvalue().strip()  # format XX.XX.XX
+        tc.LogStdOut(f"MarkdownLint version: {mdl_version}")
+        version_aggregator.GetVersionAggregator().ReportVersion(
+            "MarkDownLint", mdl_version, version_aggregator.VersionTypes.INFO)
+
+        # Get relative path for the root of package to use with ignore and path parameters
+        relpath = os.path.relpath(abs_pkg_path)
+
+        # Newer versions of markdownlint don't understand backslashes
+        relpath = relpath.replace(os.path.sep, '/')
+
+        #
+        # check for any package specific ignore patterns defined by package config
+        #
+        Ignores = []
+        if "IgnoreFiles" in pkgconfig:
+            for i in pkgconfig["IgnoreFiles"]:
+                Ignores.append(f"{relpath}/{i}")
+
+        #
+        # Make the path string to check
+        #
+        path_to_check = f'{relpath}/**/*.md'
+
+        # get path to config file -
+
+        # Currently there is support for two different config files
+        # If the config file is not found then the test case is skipped
+        #
+        # 1st - At the package root
+        # 2nd - At the workspace root of the build
+        config_file_path = None
+
+        # 1st check to see if the config file is at package root
+        if os.path.isfile(os.path.join(abs_pkg_path, MarkdownLintCheck.CONFIG_FILE_NAME)):
+            config_file_path = os.path.join(abs_pkg_path, MarkdownLintCheck.CONFIG_FILE_NAME)
+
+        # 2nd check to see if at workspace root
+        elif os.path.isfile(os.path.join(Edk2pathObj.WorkspacePath, MarkdownLintCheck.CONFIG_FILE_NAME)):
+            config_file_path = os.path.join(Edk2pathObj.WorkspacePath, MarkdownLintCheck.CONFIG_FILE_NAME)
+
+        # If not found - skip test
+        else:
+            tc.SetSkipped()
+            tc.LogStdError(f"{MarkdownLintCheck.CONFIG_FILE_NAME} not found.  Skipping test")
+            logging.warning(f"{MarkdownLintCheck.CONFIG_FILE_NAME} not found.  Skipping test")
+            return -1
+
+        # Run the linter
+        results = self._check_markdown(path_to_check, config_file_path, Ignores)
+        for r in results:
+            tc.LogStdError(r.strip())
+
+        # add result to test case
+        overall_status = len(results)
+        if overall_status != 0:
+            if "AuditOnly" in pkgconfig and pkgconfig["AuditOnly"]:
+                # set as skipped if AuditOnly
+                tc.SetSkipped()
+                return -1
+            else:
+                tc.SetFailed("Markdown Lint Check {0} Failed.  Errors {1}".format(
+                    packagename, overall_status), "CHECK_FAILED")
+        else:
+            tc.SetSuccess()
+        return overall_status
+
+    def _check_markdown(self, rel_file_to_check: os.PathLike, abs_config_file_to_use: os.PathLike, Ignores: List[str]) -> List[str]:
+        """ Run markdownlint against the given path and return any errors found.
+
+            Args:
+              rel_file_to_check: package root relative glob pattern of markdown files to check
+              abs_config_file_to_use: absolute path to the .markdownlint.yaml config file to use
+              Ignores: list of package root relative file, folder, or glob patterns to ignore
+            Returns:
+                a list of error strings reported by markdownlint.  Empty if no errors found.
+        """
+        output = StringIO()
+        param = f"--config {abs_config_file_to_use}"
+        for a in Ignores:
+            param += f' --ignore "{a}"'
+        param += f' "{rel_file_to_check}"'
+
+        ret = RunCmd("markdownlint", param, outstream=output)
+        if ret == 0:
+            return []
+        else:
+            return output.getvalue().strip().splitlines()

--- a/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck_plug_in.yaml
+++ b/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck_plug_in.yaml
@@ -1,0 +1,11 @@
+## @file
+# CiBuildPlugin used to lint repository documentation in markdown files
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+  "scope": "cibuild",
+  "name": "Markdown Lint Test",
+  "module": "MarkdownLintCheck"
+}

--- a/.pytool/Plugin/MarkdownLintCheck/Readme.md
+++ b/.pytool/Plugin/MarkdownLintCheck/Readme.md
@@ -1,0 +1,61 @@
+# Markdown Lint Plugin
+
+This CiBuildPlugin scans all the markdown files in a given package and checks for linter errors.
+
+## Requirements
+
+The test case in this plugin will be skipped if the requirements are not met.
+
+1. NodeJs installed and on your path
+2. `markdownlint-cli` NodeJs package installed
+3. A `.markdownlint.yaml` config file either at your repository root or package root.
+
+- NodeJS: <https://nodejs.org/en/>
+- markdownlint-cli: <https://www.npmjs.com/package/markdownlint-cli>
+  - Source repository: <https://github.com/igorshubovych/markdownlint-cli>
+
+## Configuration
+
+It is desired to use standard configuration methods so that both local editors and CI process leverage the same
+configuration. This mostly works but for ignoring files there is currently a small discrepancy.
+
+First there is/can be a `.markdownlintignore` file at root of the repository. This file much like a `.gitignore` is
+great for broadly ignoring files with patterns. This works for both usage in a local editor and CI.
+
+For the CI plugin, you can use the `IgnoreFiles` configuration option described in the Plugin Configuration.
+
+## Plugin Configuration
+
+The plugin has only minimal configuration options to support the UEFI codebase.
+
+``` yaml
+  "MarkdownLintCheck": {
+    "AuditOnly": False,          # If True, log all errors and then mark as skipped
+    "IgnoreFiles": []            # Package root relative file, folder, or glob pattern to ignore
+  }
+```
+
+### AuditOnly
+
+- `Boolean` - Default is `False`.
+
+If `True` run the test in an Audit only mode which will log all errors but instead of failing the build it will set the
+test as skipped. This allows visibility into the failures without breaking the build.
+
+### IgnoreFiles
+
+This supports package relative files, folders, and glob patterns to ignore. These are passed to the markdownlint-cli
+tool as quoted `-i` parameters.
+
+## Linter Configuration
+
+All configuration options available to the linter can be set in `.markdownlint.yaml`. This includes customizing
+rule options and enforcement.
+
+- Markdownlint configuration options: <https://github.com/DavidAnson/markdownlint#configuration>
+- Linter rules: <https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md>
+
+## Rule Overrides
+
+There are times when a certain rule should not apply to part of a markdown file. Markdownlint has numerous ways
+to configure this. See the in-file configuration options described in the links above.

--- a/ArmPkg/ArmPkg.ci.yaml
+++ b/ArmPkg/ArmPkg.ci.yaml
@@ -241,5 +241,11 @@
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check
                                      # (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/ArmPlatformPkg/ArmPlatformPkg.ci.yaml
+++ b/ArmPlatformPkg/ArmPlatformPkg.ci.yaml
@@ -135,5 +135,11 @@
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check
                                      # (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/ArmVirtPkg/ArmVirtPkg.ci.yaml
+++ b/ArmVirtPkg/ArmVirtPkg.ci.yaml
@@ -134,5 +134,11 @@
           # Reason: Expansion of macro that contains a print specifier.
           "FMT_CM_OBJECT_ID": "0x%lx"
       }
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/CryptoPkg/CryptoPkg.ci.yaml
+++ b/CryptoPkg/CryptoPkg.ci.yaml
@@ -157,5 +157,11 @@
             "Library/OpensslLib/OpensslGen/providers/common/include/prov/der_wrap.h",
             "Library/OpensslLib/OpensslStub/uefiprov.c"
         ]
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/EmbeddedPkg/EmbeddedPkg.ci.yaml
+++ b/EmbeddedPkg/EmbeddedPkg.ci.yaml
@@ -91,5 +91,11 @@
         "ExtendWords": [],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/EmulatorPkg/EmulatorPkg.ci.yaml
+++ b/EmulatorPkg/EmulatorPkg.ci.yaml
@@ -107,5 +107,11 @@
         ],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/FatPkg/FatPkg.ci.yaml
+++ b/FatPkg/FatPkg.ci.yaml
@@ -65,5 +65,11 @@
             "DMDEPKG",
             "lba's",
         ]
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/FmpDevicePkg/FmpDevicePkg.ci.yaml
+++ b/FmpDevicePkg/FmpDevicePkg.ci.yaml
@@ -67,5 +67,11 @@
     },
     "Defines": {
         "BLD_*_CONTINUOUS_INTEGRATION": "TRUE",
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/IntelFsp2Pkg/IntelFsp2Pkg.ci.yaml
+++ b/IntelFsp2Pkg/IntelFsp2Pkg.ci.yaml
@@ -89,5 +89,11 @@
         "ExtendWords": [],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.ci.yaml
+++ b/IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.ci.yaml
@@ -91,5 +91,11 @@
         "ExtendWords": [],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/ManageabilityPkg/ManageabilityPkg.ci.yaml
+++ b/ManageabilityPkg/ManageabilityPkg.ci.yaml
@@ -70,5 +70,11 @@
 
     "Defines": {
         "BLD_*_CONTINUOUS_INTEGRATION": "TRUE"
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/MdeModulePkg/MdeModulePkg.ci.yaml
+++ b/MdeModulePkg/MdeModulePkg.ci.yaml
@@ -120,5 +120,13 @@
             "canthave"
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,          # If True, log all errors and then mark as skipped
+        "IgnoreFiles": [ "Universal/RegularExpressionDxe/oniguruma",  # submodule outside of control
+                         "Library/BrotliCustomDecompressLib/brotli"   # submodule outside of control
+        ]
     }
 }

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -242,6 +242,7 @@
 
     ## options defined .pytool/Plugin/MarkdownLintCheck
     "MarkdownLintCheck": {
+        "AuditOnly": True,          # If True, log all errors and then mark as skipped
         "IgnoreFiles": [ "Library/MipiSysTLib/mipisyst"  # submodule outside of control
         ]            # package root relative file, folder, or glob pattern to ignore
     }

--- a/NetworkPkg/NetworkPkg.ci.yaml
+++ b/NetworkPkg/NetworkPkg.ci.yaml
@@ -84,5 +84,11 @@
         "BLD_*_NETWORK_HTTP_BOOT_ENABLE": "TRUE",
         "BLD_*_NETWORK_ISCSI_ENABLE": "TRUE",
         "BLD_*_NETWORK_PXE_BOOT_ENABLE": "TRUE",
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/OvmfPkg/OvmfPkg.ci.yaml
+++ b/OvmfPkg/OvmfPkg.ci.yaml
@@ -105,5 +105,11 @@
     # options defined in .pytool/Plugin/UncrustifyCheck
     "UncrustifyCheck": {
       "IgnoreFiles": ["VbeShim.h"]
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/PcAtChipsetPkg/PcAtChipsetPkg.ci.yaml
+++ b/PcAtChipsetPkg/PcAtChipsetPkg.ci.yaml
@@ -61,5 +61,11 @@
             "PCATCHIPSET",
             "TXRDY"
         ]
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/PrmPkg/PrmPkg.ci.yaml
+++ b/PrmPkg/PrmPkg.ci.yaml
@@ -115,5 +115,11 @@
                                      # should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check
                                      # (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/RedfishPkg/RedfishPkg.ci.yaml
+++ b/RedfishPkg/RedfishPkg.ci.yaml
@@ -106,5 +106,11 @@
     "Defines": {
         "BLD_*_CONTINUOUS_INTEGRATION": "TRUE",
         "BLD_*_REDFISH_ENABLE": "TRUE"
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/SecurityPkg/SecurityPkg.ci.yaml
+++ b/SecurityPkg/SecurityPkg.ci.yaml
@@ -134,5 +134,11 @@
           #         Replace ternary operator in debug string with single specifier
           'Index == COLUME_SIZE/2 ? " | %02x" : " %02x"': "%d"
       }
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/ShellPkg/ShellPkg.ci.yaml
+++ b/ShellPkg/ShellPkg.ci.yaml
@@ -72,5 +72,11 @@
         "ExtendWords": [],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/SourceLevelDebugPkg/SourceLevelDebugPkg.ci.yaml
+++ b/SourceLevelDebugPkg/SourceLevelDebugPkg.ci.yaml
@@ -117,5 +117,11 @@
         ],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/StandaloneMmPkg/StandaloneMmPkg.ci.yaml
+++ b/StandaloneMmPkg/StandaloneMmPkg.ci.yaml
@@ -97,5 +97,11 @@
                                      # should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check
                                      # (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/TcgTpmPkg/TcgTpmPkg.ci.yaml
+++ b/TcgTpmPkg/TcgTpmPkg.ci.yaml
@@ -135,5 +135,11 @@
             "Private/Include/Standard/time.h",
             "Private/Include/Standard/unistd.h"
         ]
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/UefiCpuPkg/UefiCpuPkg.ci.yaml
+++ b/UefiCpuPkg/UefiCpuPkg.ci.yaml
@@ -86,5 +86,11 @@
         "ExtendWords": [],           # words to extend to the dictionary for this package
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/UefiPayloadPkg/UefiPayloadPkg.ci.yaml
+++ b/UefiPayloadPkg/UefiPayloadPkg.ci.yaml
@@ -97,5 +97,11 @@
         "BLD_*_SERIAL_DRIVER_ENABLE": "FALSE",
         "BLD_*_BUILD_ARCH": "",
         "BLD_*_SECURE_BOOT_ENABLE": "TRUE",
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -130,6 +130,15 @@
             "Library/CmockaLib/cmocka/**",
             "Library/GoogleTestLib/googletest/**",
             "Library/SubhookLib/subhook/**"
+        ],
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "AuditOnly": True,          # If True, log all errors and then mark as skipped
+        "IgnoreFiles": [
+            "Library/CmockaLib/cmocka",         # cmocka is submodule outside of control
+            "Library/GoogleTestLib/googletest"  # googletest is submodule outside of control
         ]
     }
 }


### PR DESCRIPTION
# Description

This repo already has markdownlint configuration like:

- [.markdownlint.yaml](https://github.com/tianocore/edk2/blob/master/.markdownlint.yaml)
- [markdownlintignore](https://github.com/tianocore/edk2/blob/master/.markdownlintignore)

And MarkdownLintCheck configuration (even though the plugin is not in the repo):

https://github.com/tianocore/edk2/blob/bcd168735f46b30525a59b782cad032b8de55e60/MdePkg/MdePkg.ci.yaml#L243-L247

And numerous markdown linting fixes have been made recently. This PR adds a MarkdownLintCheck plugin and sets it to `AuditOnly` mode in each package. This will prevent the plugin from impacting package CI results by default while allowing packages that opt-in to keep markdown linting clean.

---

**Global: Set MarkdownLintCheck plugin to AuditOnly**

In preparation for the MarkdownLintCheck plugin being added to the
repo, this change defaults the plugin to `AuditOnly` mode in each
package. This allows package maintainers to enable the plugin as they
see fit.

> Note: This change will update all necessary ci.yaml files in a single
> commit (global) instead of 26 separate commits. This change is only
> needed for edk2 repo CI where these ci.yaml files are processed.

---

**.pytool: Add MarkdownLintCheck plugin**

This plugin runs markdownlint against all markdown files in a given
package to report linter errors.

See the following readme for me details:

  .pytool/Plugin/MarkdownLintCheck/Readme.md

---

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Run `MarkdownLintCheck`: `stuart_ci_build -c .pytool/CISettings.py --disable-all MarkdownLintCheck=run`
  - With ci.yaml changes (in the current PR), CI passes due to `AuditMode` being enabled for most packages.
  - Without the ci.yaml changes, `MarkdownLintCheck` reports errors as expected in packages without `AuditMode` enabled that have linting failures.

## Integration Instructions

- N/A