### PR TITLE
UefiPayloadPkg: make FMP PKCS7 PCD include path overridable

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -56,6 +56,12 @@
   #
   DEFINE CAPSULE_SUPPORT              = FALSE
   DEFINE CAPSULE_MAIN_FW_GUID         =
+  #
+  # Path (relative to WORKSPACE) for PcdFmpDevicePkcs7CertBufferXdr DSC include.
+  # Default: Tianocore test cert. Override with build -D FMP_DEVICE_PKCS7_PCD_INC=<path>
+  # so platforms can point at a build-local generated file under Conf/ (or elsewhere).
+  #
+  DEFINE FMP_DEVICE_PKCS7_PCD_INC     = BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
 
   #
   # Crypto Support
@@ -998,7 +1004,7 @@
       #
       # See BaseTools/Source/Python/Pkcs7Sign/Readme.md for more details on such
       # PCDs and include files.
-      !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+      !include $(FMP_DEVICE_PKCS7_PCD_INC)
     <LibraryClasses>
 !if $(BOOTLOADER) == "COREBOOT"
       FmpDeviceLib|UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf


### PR DESCRIPTION
## Description

Allow platform builds to select the generated PKCS7 certificate include without modifying `UefiPayloadPkg.dsc`. The default remains the existing TianoCore test certificate.

This is the first change split from #12342 so each capsule reliability change can be reviewed independently.

## How This Was Tested

- `PatchCheck.py`
- `stuart_build` for UefiPayloadPkg X64 FIT
- IA32/X64 FIT build with `CAPSULE_SUPPORT=TRUE` and a build-local `FMP_DEVICE_PKCS7_PCD_INC`

## Integration Instructions

None.