### PR TITLE
UefiPayloadPkg/GraphicsOutputDxe: Accept framebuffer BAR offsets

### DIFF
--- a/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
+++ b/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
@@ -435,8 +435,11 @@ GraphicsOutputDriverBindingStart (
             }
 
             if (DeviceInfo->BarIndex == MAX_UINT8) {
-              if (Resources->AddrRangeMin == GraphicsInfo->FrameBufferBase) {
-                FrameBufferBase = Resources->AddrRangeMin;
+              if (  (GraphicsInfo->FrameBufferBase >= Resources->AddrRangeMin)
+                 && (GraphicsInfo->FrameBufferBase - Resources->AddrRangeMin <=
+                     Resources->AddrLen - GraphicsInfo->FrameBufferSize))
+              {
+                FrameBufferBase = GraphicsInfo->FrameBufferBase;
                 break;
               }
             } else {


### PR DESCRIPTION
# Description

Allow UefiPayloadPkg to use a framebuffer that starts at an offset within
its PCI BAR. The BAR containment check uses subtraction so malformed ranges
cannot wrap the address calculation.

This revives #12231, which was approved and then closed by the stale bot.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- PatchCheck.py passes.
- A clean Stuart IA32/X64 GCC DEBUG build of UefiPayloadPkg passes.

## Integration Instructions

N/A
