### PR TITLE
UefiPayloadPkg: Hide boot hints when timeout is zero

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -355,6 +355,10 @@ PlatformBootManagerAfterConsole (
   //
   PlatformRegisterFvBootOption (&gUefiShellFileGuid, L"UEFI Shell", LOAD_OPTION_ACTIVE);
 
+  if (PcdGet16 (PcdPlatformBootTimeOut) == 0) {
+    return;
+  }
+
   if (FixedPcdGetBool (PcdBootManagerEscape)) {
     Print (
       L"\n"


### PR DESCRIPTION
# Description

Do not print setup and boot-menu key hints when the configured boot timeout
is zero and there is no opportunity to use them. Console setup, capsule
processing and boot-option registration still run before this check.

This revives #12341, which was closed by the stale bot.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- PatchCheck.py passes.
- A clean Stuart IA32/X64 GCC DEBUG build of UefiPayloadPkg passes.

## Integration Instructions

N/A
