### PR TITLE
UefiPayloadPkg: Support FIT booting from coreboot

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -400,6 +400,102 @@ FreeMemorySpaceMap:
 }
 
 /**
+  Allocate MMIO space in GCD, skipping already allocated platform ranges.
+
+  @param Base         Base address of the MMIO space.
+  @param Length       Length of the MMIO space.
+
+  @retval EFI_SUCCESS The unallocated MMIO space was allocated successfully.
+**/
+EFI_STATUS
+AllocateMemoryMappedIoSpace (
+  IN  UINT64  Base,
+  IN  UINT64  Length
+  )
+{
+  EFI_STATUS                       Status;
+  UINTN                            Index;
+  UINT64                           IntersectionBase;
+  UINT64                           IntersectionEnd;
+  UINTN                            NumberOfDescriptors;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMap;
+  EFI_PHYSICAL_ADDRESS             AllocationBase;
+
+  Status = gDS->GetMemorySpaceMap (&NumberOfDescriptors, &MemorySpaceMap);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: %a: GetMemorySpaceMap(): %r\n",
+      gEfiCallerBaseName,
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  for (Index = 0; Index < NumberOfDescriptors; Index++) {
+    IntersectionBase = MAX (Base, MemorySpaceMap[Index].BaseAddress);
+    IntersectionEnd  = MIN (
+                         Base + Length,
+                         MemorySpaceMap[Index].BaseAddress + MemorySpaceMap[Index].Length
+                         );
+    if (IntersectionBase >= IntersectionEnd) {
+      continue;
+    }
+
+    if (MemorySpaceMap[Index].GcdMemoryType != EfiGcdMemoryTypeMemoryMappedIo) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: %a: desc [%Lx, %Lx) type %u conflicts with aperture [%Lx, %Lx)\n",
+        gEfiCallerBaseName,
+        __func__,
+        MemorySpaceMap[Index].BaseAddress,
+        MemorySpaceMap[Index].BaseAddress + MemorySpaceMap[Index].Length,
+        (UINT32)MemorySpaceMap[Index].GcdMemoryType,
+        Base,
+        Base + Length
+        ));
+      Status = EFI_INVALID_PARAMETER;
+      goto FreeMemorySpaceMap;
+    }
+
+    if (MemorySpaceMap[Index].ImageHandle != NULL) {
+      continue;
+    }
+
+    AllocationBase = IntersectionBase;
+    Status         = gDS->AllocateMemorySpace (
+                            EfiGcdAllocateAddress,
+                            EfiGcdMemoryTypeMemoryMappedIo,
+                            0,
+                            IntersectionEnd - IntersectionBase,
+                            &AllocationBase,
+                            gImageHandle,
+                            NULL
+                            );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: %a: allocate [%Lx, %Lx): %r\n",
+        gEfiCallerBaseName,
+        __func__,
+        IntersectionBase,
+        IntersectionEnd,
+        Status
+        ));
+      goto FreeMemorySpaceMap;
+    }
+  }
+
+  Status = EFI_SUCCESS;
+
+FreeMemorySpaceMap:
+  FreePool (MemorySpaceMap);
+
+  return Status;
+}
+
+/**
   Event notification that is fired when IOMMU protocol is installed.
 
   @param  Event                 The Event that is being processed.
@@ -558,15 +654,10 @@ InitializePciHostBridge (
         }
 
         if (ResourceAssigned) {
-          Status = gDS->AllocateMemorySpace (
-                          EfiGcdAllocateAddress,
-                          EfiGcdMemoryTypeMemoryMappedIo,
-                          0,
-                          MemApertures[MemApertureIndex]->Limit - MemApertures[MemApertureIndex]->Base + 1,
-                          &HostAddress,
-                          gImageHandle,
-                          NULL
-                          );
+          Status = AllocateMemoryMappedIoSpace (
+                     HostAddress,
+                     MemApertures[MemApertureIndex]->Limit - MemApertures[MemApertureIndex]->Base + 1
+                     );
           ASSERT_EFI_ERROR (Status);
         }
       }

--- a/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
+++ b/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
@@ -279,8 +279,8 @@ PrintCpuHob (
   Hob.Raw = (UINT8 *)HobStart;
   ASSERT (HobLength >= sizeof (*Hob.Cpu));
 
-  DEBUG ((DEBUG_INFO, "   SizeOfMemorySpace = 0x%lx\n", Hob.Cpu->SizeOfMemorySpace));
-  DEBUG ((DEBUG_INFO, "   SizeOfIoSpace     = 0x%lx\n", Hob.Cpu->SizeOfIoSpace));
+  DEBUG ((DEBUG_INFO, "   SizeOfMemorySpace = 0x%x\n", Hob.Cpu->SizeOfMemorySpace));
+  DEBUG ((DEBUG_INFO, "   SizeOfIoSpace     = 0x%x\n", Hob.Cpu->SizeOfIoSpace));
   return EFI_SUCCESS;
 }
 

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -2776,6 +2776,7 @@ DriverEntry (
   EFI_TCG2_EVENT_ALGORITHM_BITMAP  TpmHashAlgorithmBitmap;
   UINT32                           ActivePCRBanks;
   UINT32                           NumberOfPCRBanks;
+  UINT32                           Tpm2PcrMask;
 
   mImageHandle = ImageHandle;
 
@@ -2882,6 +2883,27 @@ DriverEntry (
   DEBUG ((DEBUG_INFO, "Tcg2.HashAlgorithmBitmap - 0x%08x\n", mTcgDxeData.BsCap.HashAlgorithmBitmap));
   DEBUG ((DEBUG_INFO, "Tcg2.NumberOfPCRBanks      - 0x%08x\n", mTcgDxeData.BsCap.NumberOfPCRBanks));
   DEBUG ((DEBUG_INFO, "Tcg2.ActivePcrBanks        - 0x%08x\n", mTcgDxeData.BsCap.ActivePcrBanks));
+
+  //
+  // UEFI payloads do not run Tcg2Pei, so DXE constrains the TPM hash mask.
+  //
+  Tpm2PcrMask = PcdGet32 (PcdTpm2HashMask);
+  if (Tpm2PcrMask == 0) {
+    Tpm2PcrMask = mTcgDxeData.BsCap.ActivePcrBanks;
+  } else {
+    Tpm2PcrMask &= mTcgDxeData.BsCap.ActivePcrBanks;
+  }
+
+  if (Tpm2PcrMask == 0) {
+    DEBUG ((DEBUG_ERROR, "%a - No viable PCRs active\n", __func__));
+    ASSERT (FALSE);
+    return EFI_UNSUPPORTED;
+  }
+
+  if (Tpm2PcrMask != PcdGet32 (PcdTpm2HashMask)) {
+    Status = PcdSet32S (PcdTpm2HashMask, Tpm2PcrMask);
+    ASSERT_EFI_ERROR (Status);
+  }
 
   if (mTcgDxeData.BsCap.TPMPresentFlag) {
     //

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf
@@ -103,6 +103,9 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdStatusCodeSubClassTpmDevice              ## SOMETIMES_CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap                  ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2NumberOfPCRBanks                     ## CONSUMES
+  ## SOMETIMES_CONSUMES
+  ## SOMETIMES_PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask
   gEfiSecurityPkgTokenSpaceGuid.PcdTcgLogAreaMinLen                         ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2FinalLogAreaLen                      ## CONSUMES
   gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableRev                         ## CONSUMES

--- a/UefiPayloadPkg/Include/Guid/PciSegmentInfoGuid.h
+++ b/UefiPayloadPkg/Include/Guid/PciSegmentInfoGuid.h
@@ -21,7 +21,7 @@ typedef struct {
 
 typedef struct {
   UNIVERSAL_PAYLOAD_GENERIC_HEADER    Header;
-  UINTN                               Count;
+  UINT32                              Count;
   UPL_SEGMENT_INFO                    SegmentInfo[0];
 } UPL_PCI_SEGMENT_INFO_HOB;
 #pragma pack()

--- a/UefiPayloadPkg/Include/Library/FdtParserLib.h
+++ b/UefiPayloadPkg/Include/Library/FdtParserLib.h
@@ -27,7 +27,7 @@ ParseDtb (
   @retval HobList   The base address of Hoblist.
 
 **/
-UINT64
+UINTN
 EFIAPI
 FdtNodeParser (
   IN VOID  *FdtBase

--- a/UefiPayloadPkg/Library/BuildFdtLib/X86_BuildFdtLib.c
+++ b/UefiPayloadPkg/Library/BuildFdtLib/X86_BuildFdtLib.c
@@ -954,7 +954,7 @@ BuildFdtForUplRequired (
     Fit         = (VOID *)(UINTN)PayloadBase->Entry;
     DEBUG ((DEBUG_INFO, "PayloadBase Entry = 0x%08x\n", PayloadBase->Entry));
 
-    Status       = AsciiSPrint (TempStr, sizeof (TempStr), "upl-images@%lX", (UINTN)(Fit));
+    Status       = AsciiSPrint (TempStr, sizeof (TempStr), "upl-image@%lX", (UINTN)(Fit));
     UPLImageNode = FdtAddSubnode (Fdt, ParentNode, TempStr);
 
     Data64 = CpuToFdt64 ((UINTN)Fit);

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -11,6 +11,7 @@
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
+#include <Library/FdtLib.h>
 #include <Library/PcdLib.h>
 #include <Library/IoLib.h>
 #include <Library/BlParseLib.h>
@@ -118,6 +119,88 @@ IsValidCbTable (
 }
 
 /**
+  Resolve the bounded coreboot table described by a direct UPL FDT.
+
+  @param  Fdt               Pointer to the UPL FDT.
+
+  @retval NULL              The FDT has no valid coreboot table.
+  @retval Others            Pointer to the coreboot table.
+
+**/
+STATIC
+struct cb_header *
+GetCbTableFromFdt (
+  IN VOID  *Fdt
+  )
+{
+  INT32               CorebootNode;
+  INT32               FirmwareNode;
+  INT32               PropertyLength;
+  CONST FDT_PROPERTY  *Property;
+  CONST UINT64        *Reg;
+  UINT64              CbMemAddress;
+  UINT64              CbMemEnd;
+  UINT64              CbMemSize;
+  UINT64              TableAddress;
+  UINT64              TableEnd;
+  UINT64              TableSize;
+  struct cb_header    *Header;
+
+  if ((Fdt == NULL) || (FdtCheckHeader (Fdt) != 0)) {
+    return NULL;
+  }
+
+  FirmwareNode = FdtSubnodeOffsetNameLen (Fdt, 0, "firmware", sizeof ("firmware") - 1);
+  if (FirmwareNode < 0) {
+    return NULL;
+  }
+
+  CorebootNode = FdtSubnodeOffsetNameLen (
+                   Fdt,
+                   FirmwareNode,
+                   "coreboot",
+                   sizeof ("coreboot") - 1
+                   );
+  if (CorebootNode < 0) {
+    return NULL;
+  }
+
+  Property = FdtGetProperty (Fdt, CorebootNode, "reg", &PropertyLength);
+  if ((Property == NULL) || (PropertyLength != (4 * sizeof (UINT64)))) {
+    return NULL;
+  }
+
+  Reg          = (CONST UINT64 *)Property->Data;
+  TableAddress = Fdt64ToCpu (ReadUnaligned64 (&Reg[0]));
+  TableSize    = Fdt64ToCpu (ReadUnaligned64 (&Reg[1]));
+  CbMemAddress = Fdt64ToCpu (ReadUnaligned64 (&Reg[2]));
+  CbMemSize    = Fdt64ToCpu (ReadUnaligned64 (&Reg[3]));
+
+  if ((TableAddress > MAX_UINTN) || (TableSize < sizeof (*Header)) ||
+      (TableAddress > (MAX_UINT64 - TableSize)) ||
+      (CbMemAddress > (MAX_UINT64 - CbMemSize)))
+  {
+    return NULL;
+  }
+
+  TableEnd = TableAddress + TableSize;
+  CbMemEnd = CbMemAddress + CbMemSize;
+  if ((TableAddress < CbMemAddress) || (TableEnd > CbMemEnd)) {
+    return NULL;
+  }
+
+  Header = (struct cb_header *)(UINTN)TableAddress;
+  if ((Header->header_bytes != sizeof (*Header)) ||
+      (Header->table_bytes > (TableSize - Header->header_bytes)) ||
+      !IsValidCbTable (Header))
+  {
+    return NULL;
+  }
+
+  return Header;
+}
+
+/**
   This function retrieves the parameter base address from boot loader.
 
   This function will get bootloader specific parameter address for UEFI payload.
@@ -145,6 +228,13 @@ GetParameterBase (
   //
   Header = (struct cb_header *)(UINTN)GET_BOOTLOADER_PARAMETER ();
   if (IsValidCbTable (Header)) {
+    return Header;
+  }
+
+  Header = GetCbTableFromFdt ((VOID *)(UINTN)GET_BOOTLOADER_PARAMETER ());
+  if (Header != NULL) {
+    Status = PcdSet64S (PcdBootloaderParameter, (UINTN)Header);
+    ASSERT_EFI_ERROR (Status);
     return Header;
   }
 
@@ -220,6 +310,9 @@ FindCbTag (
   UINTN             Idx;
 
   Header = (struct cb_header *)GetParameterBase ();
+  if (Header == NULL) {
+    return NULL;
+  }
 
   TagPtr = NULL;
   TmpPtr = (UINT8 *)Header + Header->header_bytes;

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.inf
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   IoLib
   DebugLib
+  FdtLib
   PcdLib
   PrintLib
 

--- a/UefiPayloadPkg/Library/CustomFdtNodeParserLib/CustomFdtNodeParserLib.c
+++ b/UefiPayloadPkg/Library/CustomFdtNodeParserLib/CustomFdtNodeParserLib.c
@@ -124,9 +124,9 @@ CustomFdtNodeParser (
 {
   INT32                 Node, CustomNode;
   INT32                 TempLen;
+  CONST FDT_PROPERTY    *PropertyPtr;
   UINT64                *Data64;
   UINTN                 CHobList;
-  CONST FDT_PROPERTY    *PropertyPtr;
   EFI_PEI_HOB_POINTERS  Hob;
 
   CHobList = (UINTN)HobList;
@@ -137,17 +137,28 @@ CustomFdtNodeParser (
   // Look for if exists hob list node
   //
   Node = FdtSubnodeOffsetNameLen (FdtBase, 0, "options", (INT32)AsciiStrLen ("options"));
-  if (Node > 0) {
-    DEBUG ((DEBUG_INFO, "  Found options node (%08X)", Node));
-    CustomNode = FdtSubnodeOffsetNameLen (FdtBase, Node, "upl-custom", (INT32)AsciiStrLen ("upl-custom"));
-    if (CustomNode > 0) {
-      DEBUG ((DEBUG_INFO, "  Found upl-custom node (%08X)", CustomNode));
-      PropertyPtr = FdtGetProperty (FdtBase, CustomNode, "hoblistptr", &TempLen);
-      Data64      = (UINT64 *)(PropertyPtr->Data);
-      CHobList    = (UINTN)Fdt64ToCpu (ReadUnaligned64 (Data64));
-      DEBUG ((DEBUG_INFO, "  Found hob list node (%08X)", CustomNode));
-      DEBUG ((DEBUG_INFO, " -pointer  %016lX\n", CHobList));
-    }
+  if (Node <= 0) {
+    return CHobList;
+  }
+
+  DEBUG ((DEBUG_INFO, "  Found options node (%08X)", Node));
+  CustomNode = FdtSubnodeOffsetNameLen (FdtBase, Node, "upl-custom", (INT32)AsciiStrLen ("upl-custom"));
+  if (CustomNode <= 0) {
+    return CHobList;
+  }
+
+  DEBUG ((DEBUG_INFO, "  Found upl-custom node (%08X)", CustomNode));
+  PropertyPtr = FdtGetProperty (FdtBase, CustomNode, "hoblistptr", &TempLen);
+  if ((PropertyPtr == NULL) || (TempLen != sizeof (UINT64))) {
+    DEBUG ((DEBUG_INFO, "  Not Found hob list node\n"));
+    return CHobList;
+  }
+
+  Data64   = (UINT64 *)(PropertyPtr->Data);
+  CHobList = (UINTN)Fdt64ToCpu (ReadUnaligned64 (Data64));
+  DEBUG ((DEBUG_INFO, "  Found hob list node (%08X) -pointer  %016lX\n", CustomNode, CHobList));
+  if (CHobList == (UINTN)HobList) {
+    return CHobList;
   }
 
   Hob.Raw = (UINT8 *)CHobList;

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -389,7 +389,7 @@ ParseOptions (
     NodePtr = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + SubNode + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
     DEBUG ((DEBUG_INFO, "\n      SubNode(%08X)  %a", SubNode, NodePtr->Name));
 
-    if (AsciiStrnCmp (NodePtr->Name, "upl-images@", AsciiStrLen ("upl-images@")) == 0) {
+    if (AsciiStrnCmp (NodePtr->Name, "upl-image@", AsciiStrLen ("upl-image@")) == 0) {
       DEBUG ((DEBUG_INFO, "  Found image@ node \n"));
       //
       // Build PayloadBase HOB .

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -268,7 +268,11 @@ ParseReservedMemory (
       BuildMemoryAllocationHob (StartAddress, NumberOfBytes, EfiMemoryMappedIO);
     } else {
       PropertyPtr = FdtGetProperty (Fdt, SubNode, "compatible", &TempLen);
-      TempStr     = (CHAR8 *)(PropertyPtr->Data);
+      if (PropertyPtr == NULL) {
+        goto FallbackType;
+      }
+
+      TempStr = (CHAR8 *)(PropertyPtr->Data);
       DEBUG ((DEBUG_INFO, "compatible:  %a\n", TempStr));
       if (AsciiStrnCmp (TempStr, "boot-code", AsciiStrLen ("boot-code")) == 0) {
         DEBUG ((DEBUG_INFO, "  boot-code\n"));
@@ -314,6 +318,7 @@ ParseReservedMemory (
           SmbiosTable->SmBiosEntryPoint = (EFI_PHYSICAL_ADDRESS)(UINTN)(StartAddress);
         }
       } else {
+FallbackType:
         BuildMemoryAllocationHob (StartAddress, NumberOfBytes, EfiReservedMemoryType);
       }
     }

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -38,7 +38,8 @@ typedef enum {
   FrameBuffer,
   PciRootBridge,
   Options,
-  SerialPort,
+  IsaSerialPort,
+  MmioSerialPort,
   DoNothing
 } FDT_NODE_TYPE;
 
@@ -147,7 +148,9 @@ CheckNodeType (
 {
   DEBUG ((DEBUG_INFO, "\n CheckNodeType  %a   \n", NodeString));
   if (AsciiStrnCmp (NodeString, "serial@", AsciiStrLen ("serial@")) == 0) {
-    return SerialPort;
+    return MmioSerialPort;
+  } else if (AsciiStrnCmp (NodeString, "isa", AsciiStrLen ("isa")) == 0) {
+    return IsaSerialPort;
   } else if (AsciiStrnCmp (NodeString, "reserved-memory", AsciiStrLen ("reserved-memory")) == 0) {
     return ReservedMemory;
   } else if (AsciiStrnCmp (NodeString, "memory@", AsciiStrLen ("memory@")) == 0) {
@@ -955,6 +958,8 @@ ParseDtb (
   UINT8                 NumberOfRbSegNumAlreadyAssigned;
   UINT32                RootAddressCells;
   INT32                 ParentNode;
+  UINT32                IsaAddressCells;
+  INT32                 SSubNode;
 
   Fdt               = FdtBase;
   Depth             = 0;
@@ -1073,8 +1078,17 @@ ParseDtb (
     NodeType = CheckNodeType (NodePtr->Name, Depth);
     DEBUG ((DEBUG_INFO, "NodeType :0x%x\n", NodeType));
     switch (NodeType) {
-      case SerialPort:
+      case MmioSerialPort:
         ParseSerialPort (Fdt, Node, RootAddressCells);
+        break;
+      case IsaSerialPort:
+        PropertyPtr = FdtGetProperty (Fdt, Node, "#address-cells", &TempLen);
+        if ((PropertyPtr != NULL) && (TempLen > 0)) {
+          IsaAddressCells = Fdt32ToCpu (*(UINT32 *)PropertyPtr->Data);
+        }
+
+        SSubNode = FdtFirstSubnode (Fdt, Node);
+        ParseSerialPort (Fdt, SSubNode, IsaAddressCells);
         break;
       case ReservedMemory:
         DEBUG ((DEBUG_INFO, "ParseReservedMemory\n"));

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -65,8 +65,6 @@ typedef enum {
 
 extern VOID                         *mHobList;
 UNIVERSAL_PAYLOAD_PCI_ROOT_BRIDGES  *mPciRootBridgeInfo = NULL;
-INT32                               mNode[0x500]        = { 0 };
-UINT32                              mNodeIndex          = 0;
 UPL_PCI_SEGMENT_INFO_HOB            *mUplPciSegmentInfoHob;
 
 /**
@@ -92,45 +90,6 @@ HobConstructor (
   IN VOID  *EfiFreeMemoryBottom,
   IN VOID  *EfiFreeMemoryTop
   );
-
-/**
-  It will record the memory node initialized.
-
-  @param[in]  Node           memory node is going to parsing.
-**/
-VOID
-RecordMemoryNode (
-  INT32  Node
-  )
-{
-  DEBUG ((DEBUG_INFO, "\n RecordMemoryNode  %x , mNodeIndex :%x  \n", Node, mNodeIndex));
-  mNode[mNodeIndex] = Node;
-  mNodeIndex++;
-}
-
-/**
-  Check the memory node if initialized.
-
-  @param[in]  Node           memory node is going to parsing.
-
-  @return TRUE               memory node was initialized. don't parse it again.
-  @return FALSE              memory node wasn't initialized, go to parse it.
-**/
-BOOLEAN
-CheckMemoryNodeIfInit (
-  INT32  Node
-  )
-{
-  UINT32  i;
-
-  for (i = 0; i < mNodeIndex; i++) {
-    if (mNode[i] == Node) {
-      return TRUE;
-    }
-  }
-
-  return FALSE;
-}
 
 /**
   It will check device node from FDT.
@@ -263,8 +222,6 @@ ParseReservedMemory (
       DEBUG ((DEBUG_INFO, "\n         Property  %a", TempStr));
       DEBUG ((DEBUG_INFO, "  %016lX  %016lX\n", StartAddress, NumberOfBytes));
     }
-
-    RecordMemoryNode (SubNode);
 
     if (AsciiStrnCmp (NodePtr->Name, "mmio@", AsciiStrLen ("mmio@")) == 0) {
       DEBUG ((DEBUG_INFO, "  MemoryMappedIO"));
@@ -1069,13 +1026,19 @@ ParseDtb (
     BuildMemoryAllocationHob (Addr, Size, EfiReservedMemoryType);
   }
 
-  index = RootBridgeCount - 1;
-  Depth = 0;
+  index               = RootBridgeCount - 1;
+  Depth               = 0;
+  ReservedMemoryDepth = 0xFF;
   for (Node = FdtNextNode (Fdt, 0, &Depth); Node >= 0; Node = FdtNextNode (Fdt, Node, &Depth)) {
     NodePtr = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + Node + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
     DEBUG ((DEBUG_INFO, "\n   Node(%08x)  %a   Depth %x", Node, NodePtr->Name, Depth));
 
+    // Ensure we don't parse a child of reserved-memory as main memory block.
     NodeType = CheckNodeType (NodePtr->Name, Depth);
+    if ((ReservedMemoryDepth != 0xFF) && (Depth <= ReservedMemoryDepth)) {
+      ReservedMemoryDepth = 0xFF;
+    }
+
     DEBUG ((DEBUG_INFO, "NodeType :0x%x\n", NodeType));
     switch (NodeType) {
       case MmioSerialPort:
@@ -1093,13 +1056,14 @@ ParseDtb (
       case ReservedMemory:
         DEBUG ((DEBUG_INFO, "ParseReservedMemory\n"));
         ParseReservedMemory (Fdt, Node);
+        ReservedMemoryDepth = Depth;
         break;
       case Memory:
         DEBUG ((DEBUG_INFO, "ParseMemory\n"));
-        if (!CheckMemoryNodeIfInit (Node)) {
-          ParseMemory (Fdt, Node);
-        } else {
+        if ((ReservedMemoryDepth != 0xFF) && (Depth > ReservedMemoryDepth)) {
           DEBUG ((DEBUG_INFO, "Memory has initialized\n"));
+        } else {
+          ParseMemory (Fdt, Node);
         }
 
         break;

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -764,6 +764,8 @@ ParsePciRootBridge (
     }
   }
 
+  DEBUG ((DEBUG_INFO, "\n"));
+
   for (Property = FdtFirstPropertyOffset (Fdt, Node); Property >= 0; Property = FdtNextPropertyOffset (Fdt, Property)) {
     PropertyPtr = FdtGetPropertyByOffset (Fdt, Property, &TempLen);
     TempStr     = FdtGetString (Fdt, Fdt32ToCpu (PropertyPtr->NameOffset), NULL);
@@ -940,6 +942,8 @@ ParseDtb (
   UINT8                 NodeType;
   EFI_BOOT_MODE         BootMode;
   CHAR8                 *GmaStr;
+  UINTN                 PciRbArrayIndex;
+  INT32                 *PciRbNodes;
   UINT8                 ReservedMemoryDepth;
   INTN                  NumRsv;
   EFI_PHYSICAL_ADDRESS  Addr;
@@ -965,6 +969,8 @@ ParseDtb (
   BootMode            = 0;
   NodeType            = 0;
   RootAddressCells    = 2;
+  GmaStr              = "<NULL>";
+  PciRbArrayIndex     = 0;
   ReservedMemoryDepth = 0xFF;
 
   DEBUG ((DEBUG_INFO, "FDT = 0x%x  %x\n", Fdt, Fdt32ToCpu (*((UINT32 *)Fdt))));
@@ -1044,6 +1050,10 @@ ParseDtb (
     }
   }
 
+  if (RootBridgeCount) {
+    PciRbNodes = AllocateZeroPool (RootBridgeCount * sizeof (INT32));
+  }
+
   NumRsv = FdtGetNumberOfReserveMapEntries (Fdt);
   /* Look for an existing entry and add it to the efi mem map. */
   for (index = 0; index < NumRsv; index++) {
@@ -1080,13 +1090,14 @@ ParseDtb (
 
         break;
       case FrameBuffer:
+        // FIXME: Ensure this node gets parsed first so that it gets the
+        // correct options to feed into others (like GMA string)
         DEBUG ((DEBUG_INFO, "ParseFrameBuffer\n"));
         GmaStr = ParseFrameBuffer (Fdt, Node);
         break;
       case PciRootBridge:
-        DEBUG ((DEBUG_INFO, "ParsePciRootBridge, index :%x \n", index));
-        ParsePciRootBridge (Fdt, Node, RootBridgeCount, GmaStr, &index);
-        DEBUG ((DEBUG_INFO, "After ParsePciRootBridge, index :%x\n", index));
+        DEBUG ((DEBUG_INFO, "Found PciRootBridge\n"));
+        PciRbNodes[PciRbArrayIndex++] = Node;
         break;
       case Options:
         // FIXME: Need to ensure this node gets parsed first so that it gets
@@ -1099,6 +1110,26 @@ ParseDtb (
         break;
     }
   }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+
+  // Post processing: TODO: Need to look into it. Such cross dependency on DT nodes
+  // may not be good idea. Instead standardise GMA string?
+  while (PciRbArrayIndex--) {
+    DEBUG ((DEBUG_INFO, "Before ParsePciRootBridge, index: %d\n", index));
+    ParsePciRootBridge (Fdt, PciRbNodes[PciRbArrayIndex], RootBridgeCount, GmaStr, &index);
+    DEBUG ((DEBUG_INFO, "After ParsePciRootBridge, index: %d\n", index));
+  }
+
+  if (!RootBridgeCount) {
+    DEBUG ((DEBUG_ERROR, "Platform Init violates the spec! No PCI root bridges found.\n"));
+    goto Done;
+  }
+
+  //
+  // UniversalPayloadEntry phase does not define FreePool(), so just continue.
+  //
+  // FreePool (PciRbNodes);
 
   if ((NULL != mPciRootBridgeInfo) && (NULL != mUplPciSegmentInfoHob)) {
     // Post processing: TODO: Need to look into it. Such cross dependency on DT nodes
@@ -1144,8 +1175,8 @@ ParseDtb (
     }
   }
 
+Done:
   ((EFI_HOB_HANDOFF_INFO_TABLE *)(mHobList))->BootMode = BootMode;
-  DEBUG ((DEBUG_INFO, "\n"));
 
   return NewHobList;
 }

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -935,6 +935,7 @@ ParseDtb (
   UINT8                 NodeType;
   EFI_BOOT_MODE         BootMode;
   CHAR8                 *GmaStr;
+  UINT8                 ReservedMemoryDepth;
   INTN                  NumRsv;
   EFI_PHYSICAL_ADDRESS  Addr;
   UINT64                Size;
@@ -955,10 +956,11 @@ ParseDtb (
   index             = 0;
   // TODO: This value comes from FDT. Currently there is a bug in implementation
   // which assumes node ordering. Which requires a fix.
-  PciEnumDone      = 1;
-  BootMode         = 0;
-  NodeType         = 0;
-  RootAddressCells = 2;
+  PciEnumDone         = 1;
+  BootMode            = 0;
+  NodeType            = 0;
+  RootAddressCells    = 2;
+  ReservedMemoryDepth = 0xFF;
 
   DEBUG ((DEBUG_INFO, "FDT = 0x%x  %x\n", Fdt, Fdt32ToCpu (*((UINT32 *)Fdt))));
   DEBUG ((DEBUG_INFO, "Start parsing DTB data\n"));
@@ -973,6 +975,23 @@ ParseDtb (
   for (Node = FdtNextNode (Fdt, 0, &Depth); Node >= 0; Node = FdtNextNode (Fdt, Node, &Depth)) {
     NodePtr = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + Node + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
     DEBUG ((DEBUG_INFO, "\n   Node(%08x)  %a   Depth %x\n", Node, NodePtr->Name, Depth));
+
+    // Ensure we don't submit a child of reserved-memory as main memory block.
+    NodeType = CheckNodeType (NodePtr->Name, Depth);
+    // Already found reserved block.
+    if ((ReservedMemoryDepth != 0xFF) && (Depth > ReservedMemoryDepth)) {
+      DEBUG ((DEBUG_INFO, "Skipping reserved-memory block.\n"));
+      continue;
+    } else if ((ReservedMemoryDepth != 0xFF) && (Depth <= ReservedMemoryDepth)) {
+      ReservedMemoryDepth = 0xFF;
+    }
+
+    // Newly found reserved block.
+    if (NodeType == ReservedMemory) {
+      ReservedMemoryDepth = Depth;
+      continue;
+    }
+
     // memory node
     if (AsciiStrnCmp (NodePtr->Name, "memory@", AsciiStrLen ("memory@")) == 0) {
       for (Property = FdtFirstPropertyOffset (Fdt, Node); Property >= 0; Property = FdtNextPropertyOffset (Fdt, Property)) {

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -305,45 +305,70 @@ ParseFrameBuffer (
   CONST CHAR8                *TempStr;
   UINT32                     *Data32;
   UINT64                     FrameBufferBase;
-  UINT32                     FrameBufferSize;
+  UINT64                     FrameBufferSize;
+  UINT32                     Width;
+  UINT32                     Height;
+  UINT32                     Stride;
+  EFI_GRAPHICS_PIXEL_FORMAT  PixelFormat;
   EFI_PEI_GRAPHICS_INFO_HOB  *GraphicsInfo;
   CHAR8                      *GmaStr;
+  BOOLEAN                    HasReg;
 
-  GmaStr = "Gma";
-  //
-  // Create GraphicInfo HOB.
-  //
-  GraphicsInfo = BuildGuidHob (&gEfiGraphicsInfoHobGuid, sizeof (EFI_PEI_GRAPHICS_INFO_HOB));
-  ASSERT (GraphicsInfo != NULL);
-  if (GraphicsInfo == NULL) {
-    return GmaStr;
-  }
-
-  ZeroMem (GraphicsInfo, sizeof (EFI_PEI_GRAPHICS_INFO_HOB));
+  GmaStr          = "Gma";
+  FrameBufferBase = 0;
+  FrameBufferSize = 0;
+  Width           = 0;
+  Height          = 0;
+  Stride          = 0;
+  PixelFormat     = PixelFormatMax;
+  HasReg          = FALSE;
 
   for (Property = FdtFirstPropertyOffset (Fdt, Node); Property >= 0; Property = FdtNextPropertyOffset (Fdt, Property)) {
     PropertyPtr = FdtGetPropertyByOffset (Fdt, Property, &TempLen);
     TempStr     = FdtGetString (Fdt, Fdt32ToCpu (PropertyPtr->NameOffset), NULL);
     if (AsciiStrCmp (TempStr, "reg") == 0) {
-      Data32                        = (UINT32 *)(PropertyPtr->Data);
-      FrameBufferBase               = Fdt32ToCpu (*(Data32 + 0));
-      FrameBufferSize               = Fdt32ToCpu (*(Data32 + 1));
-      GraphicsInfo->FrameBufferBase = FrameBufferBase;
-      GraphicsInfo->FrameBufferSize = (UINT32)FrameBufferSize;
+      if (TempLen != (2 * sizeof (UINT64))) {
+        DEBUG ((DEBUG_ERROR, "Framebuffer reg must contain 64-bit address and size cells\n"));
+        return GmaStr;
+      }
+
+      FrameBufferBase = Fdt64ToCpu (ReadUnaligned64 ((CONST UINT64 *)&PropertyPtr->Data[0]));
+      FrameBufferSize = Fdt64ToCpu (ReadUnaligned64 ((CONST UINT64 *)&PropertyPtr->Data[sizeof (UINT64)]));
+      HasReg          = TRUE;
     } else if (AsciiStrCmp (TempStr, "width") == 0) {
-      Data32                                          = (UINT32 *)(PropertyPtr->Data);
-      GraphicsInfo->GraphicsMode.HorizontalResolution = Fdt32ToCpu (*Data32);
+      if (TempLen != sizeof (UINT32)) {
+        return GmaStr;
+      }
+
+      Data32 = (UINT32 *)(PropertyPtr->Data);
+      Width  = Fdt32ToCpu (ReadUnaligned32 (Data32));
     } else if (AsciiStrCmp (TempStr, "height") == 0) {
-      Data32                                        = (UINT32 *)(PropertyPtr->Data);
-      GraphicsInfo->GraphicsMode.VerticalResolution = Fdt32ToCpu (*Data32);
+      if (TempLen != sizeof (UINT32)) {
+        return GmaStr;
+      }
+
+      Data32 = (UINT32 *)(PropertyPtr->Data);
+      Height = Fdt32ToCpu (ReadUnaligned32 (Data32));
+    } else if (AsciiStrCmp (TempStr, "stride") == 0) {
+      if (TempLen != sizeof (UINT32)) {
+        return GmaStr;
+      }
+
+      Data32 = (UINT32 *)(PropertyPtr->Data);
+      Stride = Fdt32ToCpu (ReadUnaligned32 (Data32));
     } else if (AsciiStrCmp (TempStr, "format") == 0) {
+      if (TempLen != sizeof ("a8r8g8b8")) {
+        return GmaStr;
+      }
+
       TempStr = (CHAR8 *)(PropertyPtr->Data);
-      if (AsciiStrCmp (TempStr, "a8r8g8b8") == 0) {
-        GraphicsInfo->GraphicsMode.PixelFormat = PixelRedGreenBlueReserved8BitPerColor;
-      } else if (AsciiStrCmp (TempStr, "a8b8g8r8") == 0) {
-        GraphicsInfo->GraphicsMode.PixelFormat = PixelBlueGreenRedReserved8BitPerColor;
+      if ((AsciiStrCmp (TempStr, "a8r8g8b8") == 0) || (AsciiStrCmp (TempStr, "x8r8g8b8") == 0)) {
+        PixelFormat = PixelBlueGreenRedReserved8BitPerColor;
+      } else if ((AsciiStrCmp (TempStr, "a8b8g8r8") == 0) || (AsciiStrCmp (TempStr, "x8b8g8r8") == 0)) {
+        PixelFormat = PixelRedGreenBlueReserved8BitPerColor;
       } else {
-        GraphicsInfo->GraphicsMode.PixelFormat = PixelFormatMax;
+        DEBUG ((DEBUG_ERROR, "Unsupported framebuffer format: %a\n", TempStr));
+        return GmaStr;
       }
     } else if (AsciiStrCmp (TempStr, "display") == 0) {
       GmaStr = (CHAR8 *)(PropertyPtr->Data);
@@ -351,9 +376,30 @@ ParseFrameBuffer (
       DEBUG ((DEBUG_INFO, "  display (%s)", GmaStr));
     }
 
-    // In most case, PixelsPerScanLine is identical to HorizontalResolution
-    GraphicsInfo->GraphicsMode.PixelsPerScanLine = GraphicsInfo->GraphicsMode.HorizontalResolution;
   }
+
+  if (!HasReg || (FrameBufferSize > MAX_UINT32) || (Width == 0) || (Height == 0) ||
+      (Width > (MAX_UINT32 / sizeof (UINT32))) ||
+      (Stride < (Width * sizeof (UINT32))) || ((Stride % sizeof (UINT32)) != 0) ||
+      ((UINT64)Stride * Height > FrameBufferSize) || (PixelFormat == PixelFormatMax))
+  {
+    DEBUG ((DEBUG_ERROR, "Framebuffer node is incomplete or invalid\n"));
+    return GmaStr;
+  }
+
+  GraphicsInfo = BuildGuidHob (&gEfiGraphicsInfoHobGuid, sizeof (EFI_PEI_GRAPHICS_INFO_HOB));
+  ASSERT (GraphicsInfo != NULL);
+  if (GraphicsInfo == NULL) {
+    return GmaStr;
+  }
+
+  ZeroMem (GraphicsInfo, sizeof (EFI_PEI_GRAPHICS_INFO_HOB));
+  GraphicsInfo->FrameBufferBase                          = FrameBufferBase;
+  GraphicsInfo->FrameBufferSize                          = (UINT32)FrameBufferSize;
+  GraphicsInfo->GraphicsMode.HorizontalResolution        = Width;
+  GraphicsInfo->GraphicsMode.VerticalResolution          = Height;
+  GraphicsInfo->GraphicsMode.PixelFormat                 = PixelFormat;
+  GraphicsInfo->GraphicsMode.PixelsPerScanLine           = Stride / sizeof (UINT32);
 
   return GmaStr;
 }

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -204,6 +204,7 @@ ParseReservedMemory (
   UINT64                          NumberOfBytes;
   UNIVERSAL_PAYLOAD_ACPI_TABLE    *PlatformAcpiTable;
   UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *SmbiosTable;
+  CONST EFI_GUID                  *SmbiosTableGuid;
   FDT_NODE_HEADER                 *NodePtr;
   UINT32                          Attribute;
 
@@ -270,8 +271,21 @@ ParseReservedMemory (
         }
       } else if (AsciiStrnCmp (TempStr, "smbios", AsciiStrLen ("smbios")) == 0) {
         DEBUG ((DEBUG_INFO, " build smbios, NumberOfBytes:%x\n", NumberOfBytes));
+        if ((NumberOfBytes >= SMBIOS_3_0_ANCHOR_STRING_LENGTH) &&
+            (CompareMem ((VOID *)(UINTN)StartAddress, SMBIOS_3_0_ANCHOR_STRING, SMBIOS_3_0_ANCHOR_STRING_LENGTH) == 0))
+        {
+          SmbiosTableGuid = &gUniversalPayloadSmbios3TableGuid;
+        } else if ((NumberOfBytes >= SMBIOS_ANCHOR_STRING_LENGTH) &&
+                   (CompareMem ((VOID *)(UINTN)StartAddress, SMBIOS_ANCHOR_STRING, SMBIOS_ANCHOR_STRING_LENGTH) == 0))
+        {
+          SmbiosTableGuid = &gUniversalPayloadSmbiosTableGuid;
+        } else {
+          DEBUG ((DEBUG_ERROR, " invalid SMBIOS entry point at %Lx\n", StartAddress));
+          goto FallbackType;
+        }
+
         BuildMemoryAllocationHob (StartAddress, NumberOfBytes, EfiBootServicesData);
-        SmbiosTable = BuildGuidHob (&gUniversalPayloadSmbios3TableGuid, sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE));
+        SmbiosTable = BuildGuidHob (SmbiosTableGuid, sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE));
         if (SmbiosTable != NULL) {
           SmbiosTable->Header.Revision  = UNIVERSAL_PAYLOAD_SMBIOS_TABLE_REVISION;
           SmbiosTable->Header.Length    = sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE);

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -895,7 +895,6 @@ ParseDtb (
   EFI_PHYSICAL_ADDRESS  MemoryBottom;
   EFI_PHYSICAL_ADDRESS  MemoryTop;
   BOOLEAN               IsHobConstructed;
-  UINTN                 NewHobList;
   UINT8                 RootBridgeCount;
   UINT8                 index;
   UINT8                 PciEnumDone;
@@ -922,7 +921,6 @@ ParseDtb (
   Depth             = 0;
   MinimalNeededSize = FixedPcdGet32 (PcdSystemMemoryUefiRegionSize);
   IsHobConstructed  = FALSE;
-  NewHobList        = 0;
   RootBridgeCount   = 0;
   index             = 0;
   // TODO: This value comes from FDT. Currently there is a bug in implementation
@@ -975,13 +973,13 @@ ParseDtb (
           StartAddress  = Fdt64ToCpu (ReadUnaligned64 (Data64));
           NumberOfBytes = Fdt64ToCpu (ReadUnaligned64 (Data64 + 1));
           DEBUG ((DEBUG_INFO, "\n         Property(%08X)  %a", Property, TempStr));
-          DEBUG ((DEBUG_INFO, "  %016lX  %016lX", StartAddress, NumberOfBytes));
+          DEBUG ((DEBUG_INFO, "  %016lX  %016lX\n", StartAddress, NumberOfBytes));
           // If parent node type is reserved-memory we are looking at special-purpose memory. Ignore it.
           ParentNode = FdtParentOffset (Fdt, Node);
           NodePtr    = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + ParentNode + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
           NodeType   = CheckNodeType (NodePtr->Name, Depth);
           if (!IsHobConstructed && (NodeType != ReservedMemory)) {
-            if (NumberOfBytes > MinimalNeededSize) {
+            if ((NumberOfBytes > MinimalNeededSize) && (StartAddress < BASE_4GB)) {
               MemoryBottom     = StartAddress + NumberOfBytes - MinimalNeededSize;
               FreeMemoryBottom = MemoryBottom;
               FreeMemoryTop    = StartAddress + NumberOfBytes;
@@ -993,7 +991,6 @@ ParseDtb (
               DEBUG ((DEBUG_INFO, "MemoryTop :0x%llx\n", MemoryTop));
               mHobList         = HobConstructor ((VOID *)(UINTN)MemoryBottom, (VOID *)(UINTN)MemoryTop, (VOID *)(UINTN)FreeMemoryBottom, (VOID *)(UINTN)FreeMemoryTop);
               IsHobConstructed = TRUE;
-              NewHobList       = (UINTN)mHobList;
               break;
             }
           }
@@ -1156,7 +1153,7 @@ ParseDtb (
 Done:
   ((EFI_HOB_HANDOFF_INFO_TABLE *)(mHobList))->BootMode = BootMode;
 
-  return NewHobList;
+  return (UINTN)mHobList;
 }
 
 /**
@@ -1191,19 +1188,18 @@ UplInitHob (
 {
   UINTN  NHobAddress;
 
-  NHobAddress = 0;
   //
   // Check parameter type
   //
   if (FdtCheckHeader (FdtBase) == 0) {
     DEBUG ((DEBUG_INFO, "%a() FDT blob\n", __func__));
     NHobAddress = FdtNodeParser ((VOID *)FdtBase);
+
+    return NHobAddress;
   } else {
-    DEBUG ((DEBUG_INFO, "%a() HOb list\n", __func__));
+    DEBUG ((DEBUG_INFO, "%a() HOB list\n", __func__));
     mHobList = FdtBase;
 
-    return (UINTN)(mHobList);
+    return (UINTN)mHobList;
   }
-
-  return NHobAddress;
 }

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -1034,7 +1034,7 @@ ParseDtb (
   CHAR8                 *GmaStr;
   UINTN                 PciRbArrayIndex;
   INT32                 *PciRbNodes;
-  UINT8                 ReservedMemoryDepth;
+  INT32                 ReservedMemoryDepth;
   INTN                  NumRsv;
   EFI_PHYSICAL_ADDRESS  Addr;
   UINT64                Size;
@@ -1062,7 +1062,7 @@ ParseDtb (
   RootAddressCells    = 2;
   GmaStr              = "<NULL>";
   PciRbArrayIndex     = 0;
-  ReservedMemoryDepth = 0xFF;
+  ReservedMemoryDepth = -1;
 
   DEBUG ((DEBUG_INFO, "FDT = 0x%x  %x\n", Fdt, Fdt32ToCpu (*((UINT32 *)Fdt))));
   DEBUG ((DEBUG_INFO, "Start parsing DTB data\n"));
@@ -1081,11 +1081,11 @@ ParseDtb (
     // Ensure we don't submit a child of reserved-memory as main memory block.
     NodeType = CheckNodeType (NodePtr->Name, Depth);
     // Already found reserved block.
-    if ((ReservedMemoryDepth != 0xFF) && (Depth > ReservedMemoryDepth)) {
+    if ((ReservedMemoryDepth >= 0) && (Depth > ReservedMemoryDepth)) {
       DEBUG ((DEBUG_INFO, "Skipping reserved-memory block.\n"));
       continue;
-    } else if ((ReservedMemoryDepth != 0xFF) && (Depth <= ReservedMemoryDepth)) {
-      ReservedMemoryDepth = 0xFF;
+    } else if ((ReservedMemoryDepth >= 0) && (Depth <= ReservedMemoryDepth)) {
+      ReservedMemoryDepth = -1;
     }
 
     // Newly found reserved block.
@@ -1156,15 +1156,15 @@ ParseDtb (
 
   index               = RootBridgeCount - 1;
   Depth               = 0;
-  ReservedMemoryDepth = 0xFF;
+  ReservedMemoryDepth = -1;
   for (Node = FdtNextNode (Fdt, 0, &Depth); Node >= 0; Node = FdtNextNode (Fdt, Node, &Depth)) {
     NodePtr = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + Node + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
     DEBUG ((DEBUG_INFO, "\n   Node(%08x)  %a   Depth %x", Node, NodePtr->Name, Depth));
 
     // Ensure we don't parse a child of reserved-memory as main memory block.
     NodeType = CheckNodeType (NodePtr->Name, Depth);
-    if ((ReservedMemoryDepth != 0xFF) && (Depth <= ReservedMemoryDepth)) {
-      ReservedMemoryDepth = 0xFF;
+    if ((ReservedMemoryDepth >= 0) && (Depth <= ReservedMemoryDepth)) {
+      ReservedMemoryDepth = -1;
     }
 
     DEBUG ((DEBUG_INFO, "NodeType :0x%x\n", NodeType));
@@ -1188,7 +1188,7 @@ ParseDtb (
         break;
       case Memory:
         DEBUG ((DEBUG_INFO, "ParseMemory\n"));
-        if ((ReservedMemoryDepth != 0xFF) && (Depth > ReservedMemoryDepth)) {
+        if ((ReservedMemoryDepth >= 0) && (Depth > ReservedMemoryDepth)) {
           DEBUG ((DEBUG_INFO, "Memory has initialized\n"));
         } else {
           ParseMemory (Fdt, Node);

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -38,8 +38,7 @@ typedef enum {
   FrameBuffer,
   PciRootBridge,
   Options,
-  IsaSerialPort,
-  MmioSerialPort,
+  SerialPort,
   DoNothing
 } FDT_NODE_TYPE;
 
@@ -106,10 +105,10 @@ CheckNodeType (
   )
 {
   DEBUG ((DEBUG_INFO, "\n CheckNodeType  %a   \n", NodeString));
-  if (AsciiStrnCmp (NodeString, "serial@", AsciiStrLen ("serial@")) == 0) {
-    return MmioSerialPort;
-  } else if (AsciiStrnCmp (NodeString, "isa", AsciiStrLen ("isa")) == 0) {
-    return IsaSerialPort;
+  if ((AsciiStrCmp (NodeString, "serial") == 0) ||
+      (AsciiStrnCmp (NodeString, "serial@", AsciiStrLen ("serial@")) == 0))
+  {
+    return SerialPort;
   } else if (AsciiStrnCmp (NodeString, "reserved-memory", AsciiStrLen ("reserved-memory")) == 0) {
     return ReservedMemory;
   } else if (AsciiStrnCmp (NodeString, "memory@", AsciiStrLen ("memory@")) == 0) {
@@ -288,7 +287,12 @@ ParseReservedMemory (
 
     if (AsciiStrnCmp (NodePtr->Name, "mmio@", AsciiStrLen ("mmio@")) == 0) {
       DEBUG ((DEBUG_INFO, "  MemoryMappedIO"));
-      BuildMemoryAllocationHob (StartAddress, NumberOfBytes, EfiMemoryMappedIO);
+      BuildResourceDescriptorHob (
+        EFI_RESOURCE_MEMORY_MAPPED_IO,
+        MEMORY_ATTRIBUTE_DEFAULT,
+        StartAddress,
+        NumberOfBytes
+        );
     } else {
       PropertyPtr = FdtGetProperty (Fdt, SubNode, "compatible", &TempLen);
       if (PropertyPtr == NULL) {
@@ -460,7 +464,10 @@ ParseFrameBuffer (
       GmaStr++;
       DEBUG ((DEBUG_INFO, "  display (%s)", GmaStr));
     }
+  }
 
+  if ((Stride == 0) && (Width <= (MAX_UINT32 / sizeof (UINT32)))) {
+    Stride = Width * sizeof (UINT32);
   }
 
   if (!HasReg || (FrameBufferSize > MAX_UINT32) || (Width == 0) || (Height == 0) ||
@@ -479,12 +486,12 @@ ParseFrameBuffer (
   }
 
   ZeroMem (GraphicsInfo, sizeof (EFI_PEI_GRAPHICS_INFO_HOB));
-  GraphicsInfo->FrameBufferBase                          = FrameBufferBase;
-  GraphicsInfo->FrameBufferSize                          = (UINT32)FrameBufferSize;
-  GraphicsInfo->GraphicsMode.HorizontalResolution        = Width;
-  GraphicsInfo->GraphicsMode.VerticalResolution          = Height;
-  GraphicsInfo->GraphicsMode.PixelFormat                 = PixelFormat;
-  GraphicsInfo->GraphicsMode.PixelsPerScanLine           = Stride / sizeof (UINT32);
+  GraphicsInfo->FrameBufferBase                   = FrameBufferBase;
+  GraphicsInfo->FrameBufferSize                   = (UINT32)FrameBufferSize;
+  GraphicsInfo->GraphicsMode.HorizontalResolution = Width;
+  GraphicsInfo->GraphicsMode.VerticalResolution   = Height;
+  GraphicsInfo->GraphicsMode.PixelFormat          = PixelFormat;
+  GraphicsInfo->GraphicsMode.PixelsPerScanLine    = Stride / sizeof (UINT32);
 
   return GmaStr;
 }
@@ -558,7 +565,7 @@ ParseOptions (
       }
 
       PropertyPtr = FdtGetProperty (Fdt, SubNode, "pci-enum-done", &TempLen);
-      if (TempLen > 0) {
+      if (PropertyPtr != NULL) {
         *PciEnumDone = 1;
         DEBUG ((DEBUG_INFO, "  Found PciEnumDone (%08X)\n", *PciEnumDone));
       } else {
@@ -779,7 +786,6 @@ ParsePciRootBridge (
 {
   INT32               SubNode;
   INT32               Property;
-  INT32               SSubNode;
   FDT_NODE_HEADER     *NodePtr;
   CONST FDT_PROPERTY  *PropertyPtr;
   INT32               TempLen;
@@ -838,20 +844,6 @@ ParsePciRootBridge (
     if (AsciiStrnCmp (NodePtr->Name, GmaStr, AsciiStrLen (GmaStr)) == 0) {
       DEBUG ((DEBUG_INFO, "  Found gma@ node \n"));
       ParsegraphicNode (Fdt, SubNode);
-    }
-
-    if (AsciiStrnCmp (NodePtr->Name, "isa", AsciiStrLen ("isa")) == 0) {
-      PropertyPtr = FdtGetProperty (Fdt, SubNode, "#address-cells", &TempLen);
-      if ((PropertyPtr != NULL) && (TempLen > 0)) {
-        AddressCells = Fdt32ToCpu (*(UINT32 *)PropertyPtr->Data);
-      }
-
-      SSubNode = FdtFirstSubnode (Fdt, SubNode);
-      ParseSerialPort (Fdt, SSubNode, AddressCells);
-    }
-
-    if (AsciiStrnCmp (NodePtr->Name, "serial@", AsciiStrLen ("serial@")) == 0) {
-      ParseSerialPort (Fdt, SubNode, AddressCells);
     }
   }
 
@@ -1044,9 +1036,8 @@ ParseDtb (
   UINT8                 *RbSegNumAlreadyAssigned;
   UINT8                 NumberOfRbSegNumAlreadyAssigned;
   UINT32                RootAddressCells;
+  UINT32                SerialAddressCells;
   INT32                 ParentNode;
-  UINT32                IsaAddressCells;
-  INT32                 SSubNode;
 
   Fdt               = FdtBase;
   Depth             = 0;
@@ -1062,6 +1053,7 @@ ParseDtb (
   RootAddressCells    = 2;
   GmaStr              = "<NULL>";
   PciRbArrayIndex     = 0;
+  PciRbNodes          = NULL;
   ReservedMemoryDepth = -1;
 
   DEBUG ((DEBUG_INFO, "FDT = 0x%x  %x\n", Fdt, Fdt32ToCpu (*((UINT32 *)Fdt))));
@@ -1110,7 +1102,7 @@ ParseDtb (
           NodePtr    = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + ParentNode + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
           NodeType   = CheckNodeType (NodePtr->Name, Depth);
           if (!IsHobConstructed && (NodeType != ReservedMemory)) {
-            if ((NumberOfBytes > MinimalNeededSize) && (StartAddress < BASE_4GB)) {
+            if (NumberOfBytes > MinimalNeededSize) {
               MemoryBottom     = StartAddress + NumberOfBytes - MinimalNeededSize;
               FreeMemoryBottom = MemoryBottom;
               FreeMemoryTop    = StartAddress + NumberOfBytes;
@@ -1142,6 +1134,9 @@ ParseDtb (
 
   if (RootBridgeCount) {
     PciRbNodes = AllocateZeroPool (RootBridgeCount * sizeof (INT32));
+    if (PciRbNodes == NULL) {
+      goto Done;
+    }
   }
 
   NumRsv = FdtGetNumberOfReserveMapEntries (Fdt);
@@ -1169,17 +1164,17 @@ ParseDtb (
 
     DEBUG ((DEBUG_INFO, "NodeType :0x%x\n", NodeType));
     switch (NodeType) {
-      case MmioSerialPort:
-        ParseSerialPort (Fdt, Node, RootAddressCells);
-        break;
-      case IsaSerialPort:
-        PropertyPtr = FdtGetProperty (Fdt, Node, "#address-cells", &TempLen);
-        if ((PropertyPtr != NULL) && (TempLen > 0)) {
-          IsaAddressCells = Fdt32ToCpu (*(UINT32 *)PropertyPtr->Data);
+      case SerialPort:
+        SerialAddressCells = RootAddressCells;
+        ParentNode         = FdtParentOffset (Fdt, Node);
+        if (ParentNode >= 0) {
+          PropertyPtr = FdtGetProperty (Fdt, ParentNode, "#address-cells", &TempLen);
+          if ((PropertyPtr != NULL) && (TempLen == sizeof (UINT32))) {
+            SerialAddressCells = Fdt32ToCpu (ReadUnaligned32 ((CONST UINT32 *)PropertyPtr->Data));
+          }
         }
 
-        SSubNode = FdtFirstSubnode (Fdt, Node);
-        ParseSerialPort (Fdt, SSubNode, IsaAddressCells);
+        ParseSerialPort (Fdt, Node, SerialAddressCells);
         break;
       case ReservedMemory:
         DEBUG ((DEBUG_INFO, "ParseReservedMemory\n"));

--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -184,6 +184,68 @@ ParseMemory (
 }
 
 /**
+  Check whether a range is contained in a system-memory node.
+
+  @param[in]  Fdt               Address of the Fdt data.
+  @param[in]  StartAddress      Start of the range.
+  @param[in]  NumberOfBytes     Size of the range.
+
+  @retval TRUE                  The range is contained in system memory.
+  @retval FALSE                 The range is outside system memory.
+**/
+STATIC
+BOOLEAN
+IsRangeInSystemMemory (
+  IN VOID    *Fdt,
+  IN UINT64  StartAddress,
+  IN UINT64  NumberOfBytes
+  )
+{
+  CONST FDT_PROPERTY  *PropertyPtr;
+  CONST UINT64        *Data64;
+  CONST CHAR8         *NodeName;
+  UINT64              EndAddress;
+  UINT64              MemoryEnd;
+  UINT64              MemorySize;
+  UINT64              MemoryStart;
+  INT32               Node;
+  INT32               TempLen;
+
+  if ((NumberOfBytes == 0) || (StartAddress > (MAX_UINT64 - NumberOfBytes))) {
+    return FALSE;
+  }
+
+  EndAddress = StartAddress + NumberOfBytes;
+  for (Node = FdtFirstSubnode (Fdt, 0); Node >= 0; Node = FdtNextSubnode (Fdt, Node)) {
+    NodeName = FdtGetName (Fdt, Node, NULL);
+    if ((NodeName == NULL) ||
+        (AsciiStrnCmp (NodeName, "memory@", AsciiStrLen ("memory@")) != 0))
+    {
+      continue;
+    }
+
+    PropertyPtr = FdtGetProperty (Fdt, Node, "reg", &TempLen);
+    if ((PropertyPtr == NULL) || (TempLen != (2 * sizeof (UINT64)))) {
+      continue;
+    }
+
+    Data64      = (CONST UINT64 *)PropertyPtr->Data;
+    MemoryStart = Fdt64ToCpu (ReadUnaligned64 (&Data64[0]));
+    MemorySize  = Fdt64ToCpu (ReadUnaligned64 (&Data64[1]));
+    if ((MemorySize == 0) || (MemoryStart > (MAX_UINT64 - MemorySize))) {
+      continue;
+    }
+
+    MemoryEnd = MemoryStart + MemorySize;
+    if ((StartAddress >= MemoryStart) && (EndAddress <= MemoryEnd)) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
   It will ParseReservedMemory node from FDT.
 
   @param[in]  Fdt               Address of the Fdt data.
@@ -293,6 +355,15 @@ ParseReservedMemory (
         }
       } else {
 FallbackType:
+        if (!IsRangeInSystemMemory (Fdt, StartAddress, NumberOfBytes)) {
+          BuildResourceDescriptorHob (
+            EFI_RESOURCE_MEMORY_RESERVED,
+            MEMORY_ATTRIBUTE_DEFAULT,
+            StartAddress,
+            NumberOfBytes
+            );
+        }
+
         BuildMemoryAllocationHob (StartAddress, NumberOfBytes, EfiReservedMemoryType);
       }
     }

--- a/UefiPayloadPkg/Library/HobParseLib/HobParseLib.c
+++ b/UefiPayloadPkg/Library/HobParseLib/HobParseLib.c
@@ -4,15 +4,9 @@
 **/
 
 #include <PiPei.h>
-#include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/MemoryAllocationLib.h>
-#include <Library/DebugLib.h>
 #include <Library/HobLib.h>
-#include <Library/PcdLib.h>
 #include <Guid/MemoryAllocationHob.h>
-#include <Library/IoLib.h>
-#include <Library/CpuLib.h>
 #include <IndustryStandard/Acpi.h>
 #include <IndustryStandard/MemoryMappedConfigurationSpaceAccessTable.h>
 #include <Guid/AcpiBoardInfoGuid.h>
@@ -36,8 +30,6 @@
                                        EFI_RESOURCE_ATTRIBUTE_INITIALIZED | \
                                        EFI_RESOURCE_ATTRIBUTE_TESTED      )
 
-extern VOID  *mHobList;
-
 /**
   Add a new HOB to the HOB List.
 
@@ -53,42 +45,6 @@ EFIAPI
 CreateHob (
   IN  UINT16  HobType,
   IN  UINT16  HobLength
-  );
-
-/**
-  Build a Handoff Information Table HOB
-
-  This function initialize a HOB region from EfiMemoryBegin to
-  EfiMemoryTop. And EfiFreeMemoryBottom and EfiFreeMemoryTop should
-  be inside the HOB region.
-
-  @param[in] EfiMemoryBottom       Total memory start address
-  @param[in] EfiMemoryTop          Total memory end address.
-  @param[in] EfiFreeMemoryBottom   Free memory start address
-  @param[in] EfiFreeMemoryTop      Free memory end address.
-
-  @return   The pointer to the handoff HOB table.
-
-**/
-EFI_HOB_HANDOFF_INFO_TABLE *
-EFIAPI
-HobConstructor (
-  IN VOID  *EfiMemoryBottom,
-  IN VOID  *EfiMemoryTop,
-  IN VOID  *EfiFreeMemoryBottom,
-  IN VOID  *EfiFreeMemoryTop
-  );
-
-/**
-  Build ACPI board info HOB using infomation from ACPI table
-
-  @param  AcpiTableBase      ACPI table start address in memory
-
-  @retval  A pointer to ACPI board HOB ACPI_BOARD_INFO. Null if build HOB failure.
-**/
-ACPI_BOARD_INFO *
-BuildHobFromAcpi (
-  IN   UINT64  AcpiTableBase
   );
 
 /**

--- a/UefiPayloadPkg/Library/HobParseLib/HobParseLib.inf
+++ b/UefiPayloadPkg/Library/HobParseLib/HobParseLib.inf
@@ -9,9 +9,9 @@
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = HobParseLib
   FILE_GUID                      = EFB05FE7-604B-40DA-9A59-E2F998528754
-  MODULE_TYPE                    = DXE_DRIVER
+  MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = HobParseLib|DXE_DRIVER DXE_RUNTIME_DRIVER SMM_CORE DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  LIBRARY_CLASS                  = HobParseLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -28,13 +28,5 @@
   UefiPayloadPkg/UefiPayloadPkg.dec
 
 [LibraryClasses]
-  BaseLib
   BaseMemoryLib
-  IoLib
-  DebugLib
-  PcdLib
   HobLib
-
-[Pcd.IA32,Pcd.X64,Pcd.RISCV64]
-  gUefiPayloadPkgTokenSpaceGuid.PcdSystemMemoryUefiRegionSize
-  gUefiPayloadPkgTokenSpaceGuid.PcdHandOffFdtEnable

--- a/UefiPayloadPkg/PayloadLoaderPeim/FitLib/FitLib.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/FitLib/FitLib.c
@@ -13,8 +13,8 @@ PROPERTY_DATA  PropertyData32List[] = {
 };
 
 PROPERTY_DATA  PropertyData64List[] = {
-  { "entry",       PAYLOAD_ENTRY_POINT_OFFSET },
-  { "load",        PAYLOAD_LOAD_ADDR_OFFSET   }
+  { "entry", PAYLOAD_ENTRY_POINT_OFFSET },
+  { "load",  PAYLOAD_LOAD_ADDR_OFFSET   }
 };
 
 /**
@@ -66,6 +66,12 @@ FitParseFirmwarePropertyData (
     ContextOffset64  = (UINT64 *)((UINTN)Context + PropertyData64List[Index].Offset);
     *ContextOffset64 = Fdt64ToCpu (*Data64);
   }
+
+  //
+  // Need to load the FIT header (FDT) too. "load" property of tianocore entrypoint refers to image.
+  // Since FDT is directly before tianocore, subtract its size from load.
+  //
+  Context->PayloadLoadAddress -= FdtTotalSize (Fdt);
 
   return EFI_SUCCESS;
 }

--- a/UefiPayloadPkg/PayloadLoaderPeim/FitLib/FitLib.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/FitLib/FitLib.c
@@ -13,7 +13,7 @@ PROPERTY_DATA  PropertyData32List[] = {
 };
 
 PROPERTY_DATA  PropertyData64List[] = {
-  { "entry-start", PAYLOAD_ENTRY_POINT_OFFSET },
+  { "entry",       PAYLOAD_ENTRY_POINT_OFFSET },
   { "load",        PAYLOAD_LOAD_ADDR_OFFSET   }
 };
 

--- a/UefiPayloadPkg/PayloadLoaderPeim/FitLib/FitLib.c
+++ b/UefiPayloadPkg/PayloadLoaderPeim/FitLib/FitLib.c
@@ -68,10 +68,10 @@ FitParseFirmwarePropertyData (
   }
 
   //
-  // Need to load the FIT header (FDT) too. "load" property of tianocore entrypoint refers to image.
-  // Since FDT is directly before tianocore, subtract its size from load.
+  // The external image store follows the aligned FIT header.
   //
-  Context->PayloadLoadAddress -= FdtTotalSize (Fdt);
+  Context->PayloadEntryOffset += ALIGN_VALUE (FdtTotalSize (Fdt), 4);
+  Context->PayloadLoadAddress -= Context->PayloadEntryOffset;
 
   return EFI_SUCCESS;
 }

--- a/UefiPayloadPkg/Tools/MkFitImage.py
+++ b/UefiPayloadPkg/Tools/MkFitImage.py
@@ -105,6 +105,7 @@ def BuildFitImage(Fdt, InfoHeader, Arch):
         ["tianocore",   InfoHeader.Binary,        BuildTianoImageNode , InfoHeader.Description,     None, 0 ],
         ["uefi-fv",     InfoHeader.UefifvPath,    BuildFvImageNode,     "UEFI Firmware Volume",     None, 0 ],
         ["bds-fv",      InfoHeader.BdsfvPath,     BuildFvImageNode ,    "BDS Firmware Volume",      None, 0 ],
+        ["sec-fv",      InfoHeader.SecfvPath,     BuildFvImageNode ,    "Security Firmware Volume", None, 0 ],
         ["network-fv",  InfoHeader.NetworkfvPath, BuildFvImageNode ,    "Network Firmware Volume",  None, 0 ],
     ]
 

--- a/UefiPayloadPkg/Tools/MkFitImage.py
+++ b/UefiPayloadPkg/Tools/MkFitImage.py
@@ -134,7 +134,7 @@ def BuildFitImage(Fdt, InfoHeader, Arch):
             MultiImage[Index][-1] = DataOffset
             DataOffset += len (BinaryData)
     libfdt.fdt_setprop_u32(Fdt, 0, 'size', DataOffset)
-    posix_time = int(time.time())
+    posix_time = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
     libfdt.fdt_setprop_u32(Fdt, 0, 'timestamp', posix_time)
     DescriptionFit = 'Uefi OS Loader'
     libfdt.fdt_setprop(Fdt, 0, 'description', bytes(DescriptionFit, 'utf-8'), len(DescriptionFit) + 1)

--- a/UefiPayloadPkg/Tools/MkFitImage.py
+++ b/UefiPayloadPkg/Tools/MkFitImage.py
@@ -76,7 +76,7 @@ def BuildTianoImageNode(Fdt, InfoHeader, ParentNode, DataOffset, DataSize, Descr
     if InfoHeader.LoadAddr is not None:
         libfdt.fdt_setprop_u64(Fdt, ParentNode, 'load', InfoHeader.LoadAddr)
     if InfoHeader.Entry is not None:
-        libfdt.fdt_setprop_u64(Fdt, ParentNode, 'entry-start', InfoHeader.Entry)
+        libfdt.fdt_setprop_u64(Fdt, ParentNode, 'entry', InfoHeader.Entry)
     if InfoHeader.RelocStart is not None:
         libfdt.fdt_setprop_u32(Fdt, ParentNode, 'reloc-start', InfoHeader.RelocStart)
     if InfoHeader.DataSize is not None:
@@ -111,6 +111,7 @@ def BuildFitImage(Fdt, InfoHeader, Arch):
     #
     # Set basic information
     #
+    libfdt.fdt_setprop_u32(Fdt, 0, '#address-cells', 2)
     libfdt.fdt_setprop_u32(Fdt, 0, 'build-revision', InfoHeader.Revision)
     libfdt.fdt_setprop_u32(Fdt, 0, 'spec-version', InfoHeader.UplVersion)
 

--- a/UefiPayloadPkg/Tools/MkFitImage.py
+++ b/UefiPayloadPkg/Tools/MkFitImage.py
@@ -123,7 +123,7 @@ def BuildFitImage(Fdt, InfoHeader, Arch):
     BuildConfNode(Fdt, ConfNode, MultiImage)
 
     # Build image
-    DataOffset = InfoHeader.DataOffset
+    DataOffset = 0
     for Index in range (0, len (MultiImage)):
         _, Path, _, _, _, _ = MultiImage[Index]
         if exists(Path) == 1:
@@ -133,7 +133,7 @@ def BuildFitImage(Fdt, InfoHeader, Arch):
             MultiImage[Index][-2] = BinaryData
             MultiImage[Index][-1] = DataOffset
             DataOffset += len (BinaryData)
-    libfdt.fdt_setprop_u32(Fdt, 0, 'size', DataOffset)
+    libfdt.fdt_setprop_u32(Fdt, 0, 'size', InfoHeader.DataOffset + DataOffset)
     posix_time = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
     libfdt.fdt_setprop_u32(Fdt, 0, 'timestamp', posix_time)
     DescriptionFit = 'Uefi OS Loader'
@@ -187,7 +187,8 @@ def ReplaceFv (UplBinary, SectionFvFile, SectionName, Arch):
         with open (UplBinary, "rb") as File:
             Dtb = File.read ()
         Fit          = libfdt.Fdt (Dtb)
-        NewFitHeader = bytearray(Dtb[0:Fit.totalsize()])
+        FitDataOffset = (Fit.totalsize() + 3) & ~3
+        NewFitHeader = bytearray(Dtb[0:FitDataOffset])
         FitSize      = len(Dtb)
 
         LoadablesList = []
@@ -209,7 +210,8 @@ def ReplaceFv (UplBinary, SectionFvFile, SectionName, Arch):
             ImageNode    = libfdt.fdt_subnode_offset(NewFitHeader, ImagesNode, Item)
             ImageOffset  = int.from_bytes (libfdt.fdt_getprop (NewFitHeader, ImageNode, 'data-offset')[0], 'big')
             ImageSize    = int.from_bytes (libfdt.fdt_getprop (NewFitHeader, ImageNode, 'data-size')[0], 'big')
-            MultiFvList.append ([Item, Dtb[ImageOffset:ImageOffset + ImageSize]])
+            ImagePosition = FitDataOffset + ImageOffset
+            MultiFvList.append ([Item, Dtb[ImagePosition:ImagePosition + ImageSize]])
 
         IsFvExist = False
         for Index in range (0, len (MultiFvList)):
@@ -233,7 +235,10 @@ def ReplaceFv (UplBinary, SectionFvFile, SectionName, Arch):
                 SectionFvFileBinary = File.read ()
             MultiFvList.append ([SectionName, SectionFvFileBinary])
             FvNode = libfdt.fdt_add_subnode(NewFitHeader, ImagesNode, SectionName)
-            BuildFvImageNode (NewFitHeader, None, FvNode, FitSize, len(SectionFvFileBinary), SectionName + " Firmware Volume", Arch)
+            BuildFvImageNode (
+                NewFitHeader, None, FvNode, FitSize - FitDataOffset,
+                len(SectionFvFileBinary), SectionName + " Firmware Volume", Arch
+                )
             FitSize += len(SectionFvFileBinary)
         else:
             for Index in range (0, len (MultiFvList)):
@@ -255,7 +260,8 @@ def ReplaceFv (UplBinary, SectionFvFile, SectionName, Arch):
         TianoNode     = libfdt.fdt_subnode_offset(NewFitHeader, ImagesNode, 'tianocore')
         TianoOffset   = int.from_bytes (libfdt.fdt_getprop (NewFitHeader, TianoNode, 'data-offset')[0], 'big')
         TianoSize     = int.from_bytes (libfdt.fdt_getprop (NewFitHeader, TianoNode, 'data-size')[0], 'big')
-        TianoBinary   = Dtb[TianoOffset:TianoOffset + TianoSize]
+        TianoPosition = FitDataOffset + TianoOffset
+        TianoBinary   = Dtb[TianoPosition:TianoPosition + TianoSize]
 
         print("\nGenerate new fit image:")
         NewUplBinary = bytearray(FitSize)
@@ -267,8 +273,12 @@ def ReplaceFv (UplBinary, SectionFvFile, SectionName, Arch):
             ImageNode   = libfdt.fdt_subnode_offset(NewFitHeader, ImagesNode, MultiFvList[Index][0])
             ImageOffset = int.from_bytes (libfdt.fdt_getprop (NewFitHeader, ImageNode, 'data-offset')[0], 'big')
             ImageSize   = int.from_bytes (libfdt.fdt_getprop (NewFitHeader, ImageNode, 'data-size')[0], 'big')
-            NewUplBinary[ImageOffset:ImageOffset + ImageSize] = MultiFvList[Index][1]
-            print("Update " + MultiFvList[Index][0] + "\t\t to " + str(hex(ImageOffset)) + "\t ~ " + str(hex(ImageOffset + ImageSize)))
+            ImagePosition = FitDataOffset + ImageOffset
+            NewUplBinary[ImagePosition:ImagePosition + ImageSize] = MultiFvList[Index][1]
+            print(
+                "Update " + MultiFvList[Index][0] + "\t\t to " +
+                str(hex(ImagePosition)) + "\t ~ " + str(hex(ImagePosition + ImageSize))
+                )
 
         with open (UplBinary, "wb") as File:
             File.write (NewUplBinary)

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
@@ -55,6 +55,55 @@ ProcessLibraryConstructorList (
   );
 
 /**
+  Build HOBs from bootloader-specific data.
+**/
+STATIC
+VOID
+BuildBootloaderHobs (
+  VOID
+  )
+{
+  EFI_STATUS                      Status;
+  EFI_HOB_HANDOFF_INFO_TABLE      *Phit;
+  FIRMWARE_INFO                   FirmwareInfo;
+  SMMSTORE_INFO                   SmmStoreInfo;
+
+  if (GetFirstGuidHob (&gEfiSmmStoreInfoHobGuid) == NULL) {
+    Status = ParseSmmStoreInfo (&SmmStoreInfo);
+    if (!EFI_ERROR (Status)) {
+      BuildGuidDataHob (
+        &gEfiSmmStoreInfoHobGuid,
+        &SmmStoreInfo,
+        sizeof (SmmStoreInfo)
+        );
+    }
+  }
+
+  if (GetFirstGuidHob (&gEfiFirmwareInfoHobGuid) == NULL) {
+    Status = ParseFirmwareInfo (&FirmwareInfo);
+    if (!EFI_ERROR (Status)) {
+      BuildGuidDataHob (
+        &gEfiFirmwareInfoHobGuid,
+        &FirmwareInfo,
+        sizeof (FirmwareInfo)
+        );
+    }
+  }
+
+  Status = ParseCapsules (BuildCvHob);
+  if (EFI_ERROR (Status) && (Status != RETURN_NOT_FOUND)) {
+    DEBUG ((DEBUG_WARN, "Failed to parse bootloader capsules: %r\n", Status));
+  }
+
+  if (GetFirstHob (EFI_HOB_TYPE_UEFI_CAPSULE) != NULL) {
+    Phit = GetFirstHob (EFI_HOB_TYPE_HANDOFF);
+    if (Phit != NULL) {
+      Phit->BootMode = BOOT_ON_FLASH_UPDATE;
+    }
+  }
+}
+
+/**
   Find the first substring.
   @param  String    Point to the string where to find the substring.
   @param  CharSet   Point to the string to be found.
@@ -521,6 +570,8 @@ FitBuildHobs (
       ASSERT (AcpiBoardInfo != NULL);
     }
   }
+
+  BuildBootloaderHobs ();
 
   //
   // Create an empty FvHob for the DXE FV that contains DXE core.

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
@@ -564,6 +564,11 @@ FitUplEntryPoint (
  #endif
   VOID  *FdtBaseResvd;
 
+  Status = PcdSet64S (PcdBootloaderParameter, BootloaderParameter);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   if (FixedPcdGetBool (PcdHandOffFdtEnable)) {
     mHobList = (VOID *)NULL;
   } else {

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
@@ -63,10 +63,10 @@ BuildBootloaderHobs (
   VOID
   )
 {
-  EFI_STATUS                      Status;
-  EFI_HOB_HANDOFF_INFO_TABLE      *Phit;
-  FIRMWARE_INFO                   FirmwareInfo;
-  SMMSTORE_INFO                   SmmStoreInfo;
+  EFI_STATUS                  Status;
+  EFI_HOB_HANDOFF_INFO_TABLE  *Phit;
+  FIRMWARE_INFO               FirmwareInfo;
+  SMMSTORE_INFO               SmmStoreInfo;
 
   if (GetFirstGuidHob (&gEfiSmmStoreInfoHobGuid) == NULL) {
     Status = ParseSmmStoreInfo (&SmmStoreInfo);
@@ -287,7 +287,7 @@ BuildFitLoadablesFvHob (
   UINT32                  *Data32;
   UINTN                   FvBase;
 
-  Fdt = NULL;
+  Fdt    = NULL;
   *DxeFv = NULL;
 
   GuidHob = GetFirstGuidHob (&gUniversalPayloadBaseGuid);
@@ -356,7 +356,7 @@ BuildFitLoadablesFvHob (
       return EFI_COMPROMISED_DATA;
     }
 
-    Data32  = (UINT32 *)(PropertyPtr->Data);
+    Data32   = (UINT32 *)(PropertyPtr->Data);
     DataSize = Fdt32ToCpu (ReadUnaligned32 (Data32));
     if ((DataOffset > FitSize - FitDataOffset) ||
         (DataSize < sizeof (EFI_FIRMWARE_VOLUME_HEADER)) ||
@@ -520,7 +520,7 @@ FitBuildHobs (
   OUT EFI_FIRMWARE_VOLUME_HEADER  **DxeFv
   )
 {
-  EFI_STATUS                      Status;
+  EFI_STATUS                     Status;
   UINT8                          *GuidHob;
   UINT32                         FdtSize;
   EFI_HOB_FIRMWARE_VOLUME        *FvHob;
@@ -583,6 +583,7 @@ FitBuildHobs (
     DEBUG ((DEBUG_ERROR, "Failed to create FIT FV HOBs: %r\n", Status));
     return Status;
   }
+
   //
   // Update DXE FV information to first fv hob in the hob list, which
   // is the empty FvHob created before.
@@ -656,6 +657,9 @@ FitUplEntryPoint (
 
   // Build HOB based on information from Bootloader
   Status = FitBuildHobs ((UINTN)FdtBaseResvd, &DxeFv);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   // Call constructor for all libraries again since hobs were built
   ProcessLibraryConstructorList ();

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
@@ -225,19 +225,21 @@ BuildFitLoadablesFvHob (
   VOID                    *Fdt;
   UINT8                   *GuidHob;
   UNIVERSAL_PAYLOAD_BASE  *PayloadBase;
-  INT32                   ConfigNode;
-  INT32                   Config1Node;
   INT32                   ImageNode;
   INT32                   FvNode;
-  INT32                   Depth;
   CONST FDT_PROPERTY      *PropertyPtr;
   INT32                   TempLen;
   CONST CHAR8             *Fvname;
+  UINTN                   FvNameLength;
   UINT32                  DataOffset;
   UINT32                  DataSize;
+  UINT32                  FitDataOffset;
+  UINT32                  FitSize;
   UINT32                  *Data32;
+  UINTN                   FvBase;
 
   Fdt = NULL;
+  *DxeFv = NULL;
 
   GuidHob = GetFirstGuidHob (&gUniversalPayloadBaseGuid);
   if (GuidHob != NULL) {
@@ -252,17 +254,26 @@ BuildFitLoadablesFvHob (
 
   Status = FdtCheckHeader (Fdt);
   if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "FIT header at 0x%08x is invalid: %d\n", Fdt, Status));
     return EFI_UNSUPPORTED;
   }
 
-  ConfigNode = FdtSubnodeOffsetNameLen (Fdt, 0, "configurations", (INT32)AsciiStrLen ("configurations"));
-  if (ConfigNode <= 0) {
-    return EFI_NOT_FOUND;
+  PropertyPtr = FdtGetProperty (Fdt, 0, "size", &TempLen);
+  if ((PropertyPtr == NULL) || (TempLen != sizeof (UINT32))) {
+    DEBUG ((DEBUG_ERROR, "FIT root has no valid size property\n"));
+    return EFI_COMPROMISED_DATA;
   }
 
-  Config1Node = FdtSubnodeOffsetNameLen (Fdt, ConfigNode, "conf-1", (INT32)AsciiStrLen ("conf-1"));
-  if (Config1Node <= 0) {
-    return EFI_NOT_FOUND;
+  FitSize = Fdt32ToCpu (ReadUnaligned32 ((UINT32 *)PropertyPtr->Data));
+  if ((FitSize < FdtTotalSize (Fdt)) || (FitSize > SIZE_256MB)) {
+    DEBUG ((DEBUG_ERROR, "FIT size 0x%x is invalid for FDT size 0x%x\n", FitSize, FdtTotalSize (Fdt)));
+    return EFI_COMPROMISED_DATA;
+  }
+
+  FitDataOffset = ALIGN_VALUE (FdtTotalSize (Fdt), 4);
+  if ((FitDataOffset < FdtTotalSize (Fdt)) || (FitDataOffset > FitSize)) {
+    DEBUG ((DEBUG_ERROR, "FIT external-data base 0x%x is invalid\n", FitDataOffset));
+    return EFI_COMPROMISED_DATA;
   }
 
   ImageNode = FdtSubnodeOffsetNameLen (Fdt, 0, "images", (INT32)AsciiStrLen ("images"));
@@ -270,40 +281,81 @@ BuildFitLoadablesFvHob (
     return EFI_NOT_FOUND;
   }
 
-  FvNode = FdtSubnodeOffsetNameLen (Fdt, ImageNode, "tianocore", (INT32)AsciiStrLen ("tianocore"));
-  Depth  = FdtNodeDepth (Fdt, FvNode);
-  FvNode = FdtNextNode (Fdt, FvNode, &Depth);
-  Fvname = FdtGetName (Fdt, FvNode, &TempLen);
-  while ((AsciiStrCmp ((Fvname + AsciiStrLen (Fvname) - 2), "fv") == 0)) {
-    if (FvNode <= 0) {
-      return EFI_NOT_FOUND;
+  for (FvNode = FdtFirstSubnode (Fdt, ImageNode); FvNode >= 0; FvNode = FdtNextSubnode (Fdt, FvNode)) {
+    Fvname = FdtGetName (Fdt, FvNode, &TempLen);
+    if ((Fvname == NULL) || (TempLen <= 0)) {
+      return EFI_COMPROMISED_DATA;
+    }
+
+    FvNameLength = AsciiStrLen (Fvname);
+    if ((FvNameLength < 3) || (AsciiStrCmp (Fvname + FvNameLength - 3, "-fv") != 0)) {
+      continue;
     }
 
     PropertyPtr = FdtGetProperty (Fdt, FvNode, "data-offset", &TempLen);
-    Data32      = (UINT32 *)(PropertyPtr->Data);
-    DataOffset  = SwapBytes32 (*Data32);
+    if ((PropertyPtr == NULL) || (TempLen != sizeof (UINT32))) {
+      DEBUG ((DEBUG_ERROR, "FIT image %a has no valid data-offset\n", Fvname));
+      return EFI_COMPROMISED_DATA;
+    }
+
+    Data32     = (UINT32 *)(PropertyPtr->Data);
+    DataOffset = Fdt32ToCpu (ReadUnaligned32 (Data32));
 
     PropertyPtr = FdtGetProperty (Fdt, FvNode, "data-size", &TempLen);
-    Data32      = (UINT32 *)(PropertyPtr->Data);
-    DataSize    = SwapBytes32 (*Data32);
+    if ((PropertyPtr == NULL) || (TempLen != sizeof (UINT32))) {
+      DEBUG ((DEBUG_ERROR, "FIT image %a has no valid data-size\n", Fvname));
+      return EFI_COMPROMISED_DATA;
+    }
+
+    Data32  = (UINT32 *)(PropertyPtr->Data);
+    DataSize = Fdt32ToCpu (ReadUnaligned32 (Data32));
+    if ((DataOffset > FitSize - FitDataOffset) ||
+        (DataSize < sizeof (EFI_FIRMWARE_VOLUME_HEADER)) ||
+        (DataSize > FitSize - FitDataOffset - DataOffset))
+    {
+      DEBUG ((DEBUG_ERROR, "FIT image %a range 0x%x+0x%x exceeds FIT size 0x%x\n", Fvname, DataOffset, DataSize, FitSize));
+      return EFI_COMPROMISED_DATA;
+    }
+
+    if ((PayloadBase->Entry > MAX_UINTN) ||
+        (PayloadBase->Entry > MAX_UINTN - FitDataOffset) ||
+        (PayloadBase->Entry + FitDataOffset > MAX_UINTN - DataOffset) ||
+        (((PayloadBase->Entry + FitDataOffset + DataOffset) & 7) != 0))
+    {
+      return EFI_COMPROMISED_DATA;
+    }
+
+    FvBase = (UINTN)PayloadBase->Entry + FitDataOffset + DataOffset;
+    if ((((EFI_FIRMWARE_VOLUME_HEADER *)FvBase)->Signature != EFI_FVH_SIGNATURE) ||
+        (((EFI_FIRMWARE_VOLUME_HEADER *)FvBase)->FvLength != DataSize))
+    {
+      DEBUG ((DEBUG_ERROR, "FIT image %a at 0x%08x is not the declared FV\n", Fvname, FvBase));
+      return EFI_COMPROMISED_DATA;
+    }
 
     if (AsciiStrCmp (Fvname, "uefi-fv") == 0) {
-      *DxeFv = (EFI_FIRMWARE_VOLUME_HEADER *)((UINTN)PayloadBase->Entry + (UINTN)DataOffset);
-      ASSERT ((*DxeFv)->FvLength == DataSize);
+      if (*DxeFv != NULL) {
+        DEBUG ((DEBUG_ERROR, "FIT contains multiple uefi-fv images\n"));
+        return EFI_COMPROMISED_DATA;
+      }
+
+      *DxeFv = (EFI_FIRMWARE_VOLUME_HEADER *)FvBase;
     } else {
-      BuildFvHob (((UINTN)PayloadBase->Entry + (UINTN)DataOffset), DataSize);
+      BuildFvHob (FvBase, DataSize);
     }
 
     DEBUG ((
       DEBUG_INFO,
       "UPL Multiple fv[%a], Base=0x%08x, size=0x%08x\n",
       Fvname,
-      ((UINTN)PayloadBase->Entry + (UINTN)DataOffset),
+      FvBase,
       DataSize
       ));
-    Depth  = FdtNodeDepth (Fdt, FvNode);
-    FvNode = FdtNextNode (Fdt, FvNode, &Depth);
-    Fvname = FdtGetName (Fdt, FvNode, &TempLen);
+  }
+
+  if (*DxeFv == NULL) {
+    DEBUG ((DEBUG_ERROR, "FIT contains no uefi-fv image\n"));
+    return EFI_NOT_FOUND;
   }
 
   return EFI_SUCCESS;
@@ -419,6 +471,7 @@ FitBuildHobs (
   OUT EFI_FIRMWARE_VOLUME_HEADER  **DxeFv
   )
 {
+  EFI_STATUS                      Status;
   UINT8                          *GuidHob;
   UINT32                         FdtSize;
   EFI_HOB_FIRMWARE_VOLUME        *FvHob;
@@ -474,7 +527,11 @@ FitBuildHobs (
   //
   BuildFvHob ((EFI_PHYSICAL_ADDRESS)0, 0);
 
-  BuildFitLoadablesFvHob (DxeFv);
+  Status = BuildFitLoadablesFvHob (DxeFv);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed to create FIT FV HOBs: %r\n", Status));
+    return Status;
+  }
   //
   // Update DXE FV information to first fv hob in the hob list, which
   // is the empty FvHob created before.

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.inf
@@ -69,6 +69,7 @@
   PcdLib
   StackCheckLib
   MemoryAllocationLib
+  BlParseLib
 
 [Guids]
   gEfiMemoryTypeInformationGuid
@@ -87,6 +88,8 @@
   gUniversalPayloadPciRootBridgeInfoGuid
   gUniversalPayloadSmbios3TableGuid
   gUniversalPayloadDeviceTreeGuid
+  gEfiFirmwareInfoHobGuid
+  gEfiSmmStoreInfoHobGuid
 
 [FeaturePcd.IA32]
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode      ## CONSUMES

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.inf
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.inf
@@ -116,6 +116,7 @@
   gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData
   gUefiPayloadPkgTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode
   gUefiPayloadPkgTokenSpaceGuid.PcdFDTPageSize
+  gUefiPayloadPkgTokenSpaceGuid.PcdBootloaderParameter
 
 [BuildOptions]
   MSFT:*_*_*_CC_FLAGS = /wd4244 /wd4305

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
@@ -143,7 +143,7 @@ UniversalLoadDxeCore (
   @retval HobList   The base address of Hoblist.
 
 **/
-UINT64
+UINTN
 EFIAPI
 FdtNodeParser (
   IN VOID  *FdtBase

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -730,6 +730,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x3F8
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialBaudRate|$(BAUD_RATE)
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterStride|1
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterAccessWidth|8
 
 [PcdsPatchableInModule.common]
   gEfiMdeModulePkgTokenSpaceGuid.PcdBootManagerMenuFile|{ 0x21, 0xaa, 0x2c, 0x46, 0x14, 0x76, 0x03, 0x45, 0x83, 0x6e, 0x8a, 0xb6, 0xf4, 0x66, 0x23, 0x31 }

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -355,8 +355,10 @@
     BlParseLib|UefiPayloadPkg/Library/SblParseLib/SblParseLib.inf
   !endif
 !else
-  !if $(USE_CBMEM_FOR_CONSOLE) == TRUE && $(BOOTLOADER) == "COREBOOT"
+  !if $(BOOTLOADER) == "COREBOOT"
     BlParseLib|UefiPayloadPkg/Library/CbParseLib/CbParseLib.inf
+  !else
+    BlParseLib|UefiPayloadPkg/Library/SblParseLib/SblParseLib.inf
   !endif
 !endif
 

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -354,6 +354,10 @@
   !else
     BlParseLib|UefiPayloadPkg/Library/SblParseLib/SblParseLib.inf
   !endif
+!else
+  !if $(USE_CBMEM_FOR_CONSOLE) == TRUE && $(BOOTLOADER) == "COREBOOT"
+    BlParseLib|UefiPayloadPkg/Library/CbParseLib/CbParseLib.inf
+  !endif
 !endif
 
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf

--- a/UefiPayloadPkg/UniversalPayloadBuild.py
+++ b/UefiPayloadPkg/UniversalPayloadBuild.py
@@ -251,7 +251,7 @@ def BuildUniversalPayload(Args):
         fit_image_info_header.SecfvPath     = SecFvOutputDir
         fit_image_info_header.NetworkfvPath = NetworkFvOutputDir
         fit_image_info_header.DataOffset    = 0x1000
-        fit_image_info_header.LoadAddr      = Args.LoadAddress
+        fit_image_info_header.LoadAddr      = Args.LoadAddress + fit_image_info_header.DataOffset
         fit_image_info_header.Project       = 'tianocore'
 
         TargetRebaseFile = fit_image_info_header.Binary.replace (pathlib.Path(fit_image_info_header.Binary).suffix, ".pecoff")
@@ -268,7 +268,7 @@ def BuildUniversalPayload(Args):
             ))
         RunCommand (
             "GenFw --rebase 0x{:02X} -o {} {} ".format (
-              fit_image_info_header.LoadAddr + fit_image_info_header.DataOffset,
+              fit_image_info_header.LoadAddr,
               TargetRebaseFile,
               TargetRebaseFile,
             ))


### PR DESCRIPTION
# Description

Support booting a FIT Universal Payload directly from coreboot.

This revives and supersedes #6382. It updates the FIT layout to the current
Universal Payload specification, validates external data before use and makes
the FDT handoff independent of node order and optional custom nodes.

The coreboot path reuses the existing bootloader parsers for SMMSTORE,
firmware information and capsules. It also carries framebuffer, SMBIOS,
reserved-memory and serial data into the same HOBs used by the conventional
UefiPayloadPkg path. Tcg2Dxe limits measurements to active PCR banks when a
payload does not run Tcg2Pei.

A matched hardware A/B found equivalent behavior for SMMSTORE variables,
memory capsules, CFR settings, BGRT/graphics, SMBIOS, TPM, NVMe, xHCI, Wi-Fi,
S4/TME resume, ACPI, IOMMU and runtime power management. Direct UPL also
preserved a coreboot-enabled PCI device that the conventional payload
disabled while taking ownership of PCI configuration.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- `PatchCheck.py` passes all commits.
- Stuart DscCompleteCheck, UncrustifyCheck and EccCheck pass for
  MdeModulePkg, UefiPayloadPkg and SecurityPkg.
- A clean IA32/X64 GCC RELEASE build produces the FIT payload.
- Q35 boots with four CPUs, NVMe and xHCI. Truncated images, overlapping load
  ranges, entries outside their loaded image and data outside the FIT are
  rejected before payload entry. SMMSTORE survives a cold QEMU process.
- StarBook MTL was tested against a matched conventional UefiPayloadPkg build.
  Both boot Ubuntu 6.17.0-41 and pass the behavior listed above. Both also
  install an authenticated raw capsule with `fwupdtool install-blob`.
- Median coreboot time was 1.732 seconds for conventional UefiPayloadPkg and
  2.031 seconds for direct UPL. Median userspace boot differed by 0.043
  seconds. The current direct FIT load and validation account for most of the
  firmware-time difference.

The final master-rebased tip also includes independent-review fixes for the
optional custom HOB handoff, the existing revision-1 PCI segment HOB ABI,
nonzero FIT firmware offsets, HOB allocation above 4 GiB, ISA serial nodes and
the parser return ABI. Those changes pass the build and package gates above.

## Integration Instructions

N/A
