### PR TITLE
UefiPayloadPkg/SmmStoreLib: honor SMI retry delay

### DIFF
--- a/UefiPayloadPkg/Library/SmmStoreLib/X64/SmmStore.nasm
+++ b/UefiPayloadPkg/Library/SmmStoreLib/X64/SmmStore.nasm
@@ -37,8 +37,12 @@ ASM_PFX(TriggerSmi):
     jne     @Return                     ; SMM modified rax, return now
     push    rcx                         ; save rcx to stack
     mov     rcx, 10000
-    rep     pause                       ; add a small delay
+@Pause:
+    pause                               ; add a small delay
+    loop    @Pause
     pop     rcx                         ; restore rcx
+    cmp     rax, rcx                    ; Check for a response during the delay
+    jne     @Return
     cmp     r8, 0
     je      @Return
     dec     r8


### PR DESCRIPTION
## Description

`TriggerSmi()` loads RCX with 10,000 before `rep pause`, but `PAUSE` already
uses the REP prefix and does not consume RCX. The retry path therefore waits
for one instruction rather than the intended delay.

Use an explicit loop and retain the existing delay and retry counts. Check RAX
again after the delay so a response received while waiting is returned without
triggering another SMI.

This replaces the broader SMMSTORE retry change from #12342; it does not call
boot services from the runtime path or replay operations after an explicit SMM
response.

## How This Was Tested

- `PatchCheck.py`
- standalone X64 NASM assembly and disassembly
- `stuart_build` for UefiPayloadPkg X64 FIT
- IA32/X64 FIT build with SMMSTORE variables

## Integration Instructions

None.
