### PR TITLE
MdeModulePkg: Fix memory leak issues  in various drivers

### DIFF
--- a/MdeModulePkg/Bus/Ata/AhciPei/AhciMode.c
+++ b/MdeModulePkg/Bus/Ata/AhciPei/AhciMode.c
@@ -1619,6 +1619,7 @@ CreateNewDevice (
   if (IdentifyData != NULL) {
     DeviceData->IdentifyData = AllocateCopyPool (sizeof (ATA_IDENTIFY_DATA), IdentifyData);
     if (DeviceData->IdentifyData == NULL) {
+      FreePool (DeviceData);
       return EFI_OUT_OF_RESOURCES;
     }
   }
@@ -1632,6 +1633,11 @@ CreateNewDevice (
 
   Status = IdentifyAtaDevice (DeviceData);
   if (EFI_ERROR (Status)) {
+    if (DeviceData->IdentifyData != NULL) {
+      FreePool (DeviceData->IdentifyData);
+    }
+
+    FreePool (DeviceData);
     return Status;
   }
 

--- a/MdeModulePkg/Core/PiSmmCore/Smi.c
+++ b/MdeModulePkg/Core/PiSmmCore/Smi.c
@@ -345,16 +345,6 @@ SmiHandlerRegister (
     return EFI_INVALID_PARAMETER;
   }
 
-  SmiHandler = AllocateZeroPool (sizeof (SMI_HANDLER));
-  if (SmiHandler == NULL) {
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  SmiHandler->Signature  = SMI_HANDLER_SIGNATURE;
-  SmiHandler->Handler    = Handler;
-  SmiHandler->CallerAddr = (UINTN)RETURN_ADDRESS (0);
-  SmiHandler->ToRemove   = FALSE;
-
   if (HandlerType == NULL) {
     //
     // This is root SMI handler
@@ -372,7 +362,16 @@ SmiHandlerRegister (
 
   List = &SmiEntry->SmiHandlers;
 
-  SmiHandler->SmiEntry = SmiEntry;
+  SmiHandler = AllocateZeroPool (sizeof (SMI_HANDLER));
+  if (SmiHandler == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  SmiHandler->Signature  = SMI_HANDLER_SIGNATURE;
+  SmiHandler->Handler    = Handler;
+  SmiHandler->CallerAddr = (UINTN)RETURN_ADDRESS (0);
+  SmiHandler->ToRemove   = FALSE;
+  SmiHandler->SmiEntry   = SmiEntry;
   InsertTailList (List, &SmiHandler->Link);
 
   *DispatchHandle = (EFI_HANDLE)SmiHandler;

--- a/MdeModulePkg/Universal/CapsulePei/UefiCapsule.c
+++ b/MdeModulePkg/Universal/CapsulePei/UefiCapsule.c
@@ -1023,17 +1023,20 @@ GetScatterGatherHeadEntries (
 
   if (ValidIndex == 0) {
     DEBUG ((DEBUG_ERROR, "%a didn't find any SG lists in variables\n", __func__));
+    FreePool (TempList);
     return EFI_NOT_FOUND;
   }
 
   *HeadList = AllocateZeroPool ((ValidIndex + 1) * sizeof (EFI_PHYSICAL_ADDRESS));
   if (*HeadList == NULL) {
     DEBUG ((DEBUG_ERROR, "Failed to allocate memory\n"));
+    FreePool (TempList);
     return EFI_OUT_OF_RESOURCES;
   }
 
   CopyMem (*HeadList, TempList, (ValidIndex) * sizeof (EFI_PHYSICAL_ADDRESS));
   *ListLength = ValidIndex;
+  FreePool (TempList);
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
@@ -2583,6 +2583,7 @@ ConSplitterGetIntersectionBetweenConOutAndStrErr (
   StdErrMapTableSize = StdErrMaxMode * sizeof (INT32);
   StdErrMapTable     = AllocateZeroPool (StdErrMapTableSize);
   if (StdErrMapTable == NULL) {
+    FreePool (ConOutMapTable);
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/MdeModulePkg/Universal/Disk/CdExpressPei/PeiCdExpress.c
+++ b/MdeModulePkg/Universal/Disk/CdExpressPei/PeiCdExpress.c
@@ -62,6 +62,7 @@ CdExpressPeimEntry (
 
   PrivateData->BlockBuffer = AllocatePages (EFI_SIZE_TO_PAGES (PEI_CD_BLOCK_SIZE));
   if (PrivateData->BlockBuffer == NULL) {
+    FreePages (PrivateData, EFI_SIZE_TO_PAGES (sizeof (*PrivateData)));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -82,6 +83,7 @@ CdExpressPeimEntry (
 
   Status = PeiServicesInstallPpi (&PrivateData->PpiDescriptor);
   if (EFI_ERROR (Status)) {
+    FreePages (PrivateData, EFI_SIZE_TO_PAGES (sizeof (*PrivateData)));
     return EFI_OUT_OF_RESOURCES;
   }
 

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigKeywordHandler.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigKeywordHandler.c
@@ -1724,6 +1724,7 @@ ConstructConfigHdr (
   UINTN                     Index;
   UINT8                     *Buffer;
   CHAR16                    *Name;
+  CHAR16                    *NameBackup;
   CHAR8                     *AsciiName;
   UINTN                     NameSize;
   EFI_GUID                  *Guid;
@@ -1780,6 +1781,10 @@ ConstructConfigHdr (
   if (DriverHandle != NULL) {
     DevicePath = DevicePathFromHandle (DriverHandle);
     if (DevicePath == NULL) {
+      if (Name != NULL) {
+        FreePool (Name);
+      }
+
       return NULL;
     }
 
@@ -1796,6 +1801,10 @@ ConstructConfigHdr (
   MaxLen = 5 + sizeof (EFI_GUID) * 2 + 6 + NameLength * 4 + 6 + DevicePathSize * 2 + 1;
   String = AllocateZeroPool (MaxLen * sizeof (CHAR16));
   if (String == NULL) {
+    if (Name != NULL) {
+      FreePool (Name);
+    }
+
     return NULL;
   }
 
@@ -1829,15 +1838,16 @@ ConstructConfigHdr (
   String += StrLen (String);
 
   if (Name != NULL) {
+    NameBackup = Name;
     //
     // Append Name converted to <Char>NameLength
     //
-    for ( ; *Name != L'\0'; Name++) {
+    for ( ; *NameBackup != L'\0'; NameBackup++) {
       UnicodeValueToStringS (
         String,
         MaxLen * sizeof (CHAR16) - ((UINTN)String - (UINTN)ReturnString),
         PREFIX_ZERO | RADIX_HEX,
-        *Name,
+        *NameBackup,
         4
         );
       String += StrnLenS (String, MaxLen - ((UINTN)String - (UINTN)ReturnString) / sizeof (CHAR16));
@@ -1868,6 +1878,10 @@ ConstructConfigHdr (
   // Null terminate the Unicode string
   //
   *String = L'\0';
+
+  if (Name != NULL) {
+    FreePool (Name);
+  }
 
   //
   // Convert all hex digits in range [A-F] in the configuration header to [a-f]

--- a/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.c
+++ b/MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.c
@@ -482,6 +482,7 @@ SmbiosAdd (
   HandleEntry = AllocateZeroPool (sizeof (SMBIOS_HANDLE_ENTRY));
   if (HandleEntry == NULL) {
     EfiReleaseLock (&Private->DataLock);
+    FreePool (SmbiosEntry);
     return EFI_OUT_OF_RESOURCES;
   }
 


### PR DESCRIPTION
# Description

This patch series addresses multiple memory leak issues found across several MdeModulePkg components. In each case, a buffer is allocated early in a function but is not freed on certain error paths, leading to wasted memory that may accumulate and cause resource exhaustion under failure conditions.

The fixes are straightforward: add missing FreePool() calls before returning from the function when a subsequent allocation fails or an error condition is detected.

The following modules are affected and have been fixed individually:

1. **AhciPei** – CreateNewDevice(): free DeviceData when AllocateCopyPool for IdentifyData fails or IdentifyAtaDevice() returns an error.

2. **PiSmmCore** – SmiHandlerRegister(): Move SmiHandler allocation to avoid memory leak.

3. **CapsulePei** – GetScatterGatherHeadEntries(): free TempList when no valid entries are found or when allocating HeadList fails.

4. **ConSplitterDxe** – ConSplitterGetIntersectionBetweenConOutAndStrErr(): free ConOutMapTable if StdErrMapTable allocation fails.

5. **CdExpressPei** – CdExpressPeimEntry(): free PrivateData when AllocatePages for BlockBuffer fails or PeiServicesInstallPpi() returns an error.

6. **HiiDatabaseDxe** – ConstructConfigHdr(): free Name when DevicePathFromHandle() returns NULL or when String allocation fails.

7. **SmbiosDxe** – SmbiosAdd(): free SmbiosEntry when HandleEntry allocation fails.

All patches are independent and can be applied in any order. They have been tested in the respective error paths to confirm that the leaks are eliminated.


## How This Was Tested

Pass CI check.

## Integration Instructions

N/A
