### PR TITLE
EmulatorPkg: Fix transposed row/column arguments in Console Out

### DIFF
--- a/EmulatorPkg/Library/PlatformBmLib/PlatformBm.c
+++ b/EmulatorPkg/Library/PlatformBmLib/PlatformBm.c
@@ -37,8 +37,8 @@ SetupVariableInit (
     //
     // SetupVariable is corrupt
     //
-    SystemConfigData.ConOutRow    = PcdGet32 (PcdConOutColumn);
-    SystemConfigData.ConOutColumn = PcdGet32 (PcdConOutRow);
+    SystemConfigData.ConOutRow    = PcdGet32 (PcdConOutRow);
+    SystemConfigData.ConOutColumn = PcdGet32 (PcdConOutColumn);
 
     Status = gRT->SetVariable (
                     L"Setup",


### PR DESCRIPTION
# Description
SetupVariableInit incorrectly swaps ConOutRow and ConOutColumn when reading PCD values. Correct assignment mapping to match PcdConOutRow/PcdConOutColumn to their respective struct fields, fixing transposed console resolution saved into NVRAM Setup variable.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built EmulatorX64 platform, verified console resolution correctly stored in NVRAM after modification.


## Integration Instructions

N/A

Fixes: https://github.com/tianocore/edk2/issues/12766