### PR TITLE
NetworkPkg/ArpDxe: Refetch SNP mode data after MnpConfigure

### DIFF
--- a/NetworkPkg/ArpDxe/ArpDriver.c
+++ b/NetworkPkg/ArpDxe/ArpDriver.c
@@ -133,6 +133,11 @@ ArpCreateService (
     goto ERROR_EXIT;
   }
 
+  Status = ArpService->Mnp->GetModeData (ArpService->Mnp, NULL, &ArpService->SnpMode);
+  if ((Status != EFI_NOT_STARTED) && EFI_ERROR (Status)) {
+    goto ERROR_EXIT;
+  }
+
   //
   // Create the event used in the RxToken.
   //

--- a/NetworkPkg/ArpDxe/ArpImpl.h
+++ b/NetworkPkg/ArpDxe/ArpImpl.h
@@ -153,16 +153,27 @@ struct _ARP_SERVICE_DATA {
   EFI_MANAGED_NETWORK_CONFIG_DATA         MnpConfigData;
   EFI_MANAGED_NETWORK_COMPLETION_TOKEN    RxToken;
 
-  EFI_SIMPLE_NETWORK_MODE                 SnpMode;
+  //
+  // SnpMode is a cached copy of the SNP device configuration data (MAC address,
+  // media header size, hardware address size, interface type, etc.). This copy is
+  // obtained during service initialization via GetModeData.
+  //
+  // IMPORTANT: This cached data becomes STALE if MnpConfigure() is called, as
+  // MnpConfigure triggers SNP Start/Initialize which may finalize or alter mode
+  // fields not set before Start. Code that calls MnpConfigure must refetch the
+  // SNP mode data via GetModeData after reconfiguration to ensure values like
+  // MediaHeaderSize, CurrentAddress, and HwAddressSize remain valid.
+  //
+  EFI_SIMPLE_NETWORK_MODE    SnpMode;
 
-  UINTN                                   ChildrenNumber;
-  LIST_ENTRY                              ChildrenList;
+  UINTN                      ChildrenNumber;
+  LIST_ENTRY                 ChildrenList;
 
-  LIST_ENTRY                              PendingRequestTable;
-  LIST_ENTRY                              DeniedCacheTable;
-  LIST_ENTRY                              ResolvedCacheTable;
+  LIST_ENTRY                 PendingRequestTable;
+  LIST_ENTRY                 DeniedCacheTable;
+  LIST_ENTRY                 ResolvedCacheTable;
 
-  EFI_EVENT                               PeriodicTimer;
+  EFI_EVENT                  PeriodicTimer;
 };
 
 //

--- a/NetworkPkg/Ip4Dxe/Ip4Impl.h
+++ b/NetworkPkg/Ip4Dxe/Ip4Impl.h
@@ -193,28 +193,40 @@ struct _IP4_SERVICE {
   EFI_MANAGED_NETWORK_PROTOCOL       *Mnp;
 
   EFI_MANAGED_NETWORK_CONFIG_DATA    MnpConfigData;
-  EFI_SIMPLE_NETWORK_MODE            SnpMode;
 
-  EFI_EVENT                          Timer;
-  EFI_EVENT                          ReconfigCheckTimer;
-  EFI_EVENT                          ReconfigEvent;
+  //
+  // SnpMode is a cached copy of the SNP device configuration data (MAC address,
+  // media header size, hardware address size, interface type, etc.). This copy is
+  // obtained during service initialization via GetModeData.
+  //
+  // IMPORTANT: This cached data becomes STALE if MnpConfigure() is called, as
+  // MnpConfigure triggers SNP Start/Initialize which may finalize or alter mode
+  // fields not set before Start. Code that calls MnpConfigure must refetch the
+  // SNP mode data via GetModeData after reconfiguration to ensure values like
+  // MediaHeaderSize, CurrentAddress, and HwAddressSize remain valid.
+  //
+  EFI_SIMPLE_NETWORK_MODE    SnpMode;
 
-  BOOLEAN                            Reconfig;
+  EFI_EVENT                  Timer;
+  EFI_EVENT                  ReconfigCheckTimer;
+  EFI_EVENT                  ReconfigEvent;
+
+  BOOLEAN                    Reconfig;
 
   //
   // Underlying media present status.
   //
-  BOOLEAN                            MediaPresent;
+  BOOLEAN                    MediaPresent;
 
   //
   // IPv4 Configuration II Protocol instance
   //
-  IP4_CONFIG2_INSTANCE               Ip4Config2Instance;
+  IP4_CONFIG2_INSTANCE       Ip4Config2Instance;
 
-  CHAR16                             *MacString;
+  CHAR16                     *MacString;
 
-  UINT32                             MaxPacketSize;
-  UINT32                             OldMaxPacketSize; ///< The MTU before IPsec enable.
+  UINT32                     MaxPacketSize;
+  UINT32                     OldMaxPacketSize;         ///< The MTU before IPsec enable.
 };
 
 #define IP4_INSTANCE_FROM_PROTOCOL(Ip4) \

--- a/NetworkPkg/Ip6Dxe/Ip6Impl.h
+++ b/NetworkPkg/Ip6Dxe/Ip6Impl.h
@@ -220,23 +220,35 @@ struct _IP6_SERVICE {
   EFI_MANAGED_NETWORK_PROTOCOL       *Mnp;
 
   EFI_MANAGED_NETWORK_CONFIG_DATA    MnpConfigData;
-  EFI_SIMPLE_NETWORK_MODE            SnpMode;
 
-  EFI_EVENT                          Timer;
-  EFI_EVENT                          FasterTimer;
+  //
+  // SnpMode is a cached copy of the SNP device configuration data (MAC address,
+  // media header size, hardware address size, interface type, etc.). This copy is
+  // obtained during service initialization via GetModeData.
+  //
+  // IMPORTANT: This cached data becomes STALE if MnpConfigure() is called, as
+  // MnpConfigure triggers SNP Start/Initialize which may finalize or alter mode
+  // fields not set before Start. Code that calls MnpConfigure must refetch the
+  // SNP mode data via GetModeData after reconfiguration to ensure values like
+  // MediaHeaderSize, CurrentAddress, and HwAddressSize remain valid.
+  //
+  EFI_SIMPLE_NETWORK_MODE    SnpMode;
+
+  EFI_EVENT                  Timer;
+  EFI_EVENT                  FasterTimer;
 
   //
   // IPv6 Configuration Protocol instance
   //
-  IP6_CONFIG_INSTANCE                Ip6ConfigInstance;
+  IP6_CONFIG_INSTANCE        Ip6ConfigInstance;
 
   //
   // The string representation of the current mac address of the
   // NIC this IP6_SERVICE works on.
   //
-  CHAR16                             *MacString;
-  UINT32                             MaxPacketSize;
-  UINT32                             OldMaxPacketSize;
+  CHAR16                     *MacString;
+  UINT32                     MaxPacketSize;
+  UINT32                     OldMaxPacketSize;
 };
 
 /**


### PR DESCRIPTION
# Description

The ARP driver caches SNP mode data (hardware address size, interface type, current MAC address, broadcast address, media header size) into ArpService->SnpMode during service initialization. This cached copy is used throughout ARP packet processing for frame construction and validation.

MnpConfigure() is not a local-only configuration operation. When MNP configures the first child, it invokes MnpStart(), which calls MnpStartSnp() to Start and Initialize the underlying SNP device. The SNP Start() and Initialize() calls can finalize or alter SNP mode fields that may differ from pre-start values, such as final MAC addresses, hardware parameters, or media header sizing.

Without refetching after MnpConfigure, the ARP driver operates with stale mode data, which can cause:
- Incorrect frame sizing if MediaHeaderSize changed, leading to malformed transmit packets
- Use of outdated MAC addresses (CurrentAddress, BroadcastAddress) in ARP frames and headers
- ARP packet validation failures if HwAddressSize or IfType differ from the pre-start cached values, causing valid incoming ARP packets to be dropped by sanity checks

This change adds a GetModeData call after MnpConfigure to refresh ArpService->SnpMode with the finalized SNP state, ensuring all subsequent ARP operations use current and correct hardware parameters.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Intermittent network failures, and were resolved after change.

## Integration Instructions
No Integration Necessary