### PR TITLE
UefiPayloadPkg/CbParseLib: Fix inconsistent memory map

### DIFF
--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -115,6 +115,7 @@ struct cb_memory_range {
 #define CB_MEM_UNUSABLE     5
 #define CB_MEM_VENDOR_RSVD  6
 #define CB_MEM_TABLE        16
+#define CB_MEM_SOFT_RESERVED  0xefffffff
 
 struct cb_memory {
   UINT32                    tag;

--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -20,10 +20,17 @@
 
 #define GET_BOOTLOADER_PARAMETER()  PcdGet64 (PcdBootloaderParameter)
 
+typedef struct {
+  UINT64    Base;
+  UINT64    Size;
+  UINT32    Type;
+  UINT8     Flag;
+} BL_MEMORY_MAP_ENTRY;
+
 typedef RETURN_STATUS \
 (*BL_MEM_INFO_CALLBACK) (
-  MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  VOID              *Param
+  BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  VOID                 *Param
   );
 
 typedef VOID \

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -20,6 +20,47 @@
 #include <Coreboot.h>
 
 /**
+  Map a coreboot memory type to the E820-style encoding used by UefiPayloadEntry.
+
+  The numeric values must stay in sync with the E820_* definitions in UefiPayloadEntry.h.
+
+**/
+STATIC
+UINT32
+CbMemTypeToE820Type (
+  IN UINT32  CbType
+  )
+{
+  switch (CbType) {
+    case CB_MEM_RAM:
+      return 1;  // E820_RAM
+    case CB_MEM_RESERVED:
+      return 2;  // E820_RESERVED
+    case CB_MEM_ACPI:
+      return 3;  // E820_ACPI
+    case CB_MEM_NVS:
+      return 4;  // E820_NVS
+    case CB_MEM_UNUSABLE:
+      return 5;  // E820_UNUSABLE
+    //
+    // Vendor-reserved and table ranges are still DRAM from coreboot's point of
+    // view and must not be treated as "disabled" memory. Describe them as
+    // reserved memory to the E820 consumer.
+    //
+    case CB_MEM_VENDOR_RSVD:
+    case CB_MEM_TABLE:
+      return 2;  // E820_RESERVED
+    case CB_MEM_SOFT_RESERVED:
+      return 0xefffffff;  // E820_SOFT_RESERVED
+    default:
+      //
+      // Anything unknown should not be given to the OS as usable.
+      //
+      return 8;  // E820_UNDEFINED
+  }
+}
+
+/**
   Convert a packed value from cbuint64 to a UINT64 value.
 
   @param  val      The pointer to packed data.
@@ -400,7 +441,7 @@ ParseMemoryInfo (
     Range          = MEM_RANGE_PTR (Rec, Index);
     MemoryMap.Base = cb_unpack64 (Range->start);
     MemoryMap.Size = cb_unpack64 (Range->size);
-    MemoryMap.Type = (UINT8)Range->type;
+    MemoryMap.Type = CbMemTypeToE820Type (Range->type);
     MemoryMap.Flag = 0;
     MemInfoCallback (&MemoryMap, Params);
   }

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -386,7 +386,7 @@ ParseMemoryInfo (
   CB_MEMORY               *Rec;
   struct cb_memory_range  *Range;
   UINTN                   Index;
-  MEMORY_MAP_ENTRY        MemoryMap;
+  BL_MEMORY_MAP_ENTRY     MemoryMap;
 
   //
   // Get the coreboot memory table

--- a/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
+++ b/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
@@ -94,8 +94,9 @@ ParseMemoryInfo (
   IN  VOID                  *Params
   )
 {
-  MEMORY_MAP_INFO  *MemoryMapInfo;
-  UINTN            Idx;
+  MEMORY_MAP_INFO     *MemoryMapInfo;
+  BL_MEMORY_MAP_ENTRY  MemoryMap;
+  UINTN                Idx;
 
   MemoryMapInfo = (MEMORY_MAP_INFO *)GetGuidHobDataFromSbl (&gLoaderMemoryMapInfoGuid);
   if (MemoryMapInfo == NULL) {
@@ -104,7 +105,15 @@ ParseMemoryInfo (
   }
 
   for (Idx = 0; Idx < MemoryMapInfo->Count; Idx++) {
-    MemInfoCallback (&MemoryMapInfo->Entry[Idx], Params);
+    MemoryMap.Base = MemoryMapInfo->Entry[Idx].Base;
+    MemoryMap.Size = MemoryMapInfo->Entry[Idx].Size;
+    MemoryMap.Type = MemoryMapInfo->Entry[Idx].Type;
+    MemoryMap.Flag = MemoryMapInfo->Entry[Idx].Flag;
+    MemInfoCallback (&MemoryMap, Params);
+    MemoryMapInfo->Entry[Idx].Base = MemoryMap.Base;
+    MemoryMapInfo->Entry[Idx].Size = MemoryMap.Size;
+    MemoryMapInfo->Entry[Idx].Type = (UINT8)MemoryMap.Type;
+    MemoryMapInfo->Entry[Idx].Flag = MemoryMap.Flag;
   }
 
   return RETURN_SUCCESS;

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -55,7 +55,9 @@ MemInfoCallbackMmio (
   //
   // Skip types already handled in MemInfoCallback
   //
-  if ((MemoryMapEntry->Type == E820_RAM) || (MemoryMapEntry->Type == E820_ACPI)) {
+  if ((MemoryMapEntry->Type == E820_RAM) || (MemoryMapEntry->Type == E820_ACPI) ||
+      (MemoryMapEntry->Type == E820_SOFT_RESERVED))
+  {
     return EFI_SUCCESS;
   }
 
@@ -298,7 +300,7 @@ MemInfoCallback (
   // It will be added later.
   //
   if ((MemoryMapEntry->Type != E820_RAM) && (MemoryMapEntry->Type != E820_ACPI) &&
-      (MemoryMapEntry->Type != E820_NVS))
+      (MemoryMapEntry->Type != E820_NVS) && (MemoryMapEntry->Type != E820_SOFT_RESERVED))
   {
     return RETURN_SUCCESS;
   }
@@ -314,6 +316,10 @@ MemInfoCallback (
               EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
               EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
               EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE;
+
+  if (MemoryMapEntry->Type == E820_SOFT_RESERVED) {
+    Attribute |= EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE;
+  }
 
   BuildResourceDescriptorHob (Type, Attribute, (EFI_PHYSICAL_ADDRESS)Base, Size);
   DEBUG ((DEBUG_INFO, "buildhob: base = 0x%lx, size = 0x%lx, type = 0x%x\n", Base, Size, Type));

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -37,8 +37,8 @@ EFI_MEMORY_TYPE_INFORMATION  mDefaultMemoryTypeInformation[] = {
 **/
 EFI_STATUS
 MemInfoCallbackMmio (
-  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  IN VOID              *Params
+  IN BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID                 *Params
   )
 {
   EFI_PHYSICAL_ADDRESS         Base;
@@ -116,8 +116,8 @@ MemInfoCallbackMmio (
 **/
 EFI_STATUS
 FindToludCallback (
-  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  IN VOID              *Params
+  IN BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID                 *Params
   )
 {
   //
@@ -185,13 +185,13 @@ FindToludCallback (
 **/
 EFI_STATUS
 FindFreeMemForHobCallback (
-  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  IN VOID              *Params
+  IN BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID                 *Params
   )
 {
-  EFI_STATUS        Status;
-  MEMORY_MAP_ENTRY  MemoryMapEntrySplit;
-  UINTN             *HobMemBase = (UINTN *)Params;
+  EFI_STATUS           Status;
+  BL_MEMORY_MAP_ENTRY  MemoryMapEntrySplit;
+  UINTN                *HobMemBase = (UINTN *)Params;
 
   //
   // Found new base, nothing to do
@@ -284,8 +284,8 @@ FindFreeMemForHobCallback (
 **/
 EFI_STATUS
 MemInfoCallback (
-  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  IN VOID              *Params
+  IN BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID                 *Params
   )
 {
   EFI_PHYSICAL_ADDRESS         Base;

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.h
@@ -53,6 +53,7 @@
 #define E820_DISABLED   6
 #define E820_PMEM       7
 #define E820_UNDEFINED  8
+#define E820_SOFT_RESERVED  0xefffffff
 
 /**
   Add a new HOB to the HOB List.


### PR DESCRIPTION
# Description

Translate coreboot memory types to E820 values before passing them to
UefiPayloadEntry. Preserve soft-reserved memory as EFI_MEMORY_SP and map
vendor and table ranges to reserved memory.

Depends on #12913, which widens the internal BlParseLib memory type
without changing Slim Bootloader's packed HOB.

This revives #12228, which was approved and then closed by the stale bot.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- PatchCheck.py passes.
- A clean Stuart X64 GCC FIT build of UefiPayloadPkg passes.

## Integration Instructions

N/A