### PR TITLE
ArmPkg,DynamicTablesPkg: Add shared SMCCC SoC ID support

### DIFF
--- a/ArmPkg/ArmPkg.dec
+++ b/ArmPkg/ArmPkg.dec
@@ -2,7 +2,7 @@
 # ARM processor package.
 #
 # Copyright (c) 2009 - 2010, Apple Inc. All rights reserved.<BR>
-# Copyright (c) 2011 - 2023, ARM Limited. All rights reserved.
+# Copyright (c) 2011 - 2026, ARM Limited. All rights reserved.
 # Copyright (c) 2021, Ampere Computing LLC. All rights reserved.
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -50,6 +50,11 @@
   #   default conduit (HVC or SMC).
   #
   ArmMonitorLib|Include/Library/ArmMonitorLib.h
+
+  ##  @libraryclass  Provides access to the Arm SMCCC Architecture SoC ID
+  #                  interface.
+  #
+  ArmSmcccSocIdLib|Include/Library/ArmSmcccSocIdLib.h
 
   ##  @libraryclass  Provides an interface to query miscellaneous OEM
   #   information.

--- a/ArmPkg/ArmPkg.dsc
+++ b/ArmPkg/ArmPkg.dsc
@@ -2,7 +2,7 @@
 # ARM processor package.
 #
 # Copyright (c) 2009 - 2010, Apple Inc. All rights reserved.<BR>
-# Copyright (c) 2011 - 2021, Arm Limited. All rights reserved.<BR>
+# Copyright (c) 2011 - 2026, Arm Limited. All rights reserved.<BR>
 # Copyright (c) 2016, Linaro Ltd. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.<BR>
 # Copyright (c) 2021, Ampere Computing LLC. All rights reserved.
@@ -37,6 +37,7 @@
 !include MdePkg/MdeLibs.dsc.inc
 
 [LibraryClasses.common]
+  ArmSmcccSocIdLib|ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
   BootLogoLib|MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
@@ -111,6 +112,7 @@
 [Components.common]
   ArmPkg/Library/ArmCacheMaintenanceLib/ArmCacheMaintenanceLib.inf
   ArmPkg/Library/ArmPsciResetSystemLib/ArmPsciResetSystemLib.inf
+  ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf
   ArmPkg/Library/DebugAgentSymbolsBaseLib/DebugAgentSymbolsBaseLib.inf
   ArmPkg/Library/DebugPeCoffExtraActionLib/DebugPeCoffExtraActionLib.inf
   ArmPkg/Library/SemiHostingDebugLib/SemiHostingDebugLib.inf

--- a/ArmPkg/Include/Library/ArmSmcccSocIdLib.h
+++ b/ArmPkg/Include/Library/ArmSmcccSocIdLib.h
@@ -1,0 +1,39 @@
+/** @file
+  Arm SMCCC SoC ID library.
+
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+/**
+  Check whether the SMCCC Architecture SoC ID interface is supported.
+
+  @retval TRUE   The SMCCC Architecture SoC ID interface is supported.
+  @retval FALSE  The SMCCC Architecture SoC ID interface is not supported.
+**/
+BOOLEAN
+ArmSmcccSocIdIsSupported (
+  VOID
+  );
+
+/**
+  Get the JEP106 identification code and SoC revision using the SMCCC
+  Architecture SoC ID interface.
+
+  @param[out] Jep106Code   Pointer to the JEP106 identification code.
+  @param[out] SocRevision  Pointer to the SoC revision.
+
+  @retval EFI_SUCCESS            The SoC identification information was
+                                 returned successfully.
+  @retval EFI_INVALID_PARAMETER  A required output parameter is NULL.
+  @retval EFI_UNSUPPORTED        The SMCCC Architecture SoC ID interface is
+                                 unsupported or an SoC ID call failed.
+**/
+EFI_STATUS
+ArmSmcccGetSocId (
+  OUT UINT32  *Jep106Code,
+  OUT UINT32  *SocRevision
+  );

--- a/ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.c
+++ b/ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.c
@@ -1,0 +1,110 @@
+/** @file
+  Arm SMCCC SoC ID library.
+
+  Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Ampere Computing LLC. All rights reserved.<BR>
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+
+#include <IndustryStandard/ArmStdSmc.h>
+
+#include <Library/ArmSmcLib.h>
+#include <Library/ArmSmcccSocIdLib.h>
+
+/**
+  Check whether the SMCCC Architecture SoC ID interface is supported.
+
+  @retval TRUE   The SMCCC Architecture SoC ID interface is supported.
+  @retval FALSE  The SMCCC Architecture SoC ID interface is not supported.
+**/
+BOOLEAN
+ArmSmcccSocIdIsSupported (
+  VOID
+  )
+{
+  INT32  SmcCallStatus;
+  UINTN  SmcParameter;
+
+  SmcCallStatus = ArmCallSmc0 (SMCCC_VERSION, NULL, NULL, NULL);
+  if ((SmcCallStatus >= 0) && ((SmcCallStatus >> 16) < 1)) {
+    return FALSE;
+  }
+
+  SmcParameter  = SMCCC_ARCH_SOC_ID;
+  SmcCallStatus = ArmCallSmc1 (
+                    SMCCC_ARCH_FEATURES,
+                    &SmcParameter,
+                    NULL,
+                    NULL
+                    );
+
+  return (SmcCallStatus >= 0);
+}
+
+/**
+  Get the JEP106 identification code and SoC revision using the SMCCC
+  Architecture SoC ID interface.
+
+  @param[out] Jep106Code   Pointer to the JEP106 identification code.
+  @param[out] SocRevision  Pointer to the SoC revision.
+
+  @retval EFI_SUCCESS            The SoC identification information was
+                                 returned successfully.
+  @retval EFI_INVALID_PARAMETER  A required output parameter is NULL.
+  @retval EFI_UNSUPPORTED        The SMCCC Architecture SoC ID interface is
+                                 unsupported or an SoC ID call failed.
+**/
+EFI_STATUS
+ArmSmcccGetSocId (
+  OUT UINT32  *Jep106Code,
+  OUT UINT32  *SocRevision
+  )
+{
+  INT32   SmcCallStatus;
+  UINTN   SmcParameter;
+  UINT32  LocalJep106Code;
+  UINT32  LocalSocRevision;
+
+  if ((Jep106Code == NULL) || (SocRevision == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!ArmSmcccSocIdIsSupported ()) {
+    return EFI_UNSUPPORTED;
+  }
+
+  SmcParameter  = 0;
+  SmcCallStatus = ArmCallSmc1 (
+                    SMCCC_ARCH_SOC_ID,
+                    &SmcParameter,
+                    NULL,
+                    NULL
+                    );
+  if (SmcCallStatus < 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  LocalJep106Code = (UINT32)SmcCallStatus;
+
+  SmcParameter  = 1;
+  SmcCallStatus = ArmCallSmc1 (
+                    SMCCC_ARCH_SOC_ID,
+                    &SmcParameter,
+                    NULL,
+                    NULL
+                    );
+  if (SmcCallStatus < 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  LocalSocRevision = (UINT32)SmcCallStatus;
+
+  *Jep106Code  = LocalJep106Code;
+  *SocRevision = LocalSocRevision;
+
+  return EFI_SUCCESS;
+}

--- a/ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf
+++ b/ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf
@@ -1,0 +1,25 @@
+## @file
+#  Arm SMCCC SoC ID library.
+#
+#  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 1.30
+  BASE_NAME      = ArmSmcccSocIdLib
+  FILE_GUID      = 06525cc6-5a4d-4465-be65-186e2e587b1d
+  MODULE_TYPE    = BASE
+  VERSION_STRING = 1.0
+  LIBRARY_CLASS  = ArmSmcccSocIdLib
+
+[Sources]
+  ArmSmcccSocIdLib.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  ArmSmcLib

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClass.c
@@ -12,10 +12,8 @@
 #include <Uefi.h>
 #include <Protocol/Smbios.h>
 #include <IndustryStandard/ArmCache.h>
-#include <IndustryStandard/ArmStdSmc.h>
 #include <IndustryStandard/SmBios.h>
 #include <Library/ArmLib.h>
-#include <Library/ArmSmcLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/ProcessorSubClassDxe.inf
@@ -4,6 +4,7 @@
 #    Copyright (c) 2021, NUVIA Inc. All rights reserved.
 #    Copyright (c) 2015, Hisilicon Limited. All rights reserved.
 #    Copyright (c) 2015, Linaro Limited. All rights reserved.
+#    Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -34,7 +35,7 @@
 
 [LibraryClasses]
   ArmLib
-  ArmSmcLib
+  ArmSmcccSocIdLib
   BaseLib
   BaseMemoryLib
   DebugLib

--- a/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
+++ b/ArmPkg/Universal/Smbios/ProcessorSubClassDxe/SmbiosProcessorArmCommon.c
@@ -3,6 +3,7 @@
 
   Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
   Copyright (c) 2021 - 2022, Ampere Computing LLC. All rights reserved.<BR>
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -10,10 +11,9 @@
 
 #include <Uefi.h>
 #include <IndustryStandard/ArmCache.h>
-#include <IndustryStandard/ArmStdSmc.h>
 #include <IndustryStandard/SmBios.h>
 #include <Library/ArmLib.h>
-#include <Library/ArmSmcLib.h>
+#include <Library/ArmSmcccSocIdLib.h>
 #include <Library/BaseMemoryLib.h>
 
 #include "SmbiosProcessor.h"
@@ -79,75 +79,6 @@ SmbiosProcessorHasSeparateCaches (
   return SeparateCaches;
 }
 
-/** Checks if ther ARM64 SoC ID SMC call is supported
-
-    @return Whether the ARM64 SoC ID call is supported.
-**/
-BOOLEAN
-HasSmcArm64SocId (
-  VOID
-  )
-{
-  INT32    SmcCallStatus;
-  BOOLEAN  Arm64SocIdSupported;
-  UINTN    SmcParam;
-
-  Arm64SocIdSupported = FALSE;
-
-  SmcCallStatus = ArmCallSmc0 (SMCCC_VERSION, NULL, NULL, NULL);
-
-  if ((SmcCallStatus < 0) || ((SmcCallStatus >> 16) >= 1)) {
-    SmcParam      = SMCCC_ARCH_SOC_ID;
-    SmcCallStatus = ArmCallSmc1 (SMCCC_ARCH_FEATURES, &SmcParam, NULL, NULL);
-    if (SmcCallStatus >= 0) {
-      Arm64SocIdSupported = TRUE;
-    }
-  }
-
-  return Arm64SocIdSupported;
-}
-
-/** Fetches the JEP106 code and SoC Revision.
-
-    @param Jep106Code  JEP 106 code.
-    @param SocRevision SoC revision.
-
-    @retval EFI_SUCCESS Succeeded.
-    @retval EFI_UNSUPPORTED Failed.
-**/
-EFI_STATUS
-SmbiosGetSmcArm64SocId (
-  OUT INT32  *Jep106Code,
-  OUT INT32  *SocRevision
-  )
-{
-  INT32       SmcCallStatus;
-  EFI_STATUS  Status;
-  UINTN       SmcParam;
-
-  Status = EFI_SUCCESS;
-
-  SmcParam      = 0;
-  SmcCallStatus = ArmCallSmc1 (SMCCC_ARCH_SOC_ID, &SmcParam, NULL, NULL);
-
-  if (SmcCallStatus >= 0) {
-    *Jep106Code = SmcCallStatus;
-  } else {
-    Status = EFI_UNSUPPORTED;
-  }
-
-  SmcParam      = 1;
-  SmcCallStatus = ArmCallSmc1 (SMCCC_ARCH_SOC_ID, &SmcParam, NULL, NULL);
-
-  if (SmcCallStatus >= 0) {
-    *SocRevision = SmcCallStatus;
-  } else {
-    Status = EFI_UNSUPPORTED;
-  }
-
-  return Status;
-}
-
 /** Returns a value for the Processor ID field that conforms to SMBIOS
     requirements.
 
@@ -158,12 +89,13 @@ SmbiosGetProcessorId (
   VOID
   )
 {
-  INT32   Jep106Code;
-  INT32   SocRevision;
-  UINT64  ProcessorId;
+  EFI_STATUS  Status;
+  UINT32      Jep106Code;
+  UINT32      SocRevision;
+  UINT64      ProcessorId;
 
-  if (HasSmcArm64SocId ()) {
-    SmbiosGetSmcArm64SocId (&Jep106Code, &SocRevision);
+  Status = ArmSmcccGetSocId (&Jep106Code, &SocRevision);
+  if (!EFI_ERROR (Status)) {
     ProcessorId = ((UINT64)SocRevision << 32) | Jep106Code;
   } else {
     ProcessorId = ArmReadMidr ();
@@ -236,7 +168,8 @@ SmbiosGetProcessorCharacteristics (
 
   ZeroMem (&Characteristics, sizeof (Characteristics));
 
-  Characteristics.ProcessorArm64SocId = HasSmcArm64SocId ();
+  Characteristics.ProcessorArm64SocId =
+    ArmSmcccSocIdIsSupported ();
 
   return Characteristics;
 }

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -29,6 +29,7 @@
   Tpm2DeviceTableLib|DynamicTablesPkg/Library/Common/Tpm2DeviceTableLib/Tpm2DeviceTableLib.inf
 
 [LibraryClasses.AARCH64]
+  ArmSmcccSocIdLib|ArmPkg/Library/ArmSmcccSocIdLib/ArmSmcccSocIdLib.inf
   DynamicTablesScmiInfoLib|DynamicTablesPkg/Library/DynamicTablesScmiInfoLib/DynamicTablesScmiInfoLib.inf
 
 [Components.ARM, Components.AARCH64, Components.X64, Components.RISCV64, Components.LOONGARCH64]

--- a/DynamicTablesPkg/Include/Library/SmbiosSmcLib.h
+++ b/DynamicTablesPkg/Include/Library/SmbiosSmcLib.h
@@ -1,6 +1,6 @@
 /** @file
 *
-*  Copyright (c) 2025, ARM Limited. All rights reserved.
+*  Copyright (c) 2025 - 2026, ARM Limited. All rights reserved.
 *
 *  SPDX-License-Identifier: BSD-2-Clause-Patent
 *
@@ -8,14 +8,17 @@
 
 #pragma once
 
-/** Returns the SOC ID, formatted for the SMBIOS Type 4 Processor ID field.
+/**
+  Return the SoC ID formatted for the SMBIOS Type 4 Processor ID field.
 
-    @param Processor ID.
+  @param[out] ProcessorId  Pointer to the SMBIOS Processor ID.
 
-    @return 0 on success
-    @return EFI_UNSUPPORTED if SMCCC_ARCH_SOC_ID is not implemented
+  @retval EFI_SUCCESS            The Processor ID was returned successfully.
+  @retval EFI_INVALID_PARAMETER  ProcessorId is NULL.
+  @retval EFI_UNSUPPORTED        The SMCCC Architecture SoC ID interface is
+                                 unsupported or an SoC ID call failed.
 **/
-UINT64
+EFI_STATUS
 SmbiosSmcGetSocId (
-  UINT64  *ProcessorId
+  OUT UINT64  *ProcessorId
   );

--- a/DynamicTablesPkg/Library/Smbios/Arm/SmbiosSmcLib/SmbiosSmcLib.c
+++ b/DynamicTablesPkg/Library/Smbios/Arm/SmbiosSmcLib/SmbiosSmcLib.c
@@ -3,111 +3,42 @@
 
   Copyright (c) 2021, NUVIA Inc. All rights reserved.<BR>
   Copyright (c) 2021 - 2022, Ampere Computing LLC. All rights reserved.<BR>
-  Copyright (c) 2025, ARM Ltd. All rights reserved.<BR>
+  Copyright (c) 2025 - 2026, ARM Ltd. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #include <Uefi.h>
-#include <IndustryStandard/ArmStdSmc.h>
-#include <Library/ArmSmcLib.h>
+#include <Library/ArmSmcccSocIdLib.h>
 #include <Library/SmbiosSmcLib.h>
 
-/** Checks if the ARM64 SoC ID SMC call is supported
+/**
+  Return the SoC ID formatted for the SMBIOS Type 4 Processor ID field.
 
-    @return Whether the ARM64 SoC ID call is supported.
+  @param[out] ProcessorId  Pointer to the SMBIOS Processor ID.
+
+  @retval EFI_SUCCESS            The Processor ID was returned successfully.
+  @retval EFI_INVALID_PARAMETER  ProcessorId is NULL.
+  @retval EFI_UNSUPPORTED        The SMCCC Architecture SoC ID interface is
+                                 unsupported or an SoC ID call failed.
 **/
-STATIC
-BOOLEAN
-HasSmcArm64SocId (
-  VOID
-  )
-{
-  INT32    SmcCallStatus;
-  BOOLEAN  Arm64SocIdSupported;
-  UINTN    SmcParam;
-
-  Arm64SocIdSupported = FALSE;
-
-  SmcCallStatus = ArmCallSmc0 (SMCCC_VERSION, NULL, NULL, NULL);
-
-  if ((SmcCallStatus < 0) || ((SmcCallStatus >> 16) >= 1)) {
-    SmcParam      = SMCCC_ARCH_SOC_ID;
-    SmcCallStatus = ArmCallSmc1 (SMCCC_ARCH_FEATURES, &SmcParam, NULL, NULL);
-    if (SmcCallStatus >= 0) {
-      Arm64SocIdSupported = TRUE;
-    }
-  }
-
-  return Arm64SocIdSupported;
-}
-
-/** Fetches the JEP106 code and SoC Revision.
-
-    @param Jep106Code  JEP 106 code.
-    @param SocRevision SoC revision.
-
-    @retval EFI_SUCCESS Succeeded.
-    @retval EFI_UNSUPPORTED Failed.
-**/
-STATIC
 EFI_STATUS
-SmbiosGetSmcArm64SocId (
-  OUT UINT32  *Jep106Code,
-  OUT UINT32  *SocRevision
-  )
-{
-  INT32       SmcCallStatus;
-  EFI_STATUS  Status;
-  UINTN       SmcParam;
-
-  Status = EFI_SUCCESS;
-
-  SmcParam      = 0;
-  SmcCallStatus = ArmCallSmc1 (SMCCC_ARCH_SOC_ID, &SmcParam, NULL, NULL);
-
-  if (SmcCallStatus >= 0) {
-    *Jep106Code = (UINT32)SmcCallStatus;
-  } else {
-    Status = EFI_UNSUPPORTED;
-  }
-
-  SmcParam      = 1;
-  SmcCallStatus = ArmCallSmc1 (SMCCC_ARCH_SOC_ID, &SmcParam, NULL, NULL);
-
-  if (SmcCallStatus >= 0) {
-    *SocRevision = (UINT32)SmcCallStatus;
-  } else {
-    Status = EFI_UNSUPPORTED;
-  }
-
-  return Status;
-}
-
-/** Returns the SOC ID, formatted for the SMBIOS Type 4 Processor ID field.
-
-    @param Processor ID.
-
-    @return 0 on success
-    @return EFI_UNSUPPORTED if SMCCC_ARCH_SOC_ID is not implemented
-**/
-UINT64
 SmbiosSmcGetSocId (
-  UINT64  *ProcessorId
+  OUT UINT64  *ProcessorId
   )
 {
   EFI_STATUS  Status;
   UINT32      Jep106Code;
   UINT32      SocRevision;
 
-  if (HasSmcArm64SocId ()) {
-    Status = SmbiosGetSmcArm64SocId (&Jep106Code, &SocRevision);
-    if (!EFI_ERROR (Status)) {
-      *ProcessorId = ((UINT64)SocRevision << 32) | Jep106Code;
-    }
-  } else {
-    Status = EFI_UNSUPPORTED;
+  if (ProcessorId == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = ArmSmcccGetSocId (&Jep106Code, &SocRevision);
+  if (!EFI_ERROR (Status)) {
+    *ProcessorId = ((UINT64)SocRevision << 32) | Jep106Code;
   }
 
   return Status;

--- a/DynamicTablesPkg/Library/Smbios/Arm/SmbiosSmcLib/SmbiosSmcLib.inf
+++ b/DynamicTablesPkg/Library/Smbios/Arm/SmbiosSmcLib/SmbiosSmcLib.inf
@@ -1,6 +1,6 @@
 #/** @file
 #
-#  Copyright (c) 2025, ARM Ltd. All rights reserved.<BR>
+#  Copyright (c) 2025 - 2026, ARM Ltd. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -18,9 +18,10 @@
   SmbiosSmcLib.c
 
 [Packages]
+  ArmPkg/ArmPkg.dec
   DynamicTablesPkg/DynamicTablesPkg.dec
   MdePkg/MdePkg.dec
 
 [LibraryClasses]
-  ArmSmcLib
+  ArmSmcccSocIdLib
 


### PR DESCRIPTION
Add `ArmSmcccSocIdLib` as a shared interface for checking support for the
SMCCC Architecture SoC ID service and retrieving the JEP106 identification
code and SoC revision.

Migrate the following consumers to the new library:

- `ArmPkg/Universal/Smbios/ProcessorSubClassDxe`
- `DynamicTablesPkg/Library/Smbios/Arm/SmbiosSmcLib`

This removes duplicated SMCCC feature detection and SoC ID calls while
preserving the existing SMBIOS Processor ID formatting and MIDR fallback
behaviour.

The corresponding edk2-platforms change migrates the Morello SMBIOS driver:

- edk2-platforms PR: (https://github.com/tianocore/edk2-platforms/pull/1019)

## Testing

The following builds completed successfully:

- ArmPkg: AARCH64 DEBUG, RELEASE and NOOPT
- DynamicTablesPkg: AARCH64 DEBUG, RELEASE and NOOPT
- DynamicTablesPkg: X64 NOOPT
- Morello SoC: AARCH64 NOOPT
- Morello FVP: AARCH64 NOOPT