### PR TITLE
UefiPayloadPkg: skip ConnectAll on S4 resume

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -320,8 +320,13 @@ PlatformBootManagerAfterConsole (
     BootLogoEnableLogo ();
   }
 
-  EfiBootManagerConnectAll ();
-  EfiBootManagerRefreshAllBootOption ();
+  //
+  // Connecting removable media can perturb the memory map used for S4 resume.
+  //
+  if (GetBootModeHob () != BOOT_ON_S4_RESUME) {
+    EfiBootManagerConnectAll ();
+    EfiBootManagerRefreshAllBootOption ();
+  }
 
   //
   // Active BOOT_ON_FLASH_UPDATE mode means that at least one capsule has been


### PR DESCRIPTION
## Description

Do not globally connect devices or refresh boot options during S4 resume. Connecting removable media can change the DXE handle graph and EFI memory map from the hibernation image. Other boot modes retain the existing behavior.

This revives the second change from stale #12310 as a standalone patch.

## How This Was Tested

- `PatchCheck.py`
- `stuart_build` for UefiPayloadPkg X64 FIT
- Equivalent patch tested on StarBook MTL (B7-U): Linux S4 hibernate and resume with direct Universal Payload

## Integration Instructions

None.