### PR TITLE
MdeModulePkg: Handle faulting USB devices

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -819,6 +819,7 @@ XhcTransfer (
       DEBUG ((DEBUG_ERROR, "XhcTransfer[Type=%d]: pending URB is finished, Length = %d.\n", Type, Urb->Completed));
     } else if (EFI_ERROR (RecoveryStatus)) {
       DEBUG ((DEBUG_ERROR, "XhcTransfer[Type=%d]: XhcDequeueTrbFromEndpoint failed!\n", Type));
+      Status = RecoveryStatus;
     }
   }
 

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -1286,6 +1286,58 @@ EXIT:
 }
 
 /**
+  Check whether an endpoint is in the Running state.
+
+  @param  Xhc     The XHCI instance.
+  @param  SlotId  The slot id.
+  @param  Dci     The device context index.
+
+  @retval TRUE    The endpoint is in the Running state.
+  @retval FALSE   The endpoint is not in the Running state.
+
+**/
+STATIC
+BOOLEAN
+EFIAPI
+XhcEndpointRunning (
+  IN USB_XHCI_INSTANCE  *Xhc,
+  IN UINT8              SlotId,
+  IN UINT8              Dci
+  )
+{
+  DEVICE_CONTEXT  *OutputContext;
+
+  OutputContext = Xhc->UsbDevContext[SlotId].OutputContext;
+  return OutputContext && OutputContext->EP[Dci - 1].EPState == 1;
+}
+
+/**
+  Check whether an endpoint is in the Halted state.
+
+  @param  Xhc     The XHCI instance.
+  @param  SlotId  The slot id.
+  @param  Dci     The device context index.
+
+  @retval TRUE    The endpoint is in the Halted state.
+  @retval FALSE   The endpoint is not in the Halted state.
+
+**/
+STATIC
+BOOLEAN
+EFIAPI
+XhcEndpointHalted (
+  IN USB_XHCI_INSTANCE  *Xhc,
+  IN UINT8              SlotId,
+  IN UINT8              Dci
+  )
+{
+  DEVICE_CONTEXT  *OutputContext;
+
+  OutputContext = Xhc->UsbDevContext[SlotId].OutputContext;
+  return OutputContext && OutputContext->EP[Dci - 1].EPState == 2;
+}
+
+/**
   Execute the transfer by polling the URB. This is a synchronous operation.
 
   @param  Xhc               The XHCI Instance.
@@ -1333,6 +1385,10 @@ XhcExecTransfer (
     ASSERT (Dci < 32);
   }
 
+  if (!CmdTransfer && XhcEndpointHalted (Xhc, SlotId, Dci)) {
+    goto DONE;
+  }
+
   if (Timeout == 0) {
     IndefiniteTimeout = TRUE;
   }
@@ -1363,9 +1419,15 @@ XhcExecTransfer (
     ElapsedTicks += TicksDelta;
   } while (IndefiniteTimeout || ElapsedTicks < TimeoutTicks);
 
+DONE:
   if (!Finished) {
-    Urb->Result = EFI_USB_ERR_TIMEOUT;
-    Status      = EFI_TIMEOUT;
+    if (XhcEndpointHalted (Xhc, SlotId, Dci)) {
+      Urb->Result = EFI_USB_ERR_STALL;
+      Status      = EFI_DEVICE_ERROR;
+    } else {
+      Urb->Result = EFI_USB_ERR_TIMEOUT;
+      Status      = EFI_TIMEOUT;
+    }
   } else if (Urb->Result != EFI_USB_NOERROR) {
     Status = EFI_DEVICE_ERROR;
   }
@@ -3475,6 +3537,22 @@ XhcStopEndpoint (
   DEBUG ((DEBUG_VERBOSE, "XhcStopEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
 
   EvtTrb = NULL;
+
+  if (XhcEndpointHalted (Xhc, SlotId, Dci)) {
+    if (PendingUrb != NULL) {
+      PendingUrb->Result = EFI_USB_ERR_STALL;
+    }
+
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (!XhcEndpointRunning (Xhc, SlotId, Dci)) {
+    if (PendingUrb != NULL) {
+      PendingUrb->Result = EFI_USB_ERR_SYSTEM;
+    }
+
+    return EFI_DEVICE_ERROR;
+  }
 
   //
   // When XhcCheckUrbResult waits for the Stop_Endpoint completion, it also checks

--- a/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBoot.c
+++ b/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBoot.c
@@ -281,7 +281,7 @@ UsbBootExecCmdWithRetry (
                DataLen,
                Timeout
                );
-    if ((Status == EFI_SUCCESS) || (Status == EFI_NO_MEDIA)) {
+    if ((Status == EFI_SUCCESS) || (Status == EFI_NO_MEDIA) || (Status == EFI_DEVICE_ERROR)) {
       break;
     }
 


### PR DESCRIPTION
# Description

Return promptly when a faulty USB device halts or stops an xHCI endpoint.
The change reports the endpoint error, propagates dequeue failures and stops
retrying mass-storage commands after a device error.

This revives #12232, which was approved and then closed by the stale bot.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- PatchCheck.py passes.
- A clean Stuart IA32/X64 GCC DEBUG build of MdeModulePkg passes.

## Integration Instructions

N/A
