### PR TITLE
UefiPayloadPkg: scope coreboot capsule updates with RMAP

### DIFF
--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.c
@@ -1,6 +1,7 @@
 /** @file
   Internal retry helpers for SMMSTORE-backed firmware updates.
 
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -8,6 +9,12 @@
 
 #include "FmpDeviceSmmFlashRetry.h"
 
+/**
+  Delay after a failed flash operation when a stall callback is available.
+
+  @param[in] FlashIo  Flash operation callbacks.
+  @param[in] Attempt  Failed attempt number.
+**/
 STATIC
 VOID
 StallAfterFailure (
@@ -20,6 +27,19 @@ StallAfterFailure (
   }
 }
 
+/**
+  Read from flash, retrying transient failures and short reads.
+
+  @param[in]     FlashIo   Flash operation callbacks.
+  @param[in]     Lba       Flash block number.
+  @param[in]     Offset    Offset within the block.
+  @param[in,out] NumBytes  Requested and actual byte count.
+  @param[out]    Buffer    Destination buffer.
+
+  @retval EFI_SUCCESS           The requested bytes were read.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @return                       The final flash read error.
+**/
 EFI_STATUS
 FmpDeviceFlashReadWithRetry (
   IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
@@ -57,6 +77,16 @@ FmpDeviceFlashReadWithRetry (
   return EFI_ERROR (Status) ? Status : EFI_DEVICE_ERROR;
 }
 
+/**
+  Erase a flash block, retrying transient failures.
+
+  @param[in] FlashIo  Flash operation callbacks.
+  @param[in] Lba      Flash block number.
+
+  @retval EFI_SUCCESS           The block was erased.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @return                       The final flash erase error.
+**/
 EFI_STATUS
 FmpDeviceFlashEraseWithRetry (
   IN CONST FMP_DEVICE_FLASH_IO  *FlashIo,
@@ -83,6 +113,19 @@ FmpDeviceFlashEraseWithRetry (
   return Status;
 }
 
+/**
+  Write to flash, retrying transient failures and short writes.
+
+  @param[in]     FlashIo   Flash operation callbacks.
+  @param[in]     Lba       Flash block number.
+  @param[in]     Offset    Offset within the block.
+  @param[in,out] NumBytes  Requested and actual byte count.
+  @param[in]     Buffer    Source buffer.
+
+  @retval EFI_SUCCESS           The requested bytes were written.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @return                       The final flash write error.
+**/
 EFI_STATUS
 FmpDeviceFlashWriteWithRetry (
   IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
@@ -120,6 +163,19 @@ FmpDeviceFlashWriteWithRetry (
   return EFI_ERROR (Status) ? Status : EFI_DEVICE_ERROR;
 }
 
+/**
+  Read back and verify a programmed flash block.
+
+  @param[in]  FlashIo      Flash operation callbacks.
+  @param[in]  Lba          Flash block number.
+  @param[in]  Expected     Expected block contents.
+  @param[out] VerifyBuffer Scratch buffer for the readback.
+  @param[in]  BlockSize    Flash block size.
+
+  @retval EFI_SUCCESS           The block matches Expected.
+  @retval EFI_DEVICE_ERROR      The block could not be read.
+  @retval EFI_VOLUME_CORRUPTED  The block contents differ.
+**/
 STATIC
 EFI_STATUS
 VerifyFlashWrite (
@@ -142,6 +198,19 @@ VerifyFlashWrite (
   return (CompareMem (VerifyBuffer, Expected, BlockSize) == 0) ? EFI_SUCCESS : EFI_VOLUME_CORRUPTED;
 }
 
+/**
+  Erase, write and verify a complete flash block with retries.
+
+  @param[in]  FlashIo      Flash operation callbacks.
+  @param[in]  Lba          Flash block number.
+  @param[in]  Expected     Block contents to program.
+  @param[out] VerifyBuffer Scratch buffer for the readback.
+  @param[in]  BlockSize    Flash block size.
+
+  @retval EFI_SUCCESS           The block was programmed and verified.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+  @return                       The final flash operation error.
+**/
 EFI_STATUS
 FmpDeviceFlashProgramWithRetry (
   IN  CONST FMP_DEVICE_FLASH_IO  *FlashIo,

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.c
@@ -1,0 +1,189 @@
+/** @file
+  Internal retry helpers for SMMSTORE-backed firmware updates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseMemoryLib.h>
+
+#include "FmpDeviceSmmFlashRetry.h"
+
+STATIC
+VOID
+StallAfterFailure (
+  IN CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN UINTN                      Attempt
+  )
+{
+  if (FlashIo->Stall != NULL) {
+    FlashIo->Stall (Attempt);
+  }
+}
+
+EFI_STATUS
+FmpDeviceFlashReadWithRetry (
+  IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN     EFI_LBA                    Lba,
+  IN     UINTN                      Offset,
+  IN OUT UINTN                      *NumBytes,
+  OUT    UINT8                      *Buffer
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       RequestedBytes;
+  UINTN       ActualBytes;
+
+  if ((FlashIo == NULL) || (FlashIo->Read == NULL) || (NumBytes == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  RequestedBytes = *NumBytes;
+  Status         = EFI_DEVICE_ERROR;
+  ActualBytes    = 0;
+
+  for (Attempt = 0; Attempt < FMP_DEVICE_SMM_FLASH_RETRY_COUNT; ++Attempt) {
+    ActualBytes = RequestedBytes;
+    Status      = FlashIo->Read (Lba, Offset, &ActualBytes, Buffer);
+    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
+      *NumBytes = ActualBytes;
+      return EFI_SUCCESS;
+    }
+
+    *NumBytes = ActualBytes;
+    StallAfterFailure (FlashIo, Attempt);
+  }
+
+  return EFI_ERROR (Status) ? Status : EFI_DEVICE_ERROR;
+}
+
+EFI_STATUS
+FmpDeviceFlashEraseWithRetry (
+  IN CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN EFI_LBA                    Lba
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+
+  if ((FlashIo == NULL) || (FlashIo->Erase == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_DEVICE_ERROR;
+  for (Attempt = 0; Attempt < FMP_DEVICE_SMM_FLASH_RETRY_COUNT; ++Attempt) {
+    Status = FlashIo->Erase (Lba);
+    if (!EFI_ERROR (Status)) {
+      return EFI_SUCCESS;
+    }
+
+    StallAfterFailure (FlashIo, Attempt);
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+FmpDeviceFlashWriteWithRetry (
+  IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN     EFI_LBA                    Lba,
+  IN     UINTN                      Offset,
+  IN OUT UINTN                      *NumBytes,
+  IN     UINT8                      *Buffer
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       RequestedBytes;
+  UINTN       ActualBytes;
+
+  if ((FlashIo == NULL) || (FlashIo->Write == NULL) || (NumBytes == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  RequestedBytes = *NumBytes;
+  Status         = EFI_DEVICE_ERROR;
+  ActualBytes    = 0;
+
+  for (Attempt = 0; Attempt < FMP_DEVICE_SMM_FLASH_RETRY_COUNT; ++Attempt) {
+    ActualBytes = RequestedBytes;
+    Status      = FlashIo->Write (Lba, Offset, &ActualBytes, Buffer);
+    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
+      *NumBytes = ActualBytes;
+      return EFI_SUCCESS;
+    }
+
+    *NumBytes = ActualBytes;
+    StallAfterFailure (FlashIo, Attempt);
+  }
+
+  return EFI_ERROR (Status) ? Status : EFI_DEVICE_ERROR;
+}
+
+STATIC
+EFI_STATUS
+VerifyFlashWrite (
+  IN  CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN  EFI_LBA                    Lba,
+  IN  CONST UINT8                *Expected,
+  OUT UINT8                      *VerifyBuffer,
+  IN  UINTN                      BlockSize
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+
+  NumBytes = BlockSize;
+  Status   = FmpDeviceFlashReadWithRetry (FlashIo, Lba, 0, &NumBytes, VerifyBuffer);
+  if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  return (CompareMem (VerifyBuffer, Expected, BlockSize) == 0) ? EFI_SUCCESS : EFI_VOLUME_CORRUPTED;
+}
+
+EFI_STATUS
+FmpDeviceFlashProgramWithRetry (
+  IN  CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN  EFI_LBA                    Lba,
+  IN  CONST UINT8                *Expected,
+  OUT UINT8                      *VerifyBuffer,
+  IN  UINTN                      BlockSize
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       NumBytes;
+
+  if ((FlashIo == NULL) || (FlashIo->Read == NULL) || (FlashIo->Write == NULL) ||
+      (FlashIo->Erase == NULL) || (Expected == NULL) || (VerifyBuffer == NULL) || (BlockSize == 0))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_DEVICE_ERROR;
+  for (Attempt = 0; Attempt < FMP_DEVICE_SMM_FLASH_RETRY_COUNT; ++Attempt) {
+    Status = FmpDeviceFlashEraseWithRetry (FlashIo, Lba);
+    if (EFI_ERROR (Status)) {
+      StallAfterFailure (FlashIo, Attempt);
+      continue;
+    }
+
+    NumBytes = BlockSize;
+    Status   = FmpDeviceFlashWriteWithRetry (FlashIo, Lba, 0, &NumBytes, (UINT8 *)Expected);
+    if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
+      Status = EFI_DEVICE_ERROR;
+      StallAfterFailure (FlashIo, Attempt);
+      continue;
+    }
+
+    Status = VerifyFlashWrite (FlashIo, Lba, Expected, VerifyBuffer, BlockSize);
+    if (!EFI_ERROR (Status)) {
+      return EFI_SUCCESS;
+    }
+
+    StallAfterFailure (FlashIo, Attempt);
+  }
+
+  return Status;
+}

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.h
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.h
@@ -1,6 +1,7 @@
 /** @file
   Internal retry helpers for SMMSTORE-backed firmware updates.
 
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.h
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmFlashRetry.h
@@ -1,0 +1,73 @@
+/** @file
+  Internal retry helpers for SMMSTORE-backed firmware updates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Uefi.h>
+
+#define FMP_DEVICE_SMM_FLASH_RETRY_COUNT  4
+
+typedef EFI_STATUS (*FMP_DEVICE_FLASH_READ)(
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  OUT    UINT8    *Buffer
+  );
+
+typedef EFI_STATUS (*FMP_DEVICE_FLASH_WRITE)(
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  IN     UINT8    *Buffer
+  );
+
+typedef EFI_STATUS (*FMP_DEVICE_FLASH_ERASE)(
+  IN EFI_LBA  Lba
+  );
+
+typedef VOID (*FMP_DEVICE_FLASH_STALL)(
+  IN UINTN  Attempt
+  );
+
+typedef struct {
+  FMP_DEVICE_FLASH_READ     Read;
+  FMP_DEVICE_FLASH_WRITE    Write;
+  FMP_DEVICE_FLASH_ERASE    Erase;
+  FMP_DEVICE_FLASH_STALL    Stall;
+} FMP_DEVICE_FLASH_IO;
+
+EFI_STATUS
+FmpDeviceFlashReadWithRetry (
+  IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN     EFI_LBA                    Lba,
+  IN     UINTN                      Offset,
+  IN OUT UINTN                      *NumBytes,
+  OUT    UINT8                      *Buffer
+  );
+
+EFI_STATUS
+FmpDeviceFlashEraseWithRetry (
+  IN CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN EFI_LBA                    Lba
+  );
+
+EFI_STATUS
+FmpDeviceFlashWriteWithRetry (
+  IN     CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN     EFI_LBA                    Lba,
+  IN     UINTN                      Offset,
+  IN OUT UINTN                      *NumBytes,
+  IN     UINT8                      *Buffer
+  );
+
+EFI_STATUS
+FmpDeviceFlashProgramWithRetry (
+  IN  CONST FMP_DEVICE_FLASH_IO  *FlashIo,
+  IN  EFI_LBA                    Lba,
+  IN  CONST UINT8                *Expected,
+  OUT UINT8                      *VerifyBuffer,
+  IN  UINTN                      BlockSize
+  );

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -22,6 +22,7 @@
 #include <PiDxe.h>
 #include <Guid/FirmwareInfoGuid.h>
 #include <Guid/SystemResourceTable.h>
+#include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/FmpDeviceLib.h>
@@ -39,20 +40,20 @@
 
 #pragma pack(1)
 typedef struct {
-  CHAR8   Signature[8];
-  UINT8   VerMajor;
-  UINT8   VerMinor;
-  UINT64  Base;
-  UINT32  Size;
-  CHAR8   Name[32];
-  UINT16  AreaCount;
+  CHAR8     Signature[8];
+  UINT8     VerMajor;
+  UINT8     VerMinor;
+  UINT64    Base;
+  UINT32    Size;
+  CHAR8     Name[32];
+  UINT16    AreaCount;
 } FMAP_HEADER;
 
 typedef struct {
-  UINT32  Offset;
-  UINT32  Size;
-  CHAR8   Name[32];
-  UINT16  Flags;
+  UINT32    Offset;
+  UINT32    Size;
+  CHAR8     Name[32];
+  UINT16    Flags;
 } FMAP_AREA;
 #pragma pack()
 
@@ -64,13 +65,13 @@ typedef struct {
 #define REGION_MANIFEST_VERSION    1
 
 typedef struct {
-  UINT32  Signature;
-  UINT16  Version;
-  UINT16  EntryCount;
+  UINT32    Signature;
+  UINT16    Version;
+  UINT16    EntryCount;
 } REGION_MANIFEST_TRAILER;
 
 typedef struct {
-  CHAR8  RegionName[16];
+  CHAR8    RegionName[16];
 } REGION_MANIFEST_ENTRY;
 
 STATIC
@@ -224,13 +225,13 @@ LoadFlashFmap (
   OUT VOID               **FlashFmapBuffer
   )
 {
-  EFI_STATUS    Status;
-  CONST CHAR8   FmapAreaName[16] = "FMAP";
-  UINTN         FmapAreaOffset;
-  UINTN         FmapAreaSize;
-  VOID          *Buffer;
-  UINTN         FoundOffset;
-  UINTN         FoundLength;
+  EFI_STATUS   Status;
+  CONST CHAR8  FmapAreaName[16] = "FMAP";
+  UINTN        FmapAreaOffset;
+  UINTN        FmapAreaSize;
+  VOID         *Buffer;
+  UINTN        FoundOffset;
+  UINTN        FoundLength;
 
   if ((CapsuleFmapHeader == NULL) || (CapsuleFmapAreas == NULL) || (FlashFmapHeader == NULL) || (FlashFmapAreas == NULL) || (FlashFmapBuffer == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -290,11 +291,11 @@ LoadFlashFmap (
 STATIC
 EFI_STATUS
 LocateRegionManifest (
-  IN  CONST UINT8               *Image,
-  IN  UINTN                     ImageSize,
-  OUT UINTN                     *EntryCount,
+  IN  CONST UINT8                  *Image,
+  IN  UINTN                        ImageSize,
+  OUT UINTN                        *EntryCount,
   OUT CONST REGION_MANIFEST_ENTRY  **Entries,
-  OUT UINTN                     *FirmwareImageSize
+  OUT UINTN                        *FirmwareImageSize
   )
 {
   CONST REGION_MANIFEST_TRAILER  *Trailer;
@@ -352,42 +353,21 @@ FindFmapRegion (
   )
 {
   UINTN  Index;
-  UINTN  CharIndex;
+  CHAR8  FmapName[33];
+  CHAR8  ManifestName[17];
 
   for (Index = 0; Index < AreaCount; ++Index) {
     //
     // Manifest names are 16-byte, zero-padded strings, while FMAP uses 32-byte
-    // names. Compare the first 16 bytes, ensuring the FMAP name does not have
-    // additional non-zero characters beyond the manifest name.
+    // names. Convert both to NUL-terminated strings and compare.
     //
-    for (CharIndex = 0; CharIndex < 16; ++CharIndex) {
-      if (Areas[Index].Name[CharIndex] != Name[CharIndex]) {
-        break;
-      }
+    CopyMem (FmapName, Areas[Index].Name, 32);
+    FmapName[32] = '\0';
+    CopyMem (ManifestName, Name, 16);
+    ManifestName[16] = '\0';
 
-      if (Name[CharIndex] == 0) {
-        break;
-      }
-    }
-
-    if (CharIndex == 16) {
-      if (Areas[Index].Name[16] != 0) {
-        continue;
-      }
-    } else {
-      if (Areas[Index].Name[CharIndex] != 0) {
-        continue;
-      }
-
-      for (; CharIndex < 16; ++CharIndex) {
-        if (Name[CharIndex] != 0) {
-          break;
-        }
-      }
-
-      if (CharIndex != 16) {
-        continue;
-      }
+    if (AsciiStrCmp (FmapName, ManifestName) != 0) {
+      continue;
     }
 
     *RegionOffset = (UINTN)FmapHeader->Base + Areas[Index].Offset;
@@ -898,11 +878,11 @@ FmpDeviceCheckImageWithStatus (
   OUT UINT32      *LastAttemptStatus
   )
 {
-  EFI_STATUS  Status;
-  UINTN       FwSize;
-  UINTN       BlockSize;
-  UINTN       ManifestEntries;
-  UINTN       FirmwareImageSize;
+  EFI_STATUS                   Status;
+  UINTN                        FwSize;
+  UINTN                        BlockSize;
+  UINTN                        ManifestEntries;
+  UINTN                        FirmwareImageSize;
   CONST REGION_MANIFEST_ENTRY  *ManifestList;
 
   if ((Image == NULL) || (ImageUpdatable == NULL)) {
@@ -1085,6 +1065,12 @@ IncrementProgress (
 /**
   Read an arbitrary flash range into a buffer.
 
+  @param[in]  BlockSize  Flash block size, in bytes.
+  @param[in]  FlashSize  Total flash size, in bytes.
+  @param[in]  Offset     Offset from the start of flash, in bytes.
+  @param[in]  Length     Number of bytes to read.
+  @param[out] Buffer     Destination buffer for the flash contents.
+
   @retval EFI_SUCCESS            The range was read successfully.
   @retval EFI_DEVICE_ERROR       A read failed.
   @retval EFI_INVALID_PARAMETER  Input parameters were invalid.
@@ -1146,6 +1132,17 @@ ReadFlashRange (
 
   This helper preserves bytes outside the requested range within any partially
   covered flash block by read-modify-writing the full block.
+
+  @param[in]      BlockSize            Flash block size, in bytes.
+  @param[in]      Image                Source image buffer.
+  @param[in]      ImageSize            Size of Image, in bytes.
+  @param[in]      RangeOffset          Offset within Image for the update range, in bytes.
+  @param[in]      RangeSize            Size of the update range, in bytes.
+  @param[in,out]  BlockBuffer          Scratch buffer, at least BlockSize bytes.
+  @param[in]      Progress             Optional progress callback.
+  @param[in]      TotalSteps           Total number of progress reporting steps.
+  @param[in,out]  Step                 Current step counter for progress reporting.
+  @param[in,out]  ShouldReportProgress Progress reporting enabled flag.
 
   @retval EFI_SUCCESS            The range was updated successfully.
   @retval EFI_DEVICE_ERROR       A read/erase/write failed.
@@ -1469,31 +1466,31 @@ FmpDeviceSetImageWithStatus (
   OUT UINT32                                         *LastAttemptStatus
   )
 {
-  EFI_STATUS   Status;
-  UINTN        BlockSize;
-  UINTN        BlockCount;
-  UINTN        Block;
-  UINTN        EntryIndex;
-  UINTN        NumBytes;
-  UINTN        TotalSteps;
-  UINTN        Step;
-  BOOLEAN      ShouldReportProgress;
-  VOID         *ReadBuffer;
-  CONST UINT8  *WriteNext;
-  UINTN        ManifestEntryCount;
+  EFI_STATUS                   Status;
+  UINTN                        BlockSize;
+  UINTN                        BlockCount;
+  UINTN                        Block;
+  UINTN                        EntryIndex;
+  UINTN                        NumBytes;
+  UINTN                        TotalSteps;
+  UINTN                        Step;
+  BOOLEAN                      ShouldReportProgress;
+  VOID                         *ReadBuffer;
+  CONST UINT8                  *WriteNext;
+  UINTN                        ManifestEntryCount;
   CONST REGION_MANIFEST_ENTRY  *ManifestEntries;
-  UINTN        BaseImageSize;
-  BOOLEAN      UseManifest;
-  BOOLEAN      UseBiosRegion;
-  UINTN        BiosOffset;
-  UINTN        BiosSize;
-  CONST FMAP_HEADER  *FmapHeader;
-  CONST FMAP_AREA    *FmapAreas;
-  UINTN              FmapOffset;
-  UINTN              FmapLength;
-  VOID               *FlashFmapBuffer;
-  FMAP_HEADER        *FlashFmapHeader;
-  FMAP_AREA          *FlashFmapAreas;
+  UINTN                        BaseImageSize;
+  BOOLEAN                      UseManifest;
+  BOOLEAN                      UseBiosRegion;
+  UINTN                        BiosOffset;
+  UINTN                        BiosSize;
+  CONST FMAP_HEADER            *FmapHeader;
+  CONST FMAP_AREA              *FmapAreas;
+  UINTN                        FmapOffset;
+  UINTN                        FmapLength;
+  VOID                         *FlashFmapBuffer;
+  FMAP_HEADER                  *FlashFmapHeader;
+  FMAP_AREA                    *FlashFmapAreas;
 
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
   BlockCount         = 0;
@@ -1521,7 +1518,7 @@ FmpDeviceSetImageWithStatus (
   // Discover optional manifest and FMAP. If anything looks off, fall back to
   // legacy full-flash behavior.
   //
-  BaseImageSize     = ImageSize;
+  BaseImageSize      = ImageSize;
   ManifestEntryCount = 0;
   ManifestEntries    = NULL;
   UseManifest        = FALSE;
@@ -1541,12 +1538,29 @@ FmpDeviceSetImageWithStatus (
     BaseImageSize      = ImageSize;
     ManifestEntryCount = 0;
     ManifestEntries    = NULL;
+  } else {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a(): found region manifest (%u entr%s), base image size 0x%x\n",
+      __func__,
+      (UINT32)ManifestEntryCount,
+      (ManifestEntryCount == 1) ? "y" : "ies",
+      (UINT32)BaseImageSize
+      ));
   }
 
   Status = LocateFmapInImage (Image, BaseImageSize, &FmapOffset, &FmapLength);
   if (!EFI_ERROR (Status) && ((FmapOffset + FmapLength) <= BaseImageSize)) {
     FmapHeader = (CONST FMAP_HEADER *)((CONST UINT8 *)Image + FmapOffset);
     FmapAreas  = (CONST FMAP_AREA *)((CONST UINT8 *)FmapHeader + sizeof (FMAP_HEADER));
+
+    DEBUG ((
+      DEBUG_INFO,
+      "%a(): found FMAP at 0x%x (%u areas)\n",
+      __func__,
+      (UINT32)FmapOffset,
+      (UINT32)FmapHeader->AreaCount
+      ));
   }
 
   if ((ManifestEntryCount > 0) && (FmapHeader != NULL) && (FmapHeader->AreaCount > 0)) {
@@ -1562,6 +1576,13 @@ FmpDeviceSetImageWithStatus (
     if (!EFI_ERROR (FindFmapRegion (FmapHeader, FmapAreas, FmapHeader->AreaCount, SiBiosName, &BiosOffset, &BiosSize))) {
       if ((BiosSize != 0) && ((BiosOffset + BiosSize) <= BaseImageSize)) {
         UseBiosRegion = TRUE;
+        DEBUG ((
+          DEBUG_INFO,
+          "%a(): no manifest, using SI_BIOS (0x%x+0x%x)\n",
+          __func__,
+          (UINT32)BiosOffset,
+          (UINT32)BiosSize
+          ));
       }
     }
   }
@@ -1578,27 +1599,37 @@ FmpDeviceSetImageWithStatus (
     //
     BOOLEAN     LayoutMismatch;
     EFI_STATUS  FlashFmapStatus;
+    UINTN       MismatchIndex;
+    UINTN       CapsuleRegionOffset;
+    UINTN       CapsuleRegionSize;
+    UINTN       FlashRegionOffset;
+    UINTN       FlashRegionSize;
 
-    LayoutMismatch = FALSE;
-    FlashFmapStatus = LoadFlashFmap (
-                        BlockSize,
-                        BaseImageSize,
-                        FmapHeader,
-                        FmapAreas,
-                        &FlashFmapHeader,
-                        &FlashFmapAreas,
-                        &FlashFmapBuffer
-                        );
+    LayoutMismatch      = FALSE;
+    MismatchIndex       = MAX_UINTN;
+    CapsuleRegionOffset = 0;
+    CapsuleRegionSize   = 0;
+    FlashRegionOffset   = 0;
+    FlashRegionSize     = 0;
+    FlashFmapStatus     = LoadFlashFmap (
+                            BlockSize,
+                            BaseImageSize,
+                            FmapHeader,
+                            FmapAreas,
+                            &FlashFmapHeader,
+                            &FlashFmapAreas,
+                            &FlashFmapBuffer
+                            );
     if (EFI_ERROR (FlashFmapStatus)) {
       LayoutMismatch = TRUE;
+      DEBUG ((DEBUG_WARN, "%a(): failed to load flash FMAP: %r\n", __func__, FlashFmapStatus));
     }
 
     TotalSteps = 0;
     for (EntryIndex = 0; EntryIndex < ManifestEntryCount; ++EntryIndex) {
       UINTN  RegionOffset;
       UINTN  RegionSize;
-      UINTN  FlashRegionOffset;
-      UINTN  FlashRegionSize;
+      CHAR8  RegionName[17];
 
       Status = FindFmapRegion (
                  FmapHeader,
@@ -1609,9 +1640,23 @@ FmpDeviceSetImageWithStatus (
                  &RegionSize
                  );
       if (EFI_ERROR (Status) || (RegionSize == 0) || ((RegionOffset + RegionSize) > BaseImageSize)) {
+        CopyMem (RegionName, ManifestEntries[EntryIndex].RegionName, 16);
+        RegionName[16] = 0;
+        DEBUG ((DEBUG_ERROR, "%a(): invalid manifest region '%a'\n", __func__, RegionName));
         UseManifest = FALSE;
         break;
       }
+
+      CopyMem (RegionName, ManifestEntries[EntryIndex].RegionName, 16);
+      RegionName[16] = 0;
+      DEBUG ((
+        DEBUG_INFO,
+        "%a(): manifest region '%a' capsule 0x%x+0x%x\n",
+        __func__,
+        RegionName,
+        (UINT32)RegionOffset,
+        (UINT32)RegionSize
+        ));
 
       if (!LayoutMismatch) {
         Status = FindFmapRegion (
@@ -1623,7 +1668,14 @@ FmpDeviceSetImageWithStatus (
                    &FlashRegionSize
                    );
         if (EFI_ERROR (Status) || (FlashRegionOffset != RegionOffset) || (FlashRegionSize != RegionSize)) {
-          LayoutMismatch = TRUE;
+          LayoutMismatch      = TRUE;
+          MismatchIndex       = EntryIndex;
+          CapsuleRegionOffset = RegionOffset;
+          CapsuleRegionSize   = RegionSize;
+          if (EFI_ERROR (Status)) {
+            FlashRegionOffset = 0;
+            FlashRegionSize   = 0;
+          }
         }
       }
 
@@ -1641,14 +1693,39 @@ FmpDeviceSetImageWithStatus (
       // flashing the full BIOS region from the new image.
       //
       CONST CHAR8  SiBiosName[16] = "SI_BIOS";
+      CHAR8        RegionName[17];
 
       UseManifest   = FALSE;
       UseBiosRegion = FALSE;
 
+      if (MismatchIndex != MAX_UINTN) {
+        CopyMem (RegionName, ManifestEntries[MismatchIndex].RegionName, 16);
+        RegionName[16] = 0;
+        DEBUG ((
+          DEBUG_WARN,
+          "%a(): FMAP layout mismatch for '%a': flash 0x%x+0x%x vs capsule 0x%x+0x%x\n",
+          __func__,
+          RegionName,
+          (UINT32)FlashRegionOffset,
+          (UINT32)FlashRegionSize,
+          (UINT32)CapsuleRegionOffset,
+          (UINT32)CapsuleRegionSize
+          ));
+      }
+
       if (!EFI_ERROR (FindFmapRegion (FmapHeader, FmapAreas, FmapHeader->AreaCount, SiBiosName, &BiosOffset, &BiosSize))) {
         if ((BiosSize != 0) && ((BiosOffset + BiosSize) <= BaseImageSize)) {
           UseBiosRegion = TRUE;
+          DEBUG ((
+            DEBUG_WARN,
+            "%a(): flashing SI_BIOS instead (0x%x+0x%x)\n",
+            __func__,
+            (UINT32)BiosOffset,
+            (UINT32)BiosSize
+            ));
         }
+      } else {
+        DEBUG ((DEBUG_WARN, "%a(): unable to locate SI_BIOS for fallback\n", __func__));
       }
     }
   }

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -61,8 +61,10 @@ typedef struct {
 // Simple manifest that lists FMAP region names to be flashed. The manifest is
 // appended at the end of the capsule payload and is ignored when absent.
 //
-#define REGION_MANIFEST_SIGNATURE  SIGNATURE_32('R','M','A','P')
-#define REGION_MANIFEST_VERSION    1
+#define REGION_MANIFEST_SIGNATURE      SIGNATURE_32 ('R', 'M', 'A', 'P')
+#define REGION_MANIFEST_VERSION        1
+#define SMMSTORE_FLASH_RETRY_COUNT     4
+#define SMMSTORE_FLASH_RETRY_STALL_US  500
 
 typedef struct {
   UINT32    Signature;
@@ -73,6 +75,190 @@ typedef struct {
 typedef struct {
   CHAR8    RegionName[16];
 } REGION_MANIFEST_ENTRY;
+
+STATIC
+VOID
+StallBetweenFlashAttempts (
+  IN UINTN  Attempt
+  )
+{
+  if ((gBS != NULL) && (gBS->Stall != NULL)) {
+    gBS->Stall ((Attempt + 1) * SMMSTORE_FLASH_RETRY_STALL_US);
+  }
+}
+
+STATIC
+EFI_STATUS
+ReadAnyBlockWithRetry (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  OUT    VOID     *Buffer
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       RequestedBytes;
+  UINTN       ActualBytes;
+
+  if ((NumBytes == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  RequestedBytes = *NumBytes;
+  Status         = EFI_DEVICE_ERROR;
+  ActualBytes    = 0;
+
+  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
+    ActualBytes = RequestedBytes;
+    Status      = SmmStoreLibReadAnyBlock (Lba, Offset, &ActualBytes, Buffer);
+    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
+      *NumBytes = ActualBytes;
+      return EFI_SUCCESS;
+    }
+
+    *NumBytes = ActualBytes;
+    StallBetweenFlashAttempts (Attempt);
+  }
+
+  if (!EFI_ERROR (Status)) {
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  return Status;
+}
+
+STATIC
+EFI_STATUS
+EraseAnyBlockWithRetry (
+  IN EFI_LBA  Lba
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+
+  Status = EFI_DEVICE_ERROR;
+  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
+    Status = SmmStoreLibEraseAnyBlock (Lba);
+    if (!EFI_ERROR (Status)) {
+      return EFI_SUCCESS;
+    }
+
+    StallBetweenFlashAttempts (Attempt);
+  }
+
+  return Status;
+}
+
+STATIC
+EFI_STATUS
+WriteAnyBlockWithRetry (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  IN     VOID     *Buffer
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       RequestedBytes;
+  UINTN       ActualBytes;
+
+  if ((NumBytes == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  RequestedBytes = *NumBytes;
+  Status         = EFI_DEVICE_ERROR;
+  ActualBytes    = 0;
+
+  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
+    ActualBytes = RequestedBytes;
+    Status      = SmmStoreLibWriteAnyBlock (Lba, Offset, &ActualBytes, Buffer);
+    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
+      *NumBytes = ActualBytes;
+      return EFI_SUCCESS;
+    }
+
+    *NumBytes = ActualBytes;
+    StallBetweenFlashAttempts (Attempt);
+  }
+
+  if (!EFI_ERROR (Status)) {
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  return Status;
+}
+
+STATIC
+EFI_STATUS
+VerifyAnyBlockWrite (
+  IN  EFI_LBA      Lba,
+  IN  CONST UINT8  *Expected,
+  OUT UINT8        *VerifyBuffer,
+  IN  UINTN        BlockSize
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+
+  if ((Expected == NULL) || (VerifyBuffer == NULL) || (BlockSize == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NumBytes = BlockSize;
+  Status   = ReadAnyBlockWithRetry (Lba, 0, &NumBytes, VerifyBuffer);
+  if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  return (CompareMem (VerifyBuffer, Expected, BlockSize) == 0) ? EFI_SUCCESS : EFI_VOLUME_CORRUPTED;
+}
+
+STATIC
+EFI_STATUS
+ProgramAnyBlockWithRetry (
+  IN  EFI_LBA      Lba,
+  IN  CONST UINT8  *Expected,
+  OUT UINT8        *VerifyBuffer,
+  IN  UINTN        BlockSize
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       Attempt;
+  UINTN       NumBytes;
+
+  if ((Expected == NULL) || (VerifyBuffer == NULL) || (BlockSize == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = EFI_DEVICE_ERROR;
+  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
+    Status = EraseAnyBlockWithRetry (Lba);
+    if (EFI_ERROR (Status)) {
+      StallBetweenFlashAttempts (Attempt);
+      continue;
+    }
+
+    NumBytes = BlockSize;
+    Status   = WriteAnyBlockWithRetry (Lba, 0, &NumBytes, (VOID *)Expected);
+    if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
+      Status = EFI_DEVICE_ERROR;
+      StallBetweenFlashAttempts (Attempt);
+      continue;
+    }
+
+    Status = VerifyAnyBlockWrite (Lba, Expected, VerifyBuffer, BlockSize);
+    if (!EFI_ERROR (Status)) {
+      return EFI_SUCCESS;
+    }
+
+    StallBetweenFlashAttempts (Attempt);
+  }
+
+  return Status;
+}
 
 STATIC
 EFI_STATUS
@@ -1115,7 +1301,7 @@ ReadFlashRange (
     Chunk         = MIN (Remaining, BlockSize - OffsetInBlock);
 
     NumBytes = Chunk;
-    Status   = SmmStoreLibReadAnyBlock (Lba, OffsetInBlock, &NumBytes, Buffer + Cursor);
+    Status   = ReadAnyBlockWithRetry (Lba, OffsetInBlock, &NumBytes, Buffer + Cursor);
     if (EFI_ERROR (Status) || (NumBytes != Chunk)) {
       return EFI_DEVICE_ERROR;
     }
@@ -1157,6 +1343,7 @@ UpdateFlashRangeFromImage (
   IN      UINTN                                          RangeOffset,
   IN      UINTN                                          RangeSize,
   IN OUT  VOID                                           *BlockBuffer,
+  OUT     VOID                                           *VerifyBuffer,
   IN      EFI_FIRMWARE_MANAGEMENT_UPDATE_IMAGE_PROGRESS  Progress OPTIONAL,
   IN      UINTN                                          TotalSteps,
   IN OUT  UINTN                                          *Step,
@@ -1167,7 +1354,7 @@ UpdateFlashRangeFromImage (
   UINTN       Offset;
   UINTN       RangeEnd;
 
-  if ((Image == NULL) || (BlockBuffer == NULL) || (Step == NULL) || (ShouldReportProgress == NULL) || (BlockSize == 0)) {
+  if ((Image == NULL) || (BlockBuffer == NULL) || (VerifyBuffer == NULL) || (Step == NULL) || (ShouldReportProgress == NULL) || (BlockSize == 0)) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -1204,7 +1391,7 @@ UpdateFlashRangeFromImage (
       // Whole-block update: ignore read errors for the compare optimization.
       //
       NumBytes = BlockSize;
-      Status   = SmmStoreLibReadAnyBlock (Lba, 0, &NumBytes, FlashBlock);
+      Status   = ReadAnyBlockWithRetry (Lba, 0, &NumBytes, FlashBlock);
       if (!EFI_ERROR (Status) && (NumBytes == BlockSize)) {
         if (CompareMem (FlashBlock, Image + BlockBase, BlockSize) == 0) {
           IncrementProgress (Progress, TotalSteps, Step, ShouldReportProgress);
@@ -1214,18 +1401,12 @@ UpdateFlashRangeFromImage (
         }
       }
 
-      Status = SmmStoreLibEraseAnyBlock (Lba);
+      Status = ProgramAnyBlockWithRetry (Lba, Image + BlockBase, VerifyBuffer, BlockSize);
       if (EFI_ERROR (Status)) {
         return EFI_DEVICE_ERROR;
       }
 
       IncrementProgress (Progress, TotalSteps, Step, ShouldReportProgress);
-
-      NumBytes = BlockSize;
-      Status   = SmmStoreLibWriteAnyBlock (Lba, 0, &NumBytes, (VOID *)(Image + BlockBase));
-      if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
-        return EFI_DEVICE_ERROR;
-      }
 
       IncrementProgress (Progress, TotalSteps, Step, ShouldReportProgress);
       Offset += SegmentLen;
@@ -1236,7 +1417,7 @@ UpdateFlashRangeFromImage (
     // Partial-block update: must preserve the rest of the flash block.
     //
     NumBytes = BlockSize;
-    Status   = SmmStoreLibReadAnyBlock (Lba, 0, &NumBytes, FlashBlock);
+    Status   = ReadAnyBlockWithRetry (Lba, 0, &NumBytes, FlashBlock);
     if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
       return EFI_DEVICE_ERROR;
     }
@@ -1250,18 +1431,12 @@ UpdateFlashRangeFromImage (
 
     CopyMem (FlashBlock + StartInBlock, Image + BlockBase + StartInBlock, SegmentLen);
 
-    Status = SmmStoreLibEraseAnyBlock (Lba);
+    Status = ProgramAnyBlockWithRetry (Lba, FlashBlock, VerifyBuffer, BlockSize);
     if (EFI_ERROR (Status)) {
       return EFI_DEVICE_ERROR;
     }
 
     IncrementProgress (Progress, TotalSteps, Step, ShouldReportProgress);
-
-    NumBytes = BlockSize;
-    Status   = SmmStoreLibWriteAnyBlock (Lba, 0, &NumBytes, FlashBlock);
-    if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
-      return EFI_DEVICE_ERROR;
-    }
 
     IncrementProgress (Progress, TotalSteps, Step, ShouldReportProgress);
     Offset += SegmentLen;
@@ -1476,6 +1651,7 @@ FmpDeviceSetImageWithStatus (
   UINTN                        Step;
   BOOLEAN                      ShouldReportProgress;
   VOID                         *ReadBuffer;
+  VOID                         *VerifyBuffer;
   CONST UINT8                  *WriteNext;
   UINTN                        ManifestEntryCount;
   CONST REGION_MANIFEST_ENTRY  *ManifestEntries;
@@ -1496,6 +1672,7 @@ FmpDeviceSetImageWithStatus (
   BlockCount         = 0;
   Block              = 0;
   ReadBuffer         = NULL;
+  VerifyBuffer       = NULL;
 
   //
   // FmpDeviceCheckImageWithStatus() has already validated the image, so not
@@ -1590,6 +1767,13 @@ FmpDeviceSetImageWithStatus (
   ReadBuffer = AllocatePool (BlockSize);
   if (ReadBuffer == NULL) {
     DEBUG ((DEBUG_ERROR, "%a(): failed to allocate read buffer\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  VerifyBuffer = AllocatePool (BlockSize);
+  if (VerifyBuffer == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to allocate verify buffer\n", __func__));
+    FreePool (ReadBuffer);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1763,6 +1947,7 @@ FmpDeviceSetImageWithStatus (
                  RegionOffset,
                  RegionSize,
                  ReadBuffer,
+                 VerifyBuffer,
                  Progress,
                  TotalSteps,
                  &Step,
@@ -1792,6 +1977,7 @@ FmpDeviceSetImageWithStatus (
                BiosOffset,
                BiosSize,
                ReadBuffer,
+               VerifyBuffer,
                Progress,
                TotalSteps,
                &Step,
@@ -1827,7 +2013,7 @@ FmpDeviceSetImageWithStatus (
       // a serious problem, erasing or writing will fail as well).
       //
       NumBytes = BlockSize;
-      Status   = SmmStoreLibReadAnyBlock (Block, 0, &NumBytes, ReadBuffer);
+      Status   = ReadAnyBlockWithRetry (Block, 0, &NumBytes, ReadBuffer);
       if (!EFI_ERROR (Status) && (NumBytes == BlockSize)) {
         if (CompareMem (ReadBuffer, WriteNext, BlockSize) == 0) {
           // Erase step.
@@ -1838,23 +2024,17 @@ FmpDeviceSetImageWithStatus (
         }
       }
 
-      Status = SmmStoreLibEraseAnyBlock (Block);
+      Status = ProgramAnyBlockWithRetry (Block, WriteNext, VerifyBuffer, BlockSize);
       if (EFI_ERROR (Status)) {
         goto IoError;
       }
 
       IncrementProgress (Progress, TotalSteps, &Step, &ShouldReportProgress);
-
-      NumBytes = BlockSize;
-      Status   = SmmStoreLibWriteAnyBlock (Block, 0, &NumBytes, (VOID *)WriteNext);
-      if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
-        goto IoError;
-      }
-
       IncrementProgress (Progress, TotalSteps, &Step, &ShouldReportProgress);
     }
   }
 
+  FreePool (VerifyBuffer);
   FreePool (ReadBuffer);
 
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_SUCCESS;
@@ -1916,6 +2096,10 @@ IoError:
   // If the firmware ends up unbootable, then, in general, external flashing
   // via a programmer needs to be employed to recover the device.
   //
+  if (VerifyBuffer != NULL) {
+    FreePool (VerifyBuffer);
+  }
+
   FreePool (ReadBuffer);
   DEBUG ((
     DEBUG_ERROR,

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -37,6 +37,8 @@
 // Minimal FMAP parsing to locate and compare the flash map before updating.
 //
 #define FMAP_SIGNATURE  "__FMAP__"
+#define FMAP_VER_MAJOR  1
+#define FMAP_NAME_LEN   32
 
 #pragma pack(1)
 typedef struct {
@@ -45,14 +47,14 @@ typedef struct {
   UINT8     VerMinor;
   UINT64    Base;
   UINT32    Size;
-  CHAR8     Name[32];
+  CHAR8     Name[FMAP_NAME_LEN];
   UINT16    AreaCount;
 } FMAP_HEADER;
 
 typedef struct {
   UINT32    Offset;
   UINT32    Size;
-  CHAR8     Name[32];
+  CHAR8     Name[FMAP_NAME_LEN];
   UINT16    Flags;
 } FMAP_AREA;
 #pragma pack()
@@ -287,6 +289,45 @@ FindFmapRegion (
   OUT UINTN              *RegionSize
   );
 
+STATIC
+UINTN
+FmapSize (
+  IN CONST FMAP_HEADER  *FmapHeader
+  )
+{
+  return sizeof (*FmapHeader) + ((UINTN)FmapHeader->AreaCount * sizeof (FMAP_AREA));
+}
+
+STATIC
+BOOLEAN
+FmapIsGraph (
+  IN CHAR8  Character
+  )
+{
+  return (Character > ' ') && (Character <= '~');
+}
+
+STATIC
+BOOLEAN
+FmapNameIsValid (
+  IN CONST CHAR8  Name[FMAP_NAME_LEN]
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < FMAP_NAME_LEN; ++Index) {
+    if (Name[Index] == '\0') {
+      return TRUE;
+    }
+
+    if (!FmapIsGraph (Name[Index])) {
+      return FALSE;
+    }
+  }
+
+  return FALSE;
+}
+
 /**
   This function requests firmware information on the first call, caches it and
   returns on all calls afterwards.
@@ -348,8 +389,8 @@ LocateFmapInImage (
 {
   UINTN         Offset;
   CONST UINTN   HeaderSize = sizeof (FMAP_HEADER);
-  CONST UINTN   AreaSize   = sizeof (FMAP_AREA);
   CONST UINT32  MinAreas   = 1;
+  UINTN         MapSize;
 
   if ((Image == NULL) || (FmapOffset == NULL) || (FmapLength == NULL)) {
     return EFI_NOT_FOUND;
@@ -366,19 +407,25 @@ LocateFmapInImage (
       continue;
     }
 
-    if (Hdr->AreaCount < MinAreas) {
+    if (Hdr->VerMajor != FMAP_VER_MAJOR) {
       continue;
     }
 
-    //
-    // Validate that all areas fit in the buffer.
-    //
-    if (Offset + HeaderSize + (Hdr->AreaCount * AreaSize) > ImageSize) {
+    MapSize = FmapSize (Hdr);
+    if ((Hdr->AreaCount < MinAreas) || (Hdr->Size < MapSize)) {
+      continue;
+    }
+
+    if (MapSize > (ImageSize - Offset)) {
+      continue;
+    }
+
+    if (!FmapNameIsValid (Hdr->Name)) {
       continue;
     }
 
     *FmapOffset = Offset;
-    *FmapLength = HeaderSize + (Hdr->AreaCount * AreaSize);
+    *FmapLength = MapSize;
     return EFI_SUCCESS;
   }
 
@@ -1905,8 +1952,9 @@ FmpDeviceSetImageWithStatus (
   }
 
   //
-  // Discover optional manifest and FMAP. If anything looks off, fall back to
-  // a BIOS-region update where possible, then legacy full-flash behavior.
+  // Discover optional manifest and FMAP. Prefer a manifest-guided update, then
+  // fall back to an Intel-descriptor BIOS-region update, then legacy full-flash
+  // behavior.
   //
   BaseImageSize      = ImageSize;
   ManifestEntryCount = 0;

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -65,6 +65,12 @@ typedef struct {
 #define REGION_MANIFEST_VERSION        1
 #define SMMSTORE_FLASH_RETRY_COUNT     4
 #define SMMSTORE_FLASH_RETRY_STALL_US  500
+#define INTEL_DESCRIPTOR_SIGNATURE     0x0ff0a55a
+#define INTEL_DESCRIPTOR_SIGNATURE_OFF 0x10
+#define INTEL_DESCRIPTOR_FLMAP0_OFF    0x14
+#define INTEL_DESCRIPTOR_REGION_BIOS   1
+#define INTEL_DESCRIPTOR_REGION_MASK   0x7fff
+#define INTEL_DESCRIPTOR_REGION_SCALE  0x1000
 
 typedef struct {
   UINT32    Signature;
@@ -558,6 +564,198 @@ FindFmapRegion (
 
     *RegionOffset = (UINTN)FmapHeader->Base + Areas[Index].Offset;
     *RegionSize   = Areas[Index].Size;
+    return EFI_SUCCESS;
+  }
+
+  return EFI_NOT_FOUND;
+}
+
+STATIC
+UINT32
+ReadLe32 (
+  IN CONST UINT8  *Data
+  )
+{
+  return (UINT32)Data[0] |
+         ((UINT32)Data[1] << 8) |
+         ((UINT32)Data[2] << 16) |
+         ((UINT32)Data[3] << 24);
+}
+
+/**
+  Locate the BIOS region by parsing an Intel flash descriptor.
+
+  @param[in]  Image       Buffer containing at least the flash descriptor.
+  @param[in]  ImageSize   Size of Image, in bytes.
+  @param[in]  FlashSize   Total flash size to validate descriptor bounds.
+  @param[out] BiosOffset  Absolute flash offset of the BIOS region.
+  @param[out] BiosSize    Size of the BIOS region.
+
+  @retval EFI_SUCCESS     BIOS region found.
+  @retval EFI_NOT_FOUND   Descriptor or BIOS region is absent/invalid.
+**/
+STATIC
+EFI_STATUS
+FindIntelDescriptorBiosRegion (
+  IN  CONST UINT8  *Image,
+  IN  UINTN        ImageSize,
+  IN  UINTN        FlashSize,
+  OUT UINTN        *BiosOffset,
+  OUT UINTN        *BiosSize
+  )
+{
+  UINT32  Flmap0;
+  UINT32  Flreg;
+  UINTN   Frba;
+  UINTN   FlregOffset;
+  UINTN   BaseField;
+  UINTN   LimitField;
+  UINTN   RegionBase;
+  UINTN   RegionLimit;
+  UINTN   RegionSize;
+
+  if ((Image == NULL) || (BiosOffset == NULL) || (BiosSize == NULL)) {
+    return EFI_NOT_FOUND;
+  }
+
+  if (ImageSize < (INTEL_DESCRIPTOR_FLMAP0_OFF + sizeof (UINT32))) {
+    return EFI_NOT_FOUND;
+  }
+
+  if (ReadLe32 (Image + INTEL_DESCRIPTOR_SIGNATURE_OFF) != INTEL_DESCRIPTOR_SIGNATURE) {
+    return EFI_NOT_FOUND;
+  }
+
+  Flmap0      = ReadLe32 (Image + INTEL_DESCRIPTOR_FLMAP0_OFF);
+  Frba        = ((Flmap0 >> 16) & 0xff) << 4;
+  FlregOffset = Frba + (INTEL_DESCRIPTOR_REGION_BIOS * sizeof (UINT32));
+
+  if ((FlregOffset + sizeof (UINT32)) > ImageSize) {
+    return EFI_NOT_FOUND;
+  }
+
+  Flreg      = ReadLe32 (Image + FlregOffset);
+  BaseField  = Flreg & INTEL_DESCRIPTOR_REGION_MASK;
+  LimitField = (Flreg >> 16) & INTEL_DESCRIPTOR_REGION_MASK;
+
+  if ((BaseField == INTEL_DESCRIPTOR_REGION_MASK) || (LimitField == 0) || (LimitField < BaseField)) {
+    return EFI_NOT_FOUND;
+  }
+
+  RegionBase  = BaseField * INTEL_DESCRIPTOR_REGION_SCALE;
+  RegionLimit = (LimitField * INTEL_DESCRIPTOR_REGION_SCALE) |
+                (INTEL_DESCRIPTOR_REGION_SCALE - 1);
+  RegionSize  = RegionLimit - RegionBase + 1;
+
+  if ((RegionBase >= FlashSize) || (RegionSize > (FlashSize - RegionBase))) {
+    return EFI_NOT_FOUND;
+  }
+
+  *BiosOffset = RegionBase;
+  *BiosSize   = RegionSize;
+  return EFI_SUCCESS;
+}
+
+/**
+  Locate a BIOS-region fallback for scoped capsule flashing.
+
+  Prefer the existing SI_BIOS FMAP region used by most Intel boards. Apollo Lake
+  IFWI images do not expose SI_BIOS in FMAP, so fall back to the Intel flash
+  descriptor BIOS region. Non-IFD platforms naturally fail this lookup and keep
+  the legacy behavior.
+
+  @param[in]  BlockSize   SMMSTORE block size.
+  @param[in]  FlashSize   Total flash size.
+  @param[in]  Image       Capsule firmware image.
+  @param[in]  ImageSize   Capsule firmware image size.
+  @param[in]  FmapHeader  Optional capsule FMAP header.
+  @param[in]  FmapAreas   Optional capsule FMAP areas.
+  @param[out] BiosOffset  Absolute flash offset of the fallback region.
+  @param[out] BiosSize    Size of the fallback region.
+  @param[out] Source      Human-readable fallback source.
+
+  @retval EFI_SUCCESS     Fallback region found.
+  @retval EFI_NOT_FOUND   No suitable fallback region found.
+**/
+STATIC
+EFI_STATUS
+FindBiosFallbackRegion (
+  IN  UINTN              BlockSize,
+  IN  UINTN              FlashSize,
+  IN  CONST UINT8        *Image,
+  IN  UINTN              ImageSize,
+  IN  CONST FMAP_HEADER  *FmapHeader OPTIONAL,
+  IN  CONST FMAP_AREA    *FmapAreas OPTIONAL,
+  OUT UINTN              *BiosOffset,
+  OUT UINTN              *BiosSize,
+  OUT CONST CHAR8        **Source
+  )
+{
+  EFI_STATUS   Status;
+  CONST CHAR8  SiBiosName[16] = "SI_BIOS";
+  UINTN        DescriptorSize;
+  VOID         *Descriptor;
+
+  if ((Image == NULL) || (BiosOffset == NULL) || (BiosSize == NULL) || (Source == NULL)) {
+    return EFI_NOT_FOUND;
+  }
+
+  if ((FmapHeader != NULL) && (FmapAreas != NULL)) {
+    Status = FindFmapRegion (
+               FmapHeader,
+               FmapAreas,
+               FmapHeader->AreaCount,
+               SiBiosName,
+               BiosOffset,
+               BiosSize
+               );
+    if (!EFI_ERROR (Status) &&
+        (*BiosSize != 0) &&
+        (*BiosOffset < ImageSize) &&
+        (*BiosSize <= (ImageSize - *BiosOffset)))
+    {
+      *Source = "SI_BIOS";
+      return EFI_SUCCESS;
+    }
+  }
+
+  DescriptorSize = MIN (BlockSize, FlashSize);
+  Descriptor     = NULL;
+  if (DescriptorSize >= (INTEL_DESCRIPTOR_FLMAP0_OFF + sizeof (UINT32))) {
+    Descriptor = AllocatePool (DescriptorSize);
+  }
+
+  if (Descriptor != NULL) {
+    Status = ReadFlashRange (BlockSize, FlashSize, 0, DescriptorSize, Descriptor);
+    if (!EFI_ERROR (Status)) {
+      Status = FindIntelDescriptorBiosRegion (
+                 Descriptor,
+                 DescriptorSize,
+                 FlashSize,
+                 BiosOffset,
+                 BiosSize
+                 );
+      if (!EFI_ERROR (Status) &&
+          (*BiosSize != 0) &&
+          (*BiosOffset < ImageSize) &&
+          (*BiosSize <= (ImageSize - *BiosOffset)))
+      {
+        FreePool (Descriptor);
+        *Source = "live Intel descriptor";
+        return EFI_SUCCESS;
+      }
+    }
+
+    FreePool (Descriptor);
+  }
+
+  Status = FindIntelDescriptorBiosRegion (Image, ImageSize, FlashSize, BiosOffset, BiosSize);
+  if (!EFI_ERROR (Status) &&
+      (*BiosSize != 0) &&
+      (*BiosOffset < ImageSize) &&
+      (*BiosSize <= (ImageSize - *BiosOffset)))
+  {
+    *Source = "capsule Intel descriptor";
     return EFI_SUCCESS;
   }
 
@@ -1658,6 +1856,7 @@ FmpDeviceSetImageWithStatus (
   UINTN                        BaseImageSize;
   BOOLEAN                      UseManifest;
   BOOLEAN                      UseBiosRegion;
+  BOOLEAN                      TriedBiosFallback;
   UINTN                        BiosOffset;
   UINTN                        BiosSize;
   CONST FMAP_HEADER            *FmapHeader;
@@ -1693,13 +1892,14 @@ FmpDeviceSetImageWithStatus (
 
   //
   // Discover optional manifest and FMAP. If anything looks off, fall back to
-  // legacy full-flash behavior.
+  // a BIOS-region update where possible, then legacy full-flash behavior.
   //
   BaseImageSize      = ImageSize;
   ManifestEntryCount = 0;
   ManifestEntries    = NULL;
   UseManifest        = FALSE;
   UseBiosRegion      = FALSE;
+  TriedBiosFallback  = FALSE;
   BiosOffset         = 0;
   BiosSize           = 0;
   FmapHeader         = NULL;
@@ -1741,26 +1941,69 @@ FmpDeviceSetImageWithStatus (
   }
 
   if ((ManifestEntryCount > 0) && (FmapHeader != NULL) && (FmapHeader->AreaCount > 0)) {
-    UseManifest = TRUE;
-  } else if ((ManifestEntryCount == 0) && (FmapHeader != NULL)) {
     //
-    // No manifest; attempt BIOS-only update using FMAP region. On Intel
-    // platforms this typically corresponds to the IFD BIOS region exposed
-    // to firmware as "SI_BIOS".
+    // Apollo Lake IFWI images do not expose the whole BIOS region in FMAP, so a
+    // valid COREBOOT manifest would miss boot partitions outside the OBB. If
+    // there is no SI_BIOS FMAP region but an Intel descriptor is present, use
+    // the descriptor BIOS region instead.
     //
-    CONST CHAR8  SiBiosName[16] = "SI_BIOS";
+    CONST CHAR8  *BiosRegionSource;
 
-    if (!EFI_ERROR (FindFmapRegion (FmapHeader, FmapAreas, FmapHeader->AreaCount, SiBiosName, &BiosOffset, &BiosSize))) {
-      if ((BiosSize != 0) && ((BiosOffset + BiosSize) <= BaseImageSize)) {
-        UseBiosRegion = TRUE;
-        DEBUG ((
-          DEBUG_INFO,
-          "%a(): no manifest, using SI_BIOS (0x%x+0x%x)\n",
-          __func__,
-          (UINT32)BiosOffset,
-          (UINT32)BiosSize
-          ));
-      }
+    if (!EFI_ERROR (FindBiosFallbackRegion (
+                      BlockSize,
+                      BaseImageSize,
+                      (CONST UINT8 *)Image,
+                      BaseImageSize,
+                      FmapHeader,
+                      FmapAreas,
+                      &BiosOffset,
+                      &BiosSize,
+                      &BiosRegionSource
+                      )) &&
+        (AsciiStrCmp (BiosRegionSource, "SI_BIOS") != 0))
+    {
+      UseBiosRegion     = TRUE;
+      TriedBiosFallback = TRUE;
+      DEBUG ((
+        DEBUG_INFO,
+        "%a(): using %a BIOS region instead of FMAP manifest (0x%x+0x%x)\n",
+        __func__,
+        BiosRegionSource,
+        (UINT32)BiosOffset,
+        (UINT32)BiosSize
+        ));
+    } else {
+      UseManifest = TRUE;
+    }
+  } else {
+    //
+    // If there is no manifest or the FMAP cannot be parsed, attempt a BIOS-only
+    // fallback using FMAP or Intel descriptor metadata.
+    //
+    CONST CHAR8  *BiosRegionSource;
+
+    TriedBiosFallback = TRUE;
+    if (!EFI_ERROR (FindBiosFallbackRegion (
+                      BlockSize,
+                      BaseImageSize,
+                      (CONST UINT8 *)Image,
+                      BaseImageSize,
+                      FmapHeader,
+                      FmapAreas,
+                      &BiosOffset,
+                      &BiosSize,
+                      &BiosRegionSource
+                      )))
+    {
+      UseBiosRegion = TRUE;
+      DEBUG ((
+        DEBUG_INFO,
+        "%a(): using %a BIOS region fallback (0x%x+0x%x)\n",
+        __func__,
+        BiosRegionSource,
+        (UINT32)BiosOffset,
+        (UINT32)BiosSize
+        ));
     }
   }
 
@@ -1876,8 +2119,8 @@ FmpDeviceSetImageWithStatus (
       // Manifest regions no longer match the current flash layout; fall back to
       // flashing the full BIOS region from the new image.
       //
-      CONST CHAR8  SiBiosName[16] = "SI_BIOS";
       CHAR8        RegionName[17];
+      CONST CHAR8  *BiosRegionSource;
 
       UseManifest   = FALSE;
       UseBiosRegion = FALSE;
@@ -1897,19 +2140,30 @@ FmpDeviceSetImageWithStatus (
           ));
       }
 
-      if (!EFI_ERROR (FindFmapRegion (FmapHeader, FmapAreas, FmapHeader->AreaCount, SiBiosName, &BiosOffset, &BiosSize))) {
-        if ((BiosSize != 0) && ((BiosOffset + BiosSize) <= BaseImageSize)) {
-          UseBiosRegion = TRUE;
-          DEBUG ((
-            DEBUG_WARN,
-            "%a(): flashing SI_BIOS instead (0x%x+0x%x)\n",
-            __func__,
-            (UINT32)BiosOffset,
-            (UINT32)BiosSize
-            ));
-        }
+      TriedBiosFallback = TRUE;
+      if (!EFI_ERROR (FindBiosFallbackRegion (
+                        BlockSize,
+                        BaseImageSize,
+                        (CONST UINT8 *)Image,
+                        BaseImageSize,
+                        FmapHeader,
+                        FmapAreas,
+                        &BiosOffset,
+                        &BiosSize,
+                        &BiosRegionSource
+                        )))
+      {
+        UseBiosRegion = TRUE;
+        DEBUG ((
+          DEBUG_WARN,
+          "%a(): flashing %a BIOS region instead (0x%x+0x%x)\n",
+          __func__,
+          BiosRegionSource,
+          (UINT32)BiosOffset,
+          (UINT32)BiosSize
+          ));
       } else {
-        DEBUG ((DEBUG_WARN, "%a(): unable to locate SI_BIOS for fallback\n", __func__));
+        DEBUG ((DEBUG_WARN, "%a(): unable to locate BIOS region for fallback\n", __func__));
       }
     }
   }
@@ -1919,6 +2173,34 @@ FmpDeviceSetImageWithStatus (
 
   if (UseManifest && (TotalSteps == 0)) {
     UseManifest = FALSE;
+  }
+
+  if (!UseManifest && !UseBiosRegion && !TriedBiosFallback) {
+    CONST CHAR8  *BiosRegionSource;
+
+    TriedBiosFallback = TRUE;
+    if (!EFI_ERROR (FindBiosFallbackRegion (
+                      BlockSize,
+                      BaseImageSize,
+                      (CONST UINT8 *)Image,
+                      BaseImageSize,
+                      FmapHeader,
+                      FmapAreas,
+                      &BiosOffset,
+                      &BiosSize,
+                      &BiosRegionSource
+                      )))
+    {
+      UseBiosRegion = TRUE;
+      DEBUG ((
+        DEBUG_WARN,
+        "%a(): flashing %a BIOS region as fallback (0x%x+0x%x)\n",
+        __func__,
+        BiosRegionSource,
+        (UINT32)BiosOffset,
+        (UINT32)BiosSize
+        ));
+    }
   }
 
   if (UseManifest) {
@@ -1961,9 +2243,9 @@ FmpDeviceSetImageWithStatus (
 
   if (UseBiosRegion && !UseManifest) {
     //
-    // BIOS-only fallback using FMAP when no manifest is present.
+    // BIOS-only fallback using FMAP or Intel descriptor metadata.
     //
-    DEBUG ((DEBUG_INFO, "%a(): FMAP-guided BIOS-only update\n", __func__));
+    DEBUG ((DEBUG_INFO, "%a(): BIOS-region update\n", __func__));
 
     TotalSteps = ((BiosOffset + BiosSize - 1) / BlockSize - (BiosOffset / BlockSize) + 1) * 2;
     if (TotalSteps == 0) {

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -659,17 +659,14 @@ FindIntelDescriptorBiosRegion (
 /**
   Locate a BIOS-region fallback for scoped capsule flashing.
 
-  Prefer the existing SI_BIOS FMAP region used by most Intel boards. Apollo Lake
-  IFWI images do not expose SI_BIOS in FMAP, so fall back to the Intel flash
-  descriptor BIOS region. Non-IFD platforms naturally fail this lookup and keep
-  the legacy behavior.
+  Use Intel descriptor metadata for the fallback region. Prefer the live flash
+  descriptor, and validate it against the capsule descriptor when one is present.
+  Non-IFD platforms naturally fail this lookup and keep the legacy behavior.
 
   @param[in]  BlockSize   SMMSTORE block size.
   @param[in]  FlashSize   Total flash size.
   @param[in]  Image       Capsule firmware image.
   @param[in]  ImageSize   Capsule firmware image size.
-  @param[in]  FmapHeader  Optional capsule FMAP header.
-  @param[in]  FmapAreas   Optional capsule FMAP areas.
   @param[out] BiosOffset  Absolute flash offset of the fallback region.
   @param[out] BiosSize    Size of the fallback region.
   @param[out] Source      Human-readable fallback source.
@@ -684,43 +681,34 @@ FindBiosFallbackRegion (
   IN  UINTN              FlashSize,
   IN  CONST UINT8        *Image,
   IN  UINTN              ImageSize,
-  IN  CONST FMAP_HEADER  *FmapHeader OPTIONAL,
-  IN  CONST FMAP_AREA    *FmapAreas OPTIONAL,
   OUT UINTN              *BiosOffset,
   OUT UINTN              *BiosSize,
   OUT CONST CHAR8        **Source
   )
 {
-  EFI_STATUS   Status;
-  CONST CHAR8  SiBiosName[16] = "SI_BIOS";
-  UINTN        DescriptorSize;
-  VOID         *Descriptor;
+  EFI_STATUS  Status;
+  EFI_STATUS  LiveStatus;
+  EFI_STATUS  CapsuleStatus;
+  UINTN       DescriptorSize;
+  VOID        *Descriptor;
+  UINTN       LiveBiosOffset;
+  UINTN       LiveBiosSize;
+  UINTN       CapsuleBiosOffset;
+  UINTN       CapsuleBiosSize;
 
   if ((Image == NULL) || (BiosOffset == NULL) || (BiosSize == NULL) || (Source == NULL)) {
     return EFI_NOT_FOUND;
   }
 
-  if ((FmapHeader != NULL) && (FmapAreas != NULL)) {
-    Status = FindFmapRegion (
-               FmapHeader,
-               FmapAreas,
-               FmapHeader->AreaCount,
-               SiBiosName,
-               BiosOffset,
-               BiosSize
-               );
-    if (!EFI_ERROR (Status) &&
-        (*BiosSize != 0) &&
-        (*BiosOffset < ImageSize) &&
-        (*BiosSize <= (ImageSize - *BiosOffset)))
-    {
-      *Source = "SI_BIOS";
-      return EFI_SUCCESS;
-    }
-  }
+  DescriptorSize    = MIN (BlockSize, FlashSize);
+  Descriptor        = NULL;
+  LiveStatus        = EFI_NOT_FOUND;
+  CapsuleStatus     = EFI_NOT_FOUND;
+  LiveBiosOffset    = 0;
+  LiveBiosSize      = 0;
+  CapsuleBiosOffset = 0;
+  CapsuleBiosSize   = 0;
 
-  DescriptorSize = MIN (BlockSize, FlashSize);
-  Descriptor     = NULL;
   if (DescriptorSize >= (INTEL_DESCRIPTOR_FLMAP0_OFF + sizeof (UINT32))) {
     Descriptor = AllocatePool (DescriptorSize);
   }
@@ -732,30 +720,56 @@ FindBiosFallbackRegion (
                  Descriptor,
                  DescriptorSize,
                  FlashSize,
-                 BiosOffset,
-                 BiosSize
+                 &LiveBiosOffset,
+                 &LiveBiosSize
                  );
       if (!EFI_ERROR (Status) &&
-          (*BiosSize != 0) &&
-          (*BiosOffset < ImageSize) &&
-          (*BiosSize <= (ImageSize - *BiosOffset)))
+          (LiveBiosSize != 0) &&
+          (LiveBiosOffset < ImageSize) &&
+          (LiveBiosSize <= (ImageSize - LiveBiosOffset)))
       {
-        FreePool (Descriptor);
-        *Source = "live Intel descriptor";
-        return EFI_SUCCESS;
+        LiveStatus = EFI_SUCCESS;
       }
     }
 
     FreePool (Descriptor);
   }
 
-  Status = FindIntelDescriptorBiosRegion (Image, ImageSize, FlashSize, BiosOffset, BiosSize);
+  Status = FindIntelDescriptorBiosRegion (Image, ImageSize, FlashSize, &CapsuleBiosOffset, &CapsuleBiosSize);
   if (!EFI_ERROR (Status) &&
-      (*BiosSize != 0) &&
-      (*BiosOffset < ImageSize) &&
-      (*BiosSize <= (ImageSize - *BiosOffset)))
+      (CapsuleBiosSize != 0) &&
+      (CapsuleBiosOffset < ImageSize) &&
+      (CapsuleBiosSize <= (ImageSize - CapsuleBiosOffset)))
   {
-    *Source = "capsule Intel descriptor";
+    CapsuleStatus = EFI_SUCCESS;
+  }
+
+  if (!EFI_ERROR (LiveStatus)) {
+    if (!EFI_ERROR (CapsuleStatus) &&
+        ((LiveBiosOffset != CapsuleBiosOffset) || (LiveBiosSize != CapsuleBiosSize)))
+    {
+      DEBUG ((
+        DEBUG_WARN,
+        "%a(): Intel descriptor BIOS mismatch: flash 0x%x+0x%x vs capsule 0x%x+0x%x\n",
+        __func__,
+        (UINT32)LiveBiosOffset,
+        (UINT32)LiveBiosSize,
+        (UINT32)CapsuleBiosOffset,
+        (UINT32)CapsuleBiosSize
+        ));
+      return EFI_NOT_FOUND;
+    }
+
+    *BiosOffset = LiveBiosOffset;
+    *BiosSize   = LiveBiosSize;
+    *Source     = "live Intel descriptor";
+    return EFI_SUCCESS;
+  }
+
+  if (!EFI_ERROR (CapsuleStatus)) {
+    *BiosOffset = CapsuleBiosOffset;
+    *BiosSize   = CapsuleBiosSize;
+    *Source     = "capsule Intel descriptor";
     return EFI_SUCCESS;
   }
 
@@ -1941,44 +1955,11 @@ FmpDeviceSetImageWithStatus (
   }
 
   if ((ManifestEntryCount > 0) && (FmapHeader != NULL) && (FmapHeader->AreaCount > 0)) {
-    //
-    // Apollo Lake IFWI images do not expose the whole BIOS region in FMAP, so a
-    // valid COREBOOT manifest would miss boot partitions outside the OBB. If
-    // there is no SI_BIOS FMAP region but an Intel descriptor is present, use
-    // the descriptor BIOS region instead.
-    //
-    CONST CHAR8  *BiosRegionSource;
-
-    if (!EFI_ERROR (FindBiosFallbackRegion (
-                      BlockSize,
-                      BaseImageSize,
-                      (CONST UINT8 *)Image,
-                      BaseImageSize,
-                      FmapHeader,
-                      FmapAreas,
-                      &BiosOffset,
-                      &BiosSize,
-                      &BiosRegionSource
-                      )) &&
-        (AsciiStrCmp (BiosRegionSource, "SI_BIOS") != 0))
-    {
-      UseBiosRegion     = TRUE;
-      TriedBiosFallback = TRUE;
-      DEBUG ((
-        DEBUG_INFO,
-        "%a(): using %a BIOS region instead of FMAP manifest (0x%x+0x%x)\n",
-        __func__,
-        BiosRegionSource,
-        (UINT32)BiosOffset,
-        (UINT32)BiosSize
-        ));
-    } else {
-      UseManifest = TRUE;
-    }
+    UseManifest = TRUE;
   } else {
     //
     // If there is no manifest or the FMAP cannot be parsed, attempt a BIOS-only
-    // fallback using FMAP or Intel descriptor metadata.
+    // fallback using Intel descriptor metadata.
     //
     CONST CHAR8  *BiosRegionSource;
 
@@ -1988,8 +1969,6 @@ FmpDeviceSetImageWithStatus (
                       BaseImageSize,
                       (CONST UINT8 *)Image,
                       BaseImageSize,
-                      FmapHeader,
-                      FmapAreas,
                       &BiosOffset,
                       &BiosSize,
                       &BiosRegionSource
@@ -2146,8 +2125,6 @@ FmpDeviceSetImageWithStatus (
                         BaseImageSize,
                         (CONST UINT8 *)Image,
                         BaseImageSize,
-                        FmapHeader,
-                        FmapAreas,
                         &BiosOffset,
                         &BiosSize,
                         &BiosRegionSource
@@ -2184,8 +2161,6 @@ FmpDeviceSetImageWithStatus (
                       BaseImageSize,
                       (CONST UINT8 *)Image,
                       BaseImageSize,
-                      FmapHeader,
-                      FmapAreas,
                       &BiosOffset,
                       &BiosSize,
                       &BiosRegionSource

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -33,6 +33,8 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Coreboot.h>
 
+#include "FmpDeviceSmmUpdatePolicy.h"
+
 //
 // Minimal FMAP parsing to locate and compare the flash map before updating.
 //
@@ -1927,6 +1929,9 @@ FmpDeviceSetImageWithStatus (
   VOID                         *FlashFmapBuffer;
   FMAP_HEADER                  *FlashFmapHeader;
   FMAP_AREA                    *FlashFmapAreas;
+  BOOLEAN                      VariableStorePreserved;
+  UINTN                        VariableStoreOffset;
+  UINTN                        VariableStoreSize;
 
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL;
   BlockCount         = 0;
@@ -1968,9 +1973,12 @@ FmpDeviceSetImageWithStatus (
   FmapAreas          = NULL;
   FmapOffset         = 0;
   FmapLength         = 0;
-  FlashFmapBuffer    = NULL;
-  FlashFmapHeader    = NULL;
-  FlashFmapAreas     = NULL;
+  FlashFmapBuffer        = NULL;
+  FlashFmapHeader        = NULL;
+  FlashFmapAreas         = NULL;
+  VariableStorePreserved = FALSE;
+  VariableStoreOffset    = 0;
+  VariableStoreSize      = 0;
 
   Status = LocateRegionManifest (Image, ImageSize, &ManifestEntryCount, &ManifestEntries, &BaseImageSize);
   if (EFI_ERROR (Status)) {
@@ -2058,6 +2066,7 @@ FmpDeviceSetImageWithStatus (
     UINTN       CapsuleRegionSize;
     UINTN       FlashRegionOffset;
     UINTN       FlashRegionSize;
+    CONST CHAR8  SmmStoreRegionName[16] = "SMMSTORE";
 
     LayoutMismatch      = FALSE;
     MismatchIndex       = MAX_UINTN;
@@ -2077,6 +2086,23 @@ FmpDeviceSetImageWithStatus (
     if (EFI_ERROR (FlashFmapStatus)) {
       LayoutMismatch = TRUE;
       DEBUG ((DEBUG_WARN, "%a(): failed to load flash FMAP: %r\n", __func__, FlashFmapStatus));
+    } else {
+      Status = FindFmapRegion (
+                 FlashFmapHeader,
+                 FlashFmapAreas,
+                 FlashFmapHeader->AreaCount,
+                 SmmStoreRegionName,
+                 &VariableStoreOffset,
+                 &VariableStoreSize
+                 );
+      if (!EFI_ERROR (Status) && (VariableStoreSize != 0) &&
+          (VariableStoreOffset < BaseImageSize) &&
+          (VariableStoreSize <= (BaseImageSize - VariableStoreOffset)))
+      {
+        VariableStorePreserved = TRUE;
+      } else {
+        DEBUG ((DEBUG_WARN, "%a(): current SMMSTORE range is unavailable or invalid\n", __func__));
+      }
     }
 
     TotalSteps = 0;
@@ -2130,6 +2156,15 @@ FmpDeviceSetImageWithStatus (
             FlashRegionOffset = 0;
             FlashRegionSize   = 0;
           }
+        } else if (VariableStorePreserved &&
+                   FmpDeviceFlashRangesOverlap (
+                     FlashRegionOffset,
+                     FlashRegionSize,
+                     VariableStoreOffset,
+                     VariableStoreSize
+                     ))
+        {
+          VariableStorePreserved = FALSE;
         }
       }
 
@@ -2149,8 +2184,9 @@ FmpDeviceSetImageWithStatus (
       CHAR8        RegionName[17];
       CONST CHAR8  *BiosRegionSource;
 
-      UseManifest   = FALSE;
-      UseBiosRegion = FALSE;
+      UseManifest            = FALSE;
+      UseBiosRegion          = FALSE;
+      VariableStorePreserved = FALSE;
 
       if (MismatchIndex != MAX_UINTN) {
         CopyMem (RegionName, ManifestEntries[MismatchIndex].RegionName, 16);
@@ -2345,32 +2381,33 @@ FmpDeviceSetImageWithStatus (
   *LastAttemptStatus = LAST_ATTEMPT_STATUS_SUCCESS;
 
   //
-  // Updating the firmware on system flash overwrites SMMSTORE region which
-  // backs up EFI variables of the running firmware.  At this point both SMI
-  // handler from coreboot and variable services of EDK can be mistaken in
-  // their assumptions about the location, size and contents of the region.
-  // Accessing flash where SMMSTORE used to be can lead to unexpected results
-  // including corruption of the new image outside of its SMMSTORE.  Switch to
-  // the use of stubs for dealing with EFI variables that do nothing.
+  // A full-flash, BIOS-region, or overlapping manifest update can overwrite
+  // the SMMSTORE region that backs EFI variables.  In those cases, the running
+  // coreboot SMI handler and EDK variable services may have stale assumptions
+  // about the store, so replace the services with failure stubs.
   //
-  // New firmware will not report result of flashing in any way unless some
-  // kind of communication mechanism is implemented for this purpose.
+  // A manifest update may keep using variable services only when the live FMAP
+  // was read successfully, all selected regions matched the live layout, and
+  // none overlapped the live SMMSTORE range.  This lets FmpDxe persist final
+  // last-attempt state before the mandatory reset.
   //
   // If there was an error, it's unclear whether these stubs would be of any
   // help, so they are employed only on successful flashing.
   //
 
-  gRT->GetVariable         = GetVariableHook;
-  gRT->GetNextVariableName = GetNextVariableNameHook;
-  gRT->SetVariable         = SetVariableHook;
-  gRT->QueryVariableInfo   = QueryVariableInfoHook;
+  if (FmpDeviceShouldDisableVariableServices (UseManifest && VariableStorePreserved)) {
+    gRT->GetVariable         = GetVariableHook;
+    gRT->GetNextVariableName = GetNextVariableNameHook;
+    gRT->SetVariable         = SetVariableHook;
+    gRT->QueryVariableInfo   = QueryVariableInfoHook;
 
-  gRT->Hdr.CRC32 = 0;
-  gBS->CalculateCrc32 (
-         (UINT8 *)&gRT->Hdr,
-         gRT->Hdr.HeaderSize,
-         &gRT->Hdr.CRC32
-         );
+    gRT->Hdr.CRC32 = 0;
+    gBS->CalculateCrc32 (
+           (UINT8 *)&gRT->Hdr,
+           gRT->Hdr.HeaderSize,
+           &gRT->Hdr.CRC32
+           );
+  }
 
   return EFI_SUCCESS;
 

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -33,6 +33,7 @@
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Coreboot.h>
 
+#include "FmpDeviceSmmFlashRetry.h"
 #include "FmpDeviceSmmUpdatePolicy.h"
 
 //
@@ -67,7 +68,6 @@ typedef struct {
 //
 #define REGION_MANIFEST_SIGNATURE      SIGNATURE_32 ('R', 'M', 'A', 'P')
 #define REGION_MANIFEST_VERSION        1
-#define SMMSTORE_FLASH_RETRY_COUNT     4
 #define SMMSTORE_FLASH_RETRY_STALL_US  500
 #define INTEL_DESCRIPTOR_SIGNATURE     0x0ff0a55a
 #define INTEL_DESCRIPTOR_SIGNATURE_OFF 0x10
@@ -99,6 +99,46 @@ StallBetweenFlashAttempts (
 
 STATIC
 EFI_STATUS
+ReadAnyBlock (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  OUT    UINT8    *Buffer
+  )
+{
+  return SmmStoreLibReadAnyBlock (Lba, Offset, NumBytes, Buffer);
+}
+
+STATIC
+EFI_STATUS
+WriteAnyBlock (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  IN     UINT8    *Buffer
+  )
+{
+  return SmmStoreLibWriteAnyBlock (Lba, Offset, NumBytes, Buffer);
+}
+
+STATIC
+EFI_STATUS
+EraseAnyBlock (
+  IN EFI_LBA  Lba
+  )
+{
+  return SmmStoreLibEraseAnyBlock (Lba);
+}
+
+STATIC CONST FMP_DEVICE_FLASH_IO  mFlashIo = {
+  ReadAnyBlock,
+  WriteAnyBlock,
+  EraseAnyBlock,
+  StallBetweenFlashAttempts
+};
+
+STATIC
+EFI_STATUS
 ReadAnyBlockWithRetry (
   IN     EFI_LBA  Lba,
   IN     UINTN    Offset,
@@ -106,124 +146,7 @@ ReadAnyBlockWithRetry (
   OUT    VOID     *Buffer
   )
 {
-  EFI_STATUS  Status;
-  UINTN       Attempt;
-  UINTN       RequestedBytes;
-  UINTN       ActualBytes;
-
-  if ((NumBytes == NULL) || (Buffer == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  RequestedBytes = *NumBytes;
-  Status         = EFI_DEVICE_ERROR;
-  ActualBytes    = 0;
-
-  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
-    ActualBytes = RequestedBytes;
-    Status      = SmmStoreLibReadAnyBlock (Lba, Offset, &ActualBytes, Buffer);
-    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
-      *NumBytes = ActualBytes;
-      return EFI_SUCCESS;
-    }
-
-    *NumBytes = ActualBytes;
-    StallBetweenFlashAttempts (Attempt);
-  }
-
-  if (!EFI_ERROR (Status)) {
-    Status = EFI_DEVICE_ERROR;
-  }
-
-  return Status;
-}
-
-STATIC
-EFI_STATUS
-EraseAnyBlockWithRetry (
-  IN EFI_LBA  Lba
-  )
-{
-  EFI_STATUS  Status;
-  UINTN       Attempt;
-
-  Status = EFI_DEVICE_ERROR;
-  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
-    Status = SmmStoreLibEraseAnyBlock (Lba);
-    if (!EFI_ERROR (Status)) {
-      return EFI_SUCCESS;
-    }
-
-    StallBetweenFlashAttempts (Attempt);
-  }
-
-  return Status;
-}
-
-STATIC
-EFI_STATUS
-WriteAnyBlockWithRetry (
-  IN     EFI_LBA  Lba,
-  IN     UINTN    Offset,
-  IN OUT UINTN    *NumBytes,
-  IN     VOID     *Buffer
-  )
-{
-  EFI_STATUS  Status;
-  UINTN       Attempt;
-  UINTN       RequestedBytes;
-  UINTN       ActualBytes;
-
-  if ((NumBytes == NULL) || (Buffer == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  RequestedBytes = *NumBytes;
-  Status         = EFI_DEVICE_ERROR;
-  ActualBytes    = 0;
-
-  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
-    ActualBytes = RequestedBytes;
-    Status      = SmmStoreLibWriteAnyBlock (Lba, Offset, &ActualBytes, Buffer);
-    if (!EFI_ERROR (Status) && (ActualBytes == RequestedBytes)) {
-      *NumBytes = ActualBytes;
-      return EFI_SUCCESS;
-    }
-
-    *NumBytes = ActualBytes;
-    StallBetweenFlashAttempts (Attempt);
-  }
-
-  if (!EFI_ERROR (Status)) {
-    Status = EFI_DEVICE_ERROR;
-  }
-
-  return Status;
-}
-
-STATIC
-EFI_STATUS
-VerifyAnyBlockWrite (
-  IN  EFI_LBA      Lba,
-  IN  CONST UINT8  *Expected,
-  OUT UINT8        *VerifyBuffer,
-  IN  UINTN        BlockSize
-  )
-{
-  EFI_STATUS  Status;
-  UINTN       NumBytes;
-
-  if ((Expected == NULL) || (VerifyBuffer == NULL) || (BlockSize == 0)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  NumBytes = BlockSize;
-  Status   = ReadAnyBlockWithRetry (Lba, 0, &NumBytes, VerifyBuffer);
-  if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
-    return EFI_DEVICE_ERROR;
-  }
-
-  return (CompareMem (VerifyBuffer, Expected, BlockSize) == 0) ? EFI_SUCCESS : EFI_VOLUME_CORRUPTED;
+  return FmpDeviceFlashReadWithRetry (&mFlashIo, Lba, Offset, NumBytes, Buffer);
 }
 
 STATIC
@@ -235,39 +158,7 @@ ProgramAnyBlockWithRetry (
   IN  UINTN        BlockSize
   )
 {
-  EFI_STATUS  Status;
-  UINTN       Attempt;
-  UINTN       NumBytes;
-
-  if ((Expected == NULL) || (VerifyBuffer == NULL) || (BlockSize == 0)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  Status = EFI_DEVICE_ERROR;
-  for (Attempt = 0; Attempt < SMMSTORE_FLASH_RETRY_COUNT; ++Attempt) {
-    Status = EraseAnyBlockWithRetry (Lba);
-    if (EFI_ERROR (Status)) {
-      StallBetweenFlashAttempts (Attempt);
-      continue;
-    }
-
-    NumBytes = BlockSize;
-    Status   = WriteAnyBlockWithRetry (Lba, 0, &NumBytes, (VOID *)Expected);
-    if (EFI_ERROR (Status) || (NumBytes != BlockSize)) {
-      Status = EFI_DEVICE_ERROR;
-      StallBetweenFlashAttempts (Attempt);
-      continue;
-    }
-
-    Status = VerifyAnyBlockWrite (Lba, Expected, VerifyBuffer, BlockSize);
-    if (!EFI_ERROR (Status)) {
-      return EFI_SUCCESS;
-    }
-
-    StallBetweenFlashAttempts (Attempt);
-  }
-
-  return Status;
+  return FmpDeviceFlashProgramWithRetry (&mFlashIo, Lba, Expected, VerifyBuffer, BlockSize);
 }
 
 STATIC

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.c
@@ -34,6 +34,7 @@
 #include <Coreboot.h>
 
 #include "FmpDeviceSmmFlashRetry.h"
+#include "FmpDeviceSmmManifest.h"
 #include "FmpDeviceSmmUpdatePolicy.h"
 
 //
@@ -62,30 +63,19 @@ typedef struct {
 } FMAP_AREA;
 #pragma pack()
 
-//
-// Simple manifest that lists FMAP region names to be flashed. The manifest is
-// appended at the end of the capsule payload and is ignored when absent.
-//
-#define REGION_MANIFEST_SIGNATURE      SIGNATURE_32 ('R', 'M', 'A', 'P')
-#define REGION_MANIFEST_VERSION        1
-#define SMMSTORE_FLASH_RETRY_STALL_US  500
-#define INTEL_DESCRIPTOR_SIGNATURE     0x0ff0a55a
-#define INTEL_DESCRIPTOR_SIGNATURE_OFF 0x10
-#define INTEL_DESCRIPTOR_FLMAP0_OFF    0x14
-#define INTEL_DESCRIPTOR_REGION_BIOS   1
-#define INTEL_DESCRIPTOR_REGION_MASK   0x7fff
-#define INTEL_DESCRIPTOR_REGION_SCALE  0x1000
+#define SMMSTORE_FLASH_RETRY_STALL_US   500
+#define INTEL_DESCRIPTOR_SIGNATURE      0x0ff0a55a
+#define INTEL_DESCRIPTOR_SIGNATURE_OFF  0x10
+#define INTEL_DESCRIPTOR_FLMAP0_OFF     0x14
+#define INTEL_DESCRIPTOR_REGION_BIOS    1
+#define INTEL_DESCRIPTOR_REGION_MASK    0x7fff
+#define INTEL_DESCRIPTOR_REGION_SCALE   0x1000
 
-typedef struct {
-  UINT32    Signature;
-  UINT16    Version;
-  UINT16    EntryCount;
-} REGION_MANIFEST_TRAILER;
+/**
+  Delay between flash operation attempts.
 
-typedef struct {
-  CHAR8    RegionName[16];
-} REGION_MANIFEST_ENTRY;
-
+  @param[in] Attempt  Failed attempt number.
+**/
 STATIC
 VOID
 StallBetweenFlashAttempts (
@@ -97,6 +87,16 @@ StallBetweenFlashAttempts (
   }
 }
 
+/**
+  Read bytes from flash.
+
+  @param[in]     Lba       Flash block number.
+  @param[in]     Offset    Offset within the block.
+  @param[in,out] NumBytes  Requested and actual byte count.
+  @param[out]    Buffer    Destination buffer.
+
+  @return Status returned by SmmStoreLib.
+**/
 STATIC
 EFI_STATUS
 ReadAnyBlock (
@@ -109,6 +109,16 @@ ReadAnyBlock (
   return SmmStoreLibReadAnyBlock (Lba, Offset, NumBytes, Buffer);
 }
 
+/**
+  Write bytes to flash.
+
+  @param[in]     Lba       Flash block number.
+  @param[in]     Offset    Offset within the block.
+  @param[in,out] NumBytes  Requested and actual byte count.
+  @param[in]     Buffer    Source buffer.
+
+  @return Status returned by SmmStoreLib.
+**/
 STATIC
 EFI_STATUS
 WriteAnyBlock (
@@ -121,6 +131,13 @@ WriteAnyBlock (
   return SmmStoreLibWriteAnyBlock (Lba, Offset, NumBytes, Buffer);
 }
 
+/**
+  Erase a flash block.
+
+  @param[in] Lba  Flash block number.
+
+  @return Status returned by SmmStoreLib.
+**/
 STATIC
 EFI_STATUS
 EraseAnyBlock (
@@ -137,6 +154,16 @@ STATIC CONST FMP_DEVICE_FLASH_IO  mFlashIo = {
   StallBetweenFlashAttempts
 };
 
+/**
+  Read bytes from flash with retry handling.
+
+  @param[in]     Lba       Flash block number.
+  @param[in]     Offset    Offset within the block.
+  @param[in,out] NumBytes  Requested and actual byte count.
+  @param[out]    Buffer    Destination buffer.
+
+  @return Status returned by the retry helper.
+**/
 STATIC
 EFI_STATUS
 ReadAnyBlockWithRetry (
@@ -149,6 +176,16 @@ ReadAnyBlockWithRetry (
   return FmpDeviceFlashReadWithRetry (&mFlashIo, Lba, Offset, NumBytes, Buffer);
 }
 
+/**
+  Erase, write and verify a flash block with retry handling.
+
+  @param[in]  Lba           Flash block number.
+  @param[in]  Expected      Block contents to program.
+  @param[out] VerifyBuffer  Scratch buffer for readback.
+  @param[in]  BlockSize     Flash block size.
+
+  @return Status returned by the retry helper.
+**/
 STATIC
 EFI_STATUS
 ProgramAnyBlockWithRetry (
@@ -177,11 +214,18 @@ FindFmapRegion (
   IN  CONST FMAP_HEADER  *FmapHeader,
   IN  CONST FMAP_AREA    *Areas,
   IN  UINTN              AreaCount,
-  IN  CONST CHAR8        Name[16],
+  IN  CONST CHAR8        Name[REGION_MANIFEST_NAME_LEN],
   OUT UINTN              *RegionOffset,
   OUT UINTN              *RegionSize
   );
 
+/**
+  Calculate the byte size of a validated FMAP.
+
+  @param[in] FmapHeader  FMAP header.
+
+  @return Size of the FMAP header and area table.
+**/
 STATIC
 UINTN
 FmapSize (
@@ -191,6 +235,14 @@ FmapSize (
   return sizeof (*FmapHeader) + ((UINTN)FmapHeader->AreaCount * sizeof (FMAP_AREA));
 }
 
+/**
+  Check whether a character is printable in an FMAP name.
+
+  @param[in] Character  Character to check.
+
+  @retval TRUE   Character is printable.
+  @retval FALSE  Character is not printable.
+**/
 STATIC
 BOOLEAN
 FmapIsGraph (
@@ -200,6 +252,14 @@ FmapIsGraph (
   return (Character > ' ') && (Character <= '~');
 }
 
+/**
+  Validate an FMAP name as a printable, NUL-terminated string.
+
+  @param[in] Name  FMAP name to validate.
+
+  @retval TRUE   The name is valid.
+  @retval FALSE  The name is invalid.
+**/
 STATIC
 BOOLEAN
 FmapNameIsValid (
@@ -293,7 +353,7 @@ LocateFmapInImage (
     return EFI_NOT_FOUND;
   }
 
-  for (Offset = 0; Offset + HeaderSize <= ImageSize; ++Offset) {
+  for (Offset = 0; Offset <= (ImageSize - HeaderSize); ++Offset) {
     CONST FMAP_HEADER  *Hdr = (CONST FMAP_HEADER *)(Image + Offset);
 
     if (CompareMem (Hdr->Signature, FMAP_SIGNATURE, sizeof (Hdr->Signature)) != 0) {
@@ -397,7 +457,7 @@ LoadFlashFmap (
   }
 
   Status = LocateFmapInImage (Buffer, FmapAreaSize, &FoundOffset, &FoundLength);
-  if (EFI_ERROR (Status) || ((FoundOffset + FoundLength) > FmapAreaSize)) {
+  if (EFI_ERROR (Status) || (FoundOffset > FmapAreaSize) || (FoundLength > (FmapAreaSize - FoundOffset))) {
     FreePool (Buffer);
     return EFI_NOT_FOUND;
   }
@@ -405,58 +465,6 @@ LoadFlashFmap (
   *FlashFmapHeader = (FMAP_HEADER *)((UINT8 *)Buffer + FoundOffset);
   *FlashFmapAreas  = (FMAP_AREA *)((UINT8 *)(*FlashFmapHeader) + sizeof (FMAP_HEADER));
   *FlashFmapBuffer = Buffer;
-  return EFI_SUCCESS;
-}
-
-/**
-  Locate the manifest at the end of the image.
-
-  @param[in]  Image                 Capsule payload buffer.
-  @param[in]  ImageSize             Size of the payload buffer.
-  @param[out] EntryCount            Number of manifest entries.
-  @param[out] Entries               Pointer to the first manifest entry.
-  @param[out] FirmwareImageSize     Size of the firmware image excluding the manifest.
-
-  @retval EFI_SUCCESS     Manifest found and validated.
-  @retval EFI_NOT_FOUND   Manifest not present or malformed.
-**/
-STATIC
-EFI_STATUS
-LocateRegionManifest (
-  IN  CONST UINT8                  *Image,
-  IN  UINTN                        ImageSize,
-  OUT UINTN                        *EntryCount,
-  OUT CONST REGION_MANIFEST_ENTRY  **Entries,
-  OUT UINTN                        *FirmwareImageSize
-  )
-{
-  CONST REGION_MANIFEST_TRAILER  *Trailer;
-  UINTN                          EntriesSize;
-  UINTN                          ManifestStart;
-
-  if ((Image == NULL) || (EntryCount == NULL) || (Entries == NULL) || (FirmwareImageSize == NULL)) {
-    return EFI_NOT_FOUND;
-  }
-
-  if (ImageSize < sizeof (REGION_MANIFEST_TRAILER)) {
-    return EFI_NOT_FOUND;
-  }
-
-  Trailer = (CONST REGION_MANIFEST_TRAILER *)(Image + ImageSize - sizeof (REGION_MANIFEST_TRAILER));
-  if ((Trailer->Signature != REGION_MANIFEST_SIGNATURE) || (Trailer->Version != REGION_MANIFEST_VERSION)) {
-    return EFI_NOT_FOUND;
-  }
-
-  EntriesSize   = (UINTN)Trailer->EntryCount * sizeof (REGION_MANIFEST_ENTRY);
-  ManifestStart = ImageSize - sizeof (REGION_MANIFEST_TRAILER) - EntriesSize;
-  if (ManifestStart > ImageSize) {
-    return EFI_NOT_FOUND;
-  }
-
-  *EntryCount        = Trailer->EntryCount;
-  *Entries           = (CONST REGION_MANIFEST_ENTRY *)(Image + ManifestStart);
-  *FirmwareImageSize = ManifestStart;
-
   return EFI_SUCCESS;
 }
 
@@ -484,9 +492,16 @@ FindFmapRegion (
   OUT UINTN              *RegionSize
   )
 {
-  UINTN  Index;
-  CHAR8  FmapName[33];
-  CHAR8  ManifestName[17];
+  UINT64  Base;
+  UINTN   Index;
+  CHAR8   FmapName[33];
+  CHAR8   ManifestName[REGION_MANIFEST_NAME_LEN + 1];
+
+  if ((FmapHeader == NULL) || (Areas == NULL) || (Name == NULL) ||
+      (RegionOffset == NULL) || (RegionSize == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
 
   for (Index = 0; Index < AreaCount; ++Index) {
     //
@@ -495,14 +510,19 @@ FindFmapRegion (
     //
     CopyMem (FmapName, Areas[Index].Name, 32);
     FmapName[32] = '\0';
-    CopyMem (ManifestName, Name, 16);
-    ManifestName[16] = '\0';
+    CopyMem (ManifestName, Name, REGION_MANIFEST_NAME_LEN);
+    ManifestName[REGION_MANIFEST_NAME_LEN] = '\0';
 
     if (AsciiStrCmp (FmapName, ManifestName) != 0) {
       continue;
     }
 
-    *RegionOffset = (UINTN)FmapHeader->Base + Areas[Index].Offset;
+    Base = FmapHeader->Base;
+    if ((Base > MAX_UINTN) || (Areas[Index].Offset > (MAX_UINTN - (UINTN)Base))) {
+      return EFI_COMPROMISED_DATA;
+    }
+
+    *RegionOffset = (UINTN)Base + Areas[Index].Offset;
     *RegionSize   = Areas[Index].Size;
     return EFI_SUCCESS;
   }
@@ -510,6 +530,13 @@ FindFmapRegion (
   return EFI_NOT_FOUND;
 }
 
+/**
+  Read a little-endian 32-bit value from an unaligned byte buffer.
+
+  @param[in] Data  Four-byte input buffer.
+
+  @return Decoded value.
+**/
 STATIC
 UINT32
 ReadLe32 (
@@ -585,7 +612,7 @@ FindIntelDescriptorBiosRegion (
   RegionBase  = BaseField * INTEL_DESCRIPTOR_REGION_SCALE;
   RegionLimit = (LimitField * INTEL_DESCRIPTOR_REGION_SCALE) |
                 (INTEL_DESCRIPTOR_REGION_SCALE - 1);
-  RegionSize  = RegionLimit - RegionBase + 1;
+  RegionSize = RegionLimit - RegionBase + 1;
 
   if ((RegionBase >= FlashSize) || (RegionSize > (FlashSize - RegionBase))) {
     return EFI_NOT_FOUND;
@@ -617,13 +644,13 @@ FindIntelDescriptorBiosRegion (
 STATIC
 EFI_STATUS
 FindBiosFallbackRegion (
-  IN  UINTN              BlockSize,
-  IN  UINTN              FlashSize,
-  IN  CONST UINT8        *Image,
-  IN  UINTN              ImageSize,
-  OUT UINTN              *BiosOffset,
-  OUT UINTN              *BiosSize,
-  OUT CONST CHAR8        **Source
+  IN  UINTN        BlockSize,
+  IN  UINTN        FlashSize,
+  IN  CONST UINT8  *Image,
+  IN  UINTN        ImageSize,
+  OUT UINTN        *BiosOffset,
+  OUT UINTN        *BiosSize,
+  OUT CONST CHAR8  **Source
   )
 {
   EFI_STATUS  Status;
@@ -1240,18 +1267,38 @@ FmpDeviceCheckImageWithStatus (
   ManifestList      = NULL;
   ManifestEntries   = 0;
 
-  if (ImageSize != FwSize) {
-    Status = LocateRegionManifest (Image, ImageSize, &ManifestEntries, &ManifestList, &FirmwareImageSize);
-    if (EFI_ERROR (Status) || (FirmwareImageSize != FwSize) || (ManifestEntries == 0)) {
+  Status = FmpDeviceLocateRegionManifest (
+             Image,
+             ImageSize,
+             &ManifestEntries,
+             &ManifestList,
+             &FirmwareImageSize
+             );
+  if (Status == EFI_NOT_FOUND) {
+    if (ImageSize == FwSize) {
+      FirmwareImageSize = ImageSize;
+    } else {
       DEBUG ((
         DEBUG_ERROR,
-        "%a(): image size (0x%x) doesn't match firmware size (0x%x) and no valid manifest found\n",
+        "%a(): image size (0x%x) doesn't match firmware size (0x%x)\n",
         __func__,
         ImageSize,
         FwSize
         ));
       return EFI_ABORTED;
     }
+  } else if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): invalid region manifest: %r\n", __func__, Status));
+    return EFI_ABORTED;
+  } else if (FirmwareImageSize != FwSize) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a(): manifest image size (0x%x) doesn't match firmware size (0x%x)\n",
+      __func__,
+      FirmwareImageSize,
+      FwSize
+      ));
+    return EFI_ABORTED;
   }
 
   Status = SmmStoreLibGetBlockSize (&BlockSize);
@@ -1477,6 +1524,7 @@ ReadFlashRange (
   @param[in]      RangeOffset          Offset within Image for the update range, in bytes.
   @param[in]      RangeSize            Size of the update range, in bytes.
   @param[in,out]  BlockBuffer          Scratch buffer, at least BlockSize bytes.
+  @param[out]     VerifyBuffer         Scratch buffer for flash readback.
   @param[in]      Progress             Optional progress callback.
   @param[in]      TotalSteps           Total number of progress reporting steps.
   @param[in,out]  Step                 Current step counter for progress reporting.
@@ -1799,6 +1847,7 @@ FmpDeviceSetImageWithStatus (
   UINTN                        Block;
   UINTN                        EntryIndex;
   UINTN                        NumBytes;
+  UINTN                        RangeSteps;
   UINTN                        TotalSteps;
   UINTN                        Step;
   BOOLEAN                      ShouldReportProgress;
@@ -1829,6 +1878,7 @@ FmpDeviceSetImageWithStatus (
   Block              = 0;
   ReadBuffer         = NULL;
   VerifyBuffer       = NULL;
+  TotalSteps         = 0;
 
   //
   // FmpDeviceCheckImageWithStatus() has already validated the image, so not
@@ -1852,18 +1902,18 @@ FmpDeviceSetImageWithStatus (
   // fall back to an Intel-descriptor BIOS-region update, then legacy full-flash
   // behavior.
   //
-  BaseImageSize      = ImageSize;
-  ManifestEntryCount = 0;
-  ManifestEntries    = NULL;
-  UseManifest        = FALSE;
-  UseBiosRegion      = FALSE;
-  TriedBiosFallback  = FALSE;
-  BiosOffset         = 0;
-  BiosSize           = 0;
-  FmapHeader         = NULL;
-  FmapAreas          = NULL;
-  FmapOffset         = 0;
-  FmapLength         = 0;
+  BaseImageSize          = ImageSize;
+  ManifestEntryCount     = 0;
+  ManifestEntries        = NULL;
+  UseManifest            = FALSE;
+  UseBiosRegion          = FALSE;
+  TriedBiosFallback      = FALSE;
+  BiosOffset             = 0;
+  BiosSize               = 0;
+  FmapHeader             = NULL;
+  FmapAreas              = NULL;
+  FmapOffset             = 0;
+  FmapLength             = 0;
   FlashFmapBuffer        = NULL;
   FlashFmapHeader        = NULL;
   FlashFmapAreas         = NULL;
@@ -1871,11 +1921,20 @@ FmpDeviceSetImageWithStatus (
   VariableStoreOffset    = 0;
   VariableStoreSize      = 0;
 
-  Status = LocateRegionManifest (Image, ImageSize, &ManifestEntryCount, &ManifestEntries, &BaseImageSize);
-  if (EFI_ERROR (Status)) {
+  Status = FmpDeviceLocateRegionManifest (
+             Image,
+             ImageSize,
+             &ManifestEntryCount,
+             &ManifestEntries,
+             &BaseImageSize
+             );
+  if (Status == EFI_NOT_FOUND) {
     BaseImageSize      = ImageSize;
     ManifestEntryCount = 0;
     ManifestEntries    = NULL;
+  } else if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a(): invalid region manifest: %r\n", __func__, Status));
+    return EFI_ABORTED;
   } else {
     DEBUG ((
       DEBUG_INFO,
@@ -1888,7 +1947,7 @@ FmpDeviceSetImageWithStatus (
   }
 
   Status = LocateFmapInImage (Image, BaseImageSize, &FmapOffset, &FmapLength);
-  if (!EFI_ERROR (Status) && ((FmapOffset + FmapLength) <= BaseImageSize)) {
+  if (!EFI_ERROR (Status) && (FmapOffset <= BaseImageSize) && (FmapLength <= (BaseImageSize - FmapOffset))) {
     FmapHeader = (CONST FMAP_HEADER *)((CONST UINT8 *)Image + FmapOffset);
     FmapAreas  = (CONST FMAP_AREA *)((CONST UINT8 *)FmapHeader + sizeof (FMAP_HEADER));
 
@@ -1901,7 +1960,12 @@ FmpDeviceSetImageWithStatus (
       ));
   }
 
-  if ((ManifestEntryCount > 0) && (FmapHeader != NULL) && (FmapHeader->AreaCount > 0)) {
+  if (ManifestEntryCount > 0) {
+    if ((FmapHeader == NULL) || (FmapHeader->AreaCount == 0)) {
+      DEBUG ((DEBUG_ERROR, "%a(): manifest found without a valid FMAP\n", __func__));
+      return EFI_ABORTED;
+    }
+
     UseManifest = TRUE;
   } else {
     //
@@ -1911,15 +1975,17 @@ FmpDeviceSetImageWithStatus (
     CONST CHAR8  *BiosRegionSource;
 
     TriedBiosFallback = TRUE;
-    if (!EFI_ERROR (FindBiosFallbackRegion (
-                      BlockSize,
-                      BaseImageSize,
-                      (CONST UINT8 *)Image,
-                      BaseImageSize,
-                      &BiosOffset,
-                      &BiosSize,
-                      &BiosRegionSource
-                      )))
+    if (!EFI_ERROR (
+           FindBiosFallbackRegion (
+             BlockSize,
+             BaseImageSize,
+             (CONST UINT8 *)Image,
+             BaseImageSize,
+             &BiosOffset,
+             &BiosSize,
+             &BiosRegionSource
+             )
+           ))
     {
       UseBiosRegion = TRUE;
       DEBUG ((
@@ -1930,6 +1996,47 @@ FmpDeviceSetImageWithStatus (
         (UINT32)BiosOffset,
         (UINT32)BiosSize
         ));
+    }
+  }
+
+  if (UseManifest) {
+    for (EntryIndex = 0; EntryIndex < ManifestEntryCount; ++EntryIndex) {
+      UINTN  RegionOffset;
+      UINTN  RegionSize;
+      CHAR8  RegionName[REGION_MANIFEST_NAME_LEN + 1];
+
+      Status = FindFmapRegion (
+                 FmapHeader,
+                 FmapAreas,
+                 FmapHeader->AreaCount,
+                 ManifestEntries[EntryIndex].RegionName,
+                 &RegionOffset,
+                 &RegionSize
+                 );
+      if (EFI_ERROR (Status) || (RegionSize == 0) ||
+          (RegionOffset > BaseImageSize) || (RegionSize > (BaseImageSize - RegionOffset)))
+      {
+        CopyMem (
+          RegionName,
+          ManifestEntries[EntryIndex].RegionName,
+          REGION_MANIFEST_NAME_LEN
+          );
+        RegionName[REGION_MANIFEST_NAME_LEN] = 0;
+        DEBUG ((DEBUG_ERROR, "%a(): invalid manifest region '%a'\n", __func__, RegionName));
+        return EFI_ABORTED;
+      }
+
+      Status = FmpDeviceGetFlashRangeStepCount (RegionOffset, RegionSize, BlockSize, &RangeSteps);
+      if (EFI_ERROR (Status) || (TotalSteps > (MAX_UINTN - RangeSteps))) {
+        DEBUG ((DEBUG_ERROR, "%a(): invalid progress range for manifest region\n", __func__));
+        return EFI_ABORTED;
+      }
+
+      TotalSteps += RangeSteps;
+    }
+
+    if (TotalSteps == 0) {
+      return EFI_ABORTED;
     }
   }
 
@@ -1950,14 +2057,14 @@ FmpDeviceSetImageWithStatus (
     //
     // Validate manifest regions against the FMAP before flashing.
     //
-    BOOLEAN     LayoutMismatch;
-    EFI_STATUS  FlashFmapStatus;
-    UINTN       MismatchIndex;
-    UINTN       CapsuleRegionOffset;
-    UINTN       CapsuleRegionSize;
-    UINTN       FlashRegionOffset;
-    UINTN       FlashRegionSize;
-    CONST CHAR8  SmmStoreRegionName[16] = "SMMSTORE";
+    BOOLEAN      LayoutMismatch;
+    EFI_STATUS   FlashFmapStatus;
+    UINTN        MismatchIndex;
+    UINTN        CapsuleRegionOffset;
+    UINTN        CapsuleRegionSize;
+    UINTN        FlashRegionOffset;
+    UINTN        FlashRegionSize;
+    CONST CHAR8  SmmStoreRegionName[REGION_MANIFEST_NAME_LEN] = "SMMSTORE";
 
     LayoutMismatch      = FALSE;
     MismatchIndex       = MAX_UINTN;
@@ -1996,11 +2103,10 @@ FmpDeviceSetImageWithStatus (
       }
     }
 
-    TotalSteps = 0;
     for (EntryIndex = 0; EntryIndex < ManifestEntryCount; ++EntryIndex) {
       UINTN  RegionOffset;
       UINTN  RegionSize;
-      CHAR8  RegionName[17];
+      CHAR8  RegionName[REGION_MANIFEST_NAME_LEN + 1];
 
       Status = FindFmapRegion (
                  FmapHeader,
@@ -2010,16 +2116,16 @@ FmpDeviceSetImageWithStatus (
                  &RegionOffset,
                  &RegionSize
                  );
-      if (EFI_ERROR (Status) || (RegionSize == 0) || ((RegionOffset + RegionSize) > BaseImageSize)) {
-        CopyMem (RegionName, ManifestEntries[EntryIndex].RegionName, 16);
-        RegionName[16] = 0;
-        DEBUG ((DEBUG_ERROR, "%a(): invalid manifest region '%a'\n", __func__, RegionName));
-        UseManifest = FALSE;
-        break;
+      if (EFI_ERROR (Status)) {
+        goto InvalidImage;
       }
 
-      CopyMem (RegionName, ManifestEntries[EntryIndex].RegionName, 16);
-      RegionName[16] = 0;
+      CopyMem (
+        RegionName,
+        ManifestEntries[EntryIndex].RegionName,
+        REGION_MANIFEST_NAME_LEN
+        );
+      RegionName[REGION_MANIFEST_NAME_LEN] = 0;
       DEBUG ((
         DEBUG_INFO,
         "%a(): manifest region '%a' capsule 0x%x+0x%x\n",
@@ -2058,8 +2164,6 @@ FmpDeviceSetImageWithStatus (
           VariableStorePreserved = FALSE;
         }
       }
-
-      TotalSteps += ((RegionOffset + RegionSize - 1) / BlockSize - (RegionOffset / BlockSize) + 1) * 2;
     }
 
     if (FlashFmapBuffer != NULL) {
@@ -2072,7 +2176,7 @@ FmpDeviceSetImageWithStatus (
       // Manifest regions no longer match the current flash layout; fall back to
       // flashing the full BIOS region from the new image.
       //
-      CHAR8        RegionName[17];
+      CHAR8        RegionName[REGION_MANIFEST_NAME_LEN + 1];
       CONST CHAR8  *BiosRegionSource;
 
       UseManifest            = FALSE;
@@ -2080,8 +2184,12 @@ FmpDeviceSetImageWithStatus (
       VariableStorePreserved = FALSE;
 
       if (MismatchIndex != MAX_UINTN) {
-        CopyMem (RegionName, ManifestEntries[MismatchIndex].RegionName, 16);
-        RegionName[16] = 0;
+        CopyMem (
+          RegionName,
+          ManifestEntries[MismatchIndex].RegionName,
+          REGION_MANIFEST_NAME_LEN
+          );
+        RegionName[REGION_MANIFEST_NAME_LEN] = 0;
         DEBUG ((
           DEBUG_WARN,
           "%a(): FMAP layout mismatch for '%a': flash 0x%x+0x%x vs capsule 0x%x+0x%x\n",
@@ -2095,15 +2203,17 @@ FmpDeviceSetImageWithStatus (
       }
 
       TriedBiosFallback = TRUE;
-      if (!EFI_ERROR (FindBiosFallbackRegion (
-                        BlockSize,
-                        BaseImageSize,
-                        (CONST UINT8 *)Image,
-                        BaseImageSize,
-                        &BiosOffset,
-                        &BiosSize,
-                        &BiosRegionSource
-                        )))
+      if (!EFI_ERROR (
+             FindBiosFallbackRegion (
+               BlockSize,
+               BaseImageSize,
+               (CONST UINT8 *)Image,
+               BaseImageSize,
+               &BiosOffset,
+               &BiosSize,
+               &BiosRegionSource
+               )
+             ))
       {
         UseBiosRegion = TRUE;
         DEBUG ((
@@ -2123,23 +2233,21 @@ FmpDeviceSetImageWithStatus (
   ShouldReportProgress = TRUE;
   Step                 = 0;
 
-  if (UseManifest && (TotalSteps == 0)) {
-    UseManifest = FALSE;
-  }
-
   if (!UseManifest && !UseBiosRegion && !TriedBiosFallback) {
     CONST CHAR8  *BiosRegionSource;
 
     TriedBiosFallback = TRUE;
-    if (!EFI_ERROR (FindBiosFallbackRegion (
-                      BlockSize,
-                      BaseImageSize,
-                      (CONST UINT8 *)Image,
-                      BaseImageSize,
-                      &BiosOffset,
-                      &BiosSize,
-                      &BiosRegionSource
-                      )))
+    if (!EFI_ERROR (
+           FindBiosFallbackRegion (
+             BlockSize,
+             BaseImageSize,
+             (CONST UINT8 *)Image,
+             BaseImageSize,
+             &BiosOffset,
+             &BiosSize,
+             &BiosRegionSource
+             )
+           ))
     {
       UseBiosRegion = TRUE;
       DEBUG ((
@@ -2168,8 +2276,10 @@ FmpDeviceSetImageWithStatus (
                  &RegionOffset,
                  &RegionSize
                  );
-      if (EFI_ERROR (Status) || ((RegionOffset + RegionSize) > BaseImageSize)) {
-        goto IoError;
+      if (EFI_ERROR (Status) || (RegionOffset > BaseImageSize) ||
+          (RegionSize > (BaseImageSize - RegionOffset)))
+      {
+        goto InvalidImage;
       }
 
       Status = UpdateFlashRangeFromImage (
@@ -2197,9 +2307,9 @@ FmpDeviceSetImageWithStatus (
     //
     DEBUG ((DEBUG_INFO, "%a(): BIOS-region update\n", __func__));
 
-    TotalSteps = ((BiosOffset + BiosSize - 1) / BlockSize - (BiosOffset / BlockSize) + 1) * 2;
-    if (TotalSteps == 0) {
-      goto IoError;
+    Status = FmpDeviceGetFlashRangeStepCount (BiosOffset, BiosSize, BlockSize, &TotalSteps);
+    if (EFI_ERROR (Status)) {
+      goto InvalidImage;
     }
 
     Status = UpdateFlashRangeFromImage (
@@ -2232,6 +2342,10 @@ FmpDeviceSetImageWithStatus (
       BlockCount,
       BlockSize
       ));
+
+    if (BlockCount > (MAX_UINTN / 2)) {
+      goto InvalidImage;
+    }
 
     TotalSteps = BlockCount * 2; // Erase and write of each block.
     WriteNext  = Image;
@@ -2301,6 +2415,22 @@ FmpDeviceSetImageWithStatus (
   }
 
   return EFI_SUCCESS;
+
+InvalidImage:
+  if (FlashFmapBuffer != NULL) {
+    FreePool (FlashFmapBuffer);
+  }
+
+  if (VerifyBuffer != NULL) {
+    FreePool (VerifyBuffer);
+  }
+
+  if (ReadBuffer != NULL) {
+    FreePool (ReadBuffer);
+  }
+
+  DEBUG ((DEBUG_ERROR, "%a(): capsule metadata is invalid\n", __func__));
+  return EFI_ABORTED;
 
 IoError:
   //

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -21,6 +21,8 @@
 
 [Sources]
   FmpDeviceSmmLib.c
+  FmpDeviceSmmUpdatePolicy.c
+  FmpDeviceSmmUpdatePolicy.h
 
 [LibraryClasses]
   BaseMemoryLib

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -23,6 +23,8 @@
   FmpDeviceSmmLib.c
   FmpDeviceSmmFlashRetry.c
   FmpDeviceSmmFlashRetry.h
+  FmpDeviceSmmManifest.c
+  FmpDeviceSmmManifest.h
   FmpDeviceSmmUpdatePolicy.c
   FmpDeviceSmmUpdatePolicy.h
 

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLib.inf
@@ -21,6 +21,8 @@
 
 [Sources]
   FmpDeviceSmmLib.c
+  FmpDeviceSmmFlashRetry.c
+  FmpDeviceSmmFlashRetry.h
   FmpDeviceSmmUpdatePolicy.c
   FmpDeviceSmmUpdatePolicy.h
 

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
@@ -1,0 +1,139 @@
+/** @file
+  Unit tests for SMMSTORE-backed firmware update policy.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UnitTestLib.h>
+
+#include "FmpDeviceSmmUpdatePolicy.h"
+
+#define UNIT_TEST_APP_NAME     "FmpDeviceSmmLib Unit Tests"
+#define UNIT_TEST_APP_VERSION  "1.0"
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+PreservedStoreKeepsVariableServices (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_FALSE (FmpDeviceShouldDisableVariableServices (TRUE));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+UnprovenStoreDisablesVariableServices (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_TRUE (FmpDeviceShouldDisableVariableServices (FALSE));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+OverlappingRangesAreDetected (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_TRUE (FmpDeviceFlashRangesOverlap (0x1000, 0x2000, 0x2000, 0x1000));
+  UT_ASSERT_TRUE (FmpDeviceFlashRangesOverlap (0x2000, 0x1000, 0x1000, 0x2000));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+AdjacentRangesDoNotOverlap (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_FALSE (FmpDeviceFlashRangesOverlap (0x1000, 0x1000, 0x2000, 0x1000));
+  UT_ASSERT_FALSE (FmpDeviceFlashRangesOverlap (0x2000, 0x1000, 0x1000, 0x1000));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+MalformedRangesFailClosed (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_TRUE (FmpDeviceFlashRangesOverlap (0x1000, 0, 0x2000, 0x1000));
+  UT_ASSERT_TRUE (FmpDeviceFlashRangesOverlap (MAX_UINTN - 1, 2, 0x2000, 0x1000));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+EFI_STATUS
+EFIAPI
+UnitTestingEntry (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      PolicyTests;
+
+  Framework = NULL;
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_APP_NAME, UNIT_TEST_APP_VERSION));
+
+  Status = InitUnitTestFramework (
+             &Framework,
+             UNIT_TEST_APP_NAME,
+             gEfiCallerBaseName,
+             UNIT_TEST_APP_VERSION
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = CreateUnitTestSuite (
+             &PolicyTests,
+             Framework,
+             "SMMSTORE update policy",
+             "FmpDeviceSmmLib.Policy",
+             NULL,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    FreeUnitTestFramework (Framework);
+    return Status;
+  }
+
+  AddTestCase (PolicyTests, "Preserved store keeps variable services", "PreservedStore", PreservedStoreKeepsVariableServices, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Unproven store disables variable services", "UnprovenStore", UnprovenStoreDisablesVariableServices, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Overlapping ranges are detected", "Overlap", OverlappingRangesAreDetected, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Adjacent ranges do not overlap", "Adjacent", AdjacentRangesDoNotOverlap, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Malformed ranges fail closed", "Malformed", MalformedRangesFailClosed, NULL, NULL, NULL);
+
+  Status = RunAllTestSuites (Framework);
+  FreeUnitTestFramework (Framework);
+  return Status;
+}
+
+#define FmpDeviceSmmLibUnitTestMain  main
+
+INT32
+FmpDeviceSmmLibUnitTestMain (
+  IN INT32  Argc,
+  IN CHAR8  *Argv[]
+  )
+{
+  return EFI_ERROR (UnitTestingEntry ()) ? 1 : 0;
+}

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
@@ -1,6 +1,7 @@
 /** @file
   Unit tests for SMMSTORE-backed firmware update policy.
 
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -18,6 +19,7 @@
 #include <Library/UnitTestLib.h>
 
 #include "FmpDeviceSmmFlashRetry.h"
+#include "FmpDeviceSmmManifest.h"
 #include "FmpDeviceSmmUpdatePolicy.h"
 
 #define UNIT_TEST_APP_NAME     "FmpDeviceSmmLib Unit Tests"
@@ -39,6 +41,20 @@ typedef struct {
 
 STATIC FLASH_IO_TEST_CONTEXT  mFlashContext;
 
+typedef struct {
+  UINT8                      Firmware[32];
+  REGION_MANIFEST_ENTRY      Entries[2];
+  REGION_MANIFEST_TRAILER    Trailer;
+} TEST_MANIFEST_IMAGE;
+
+/**
+  Consume one injected failure.
+
+  @param[in,out] Failures  Remaining failure count.
+
+  @retval TRUE   A failure was consumed.
+  @retval FALSE  No failures remain.
+**/
 STATIC
 BOOLEAN
 ConsumeFailure (
@@ -53,6 +69,18 @@ ConsumeFailure (
   return TRUE;
 }
 
+/**
+  Read from the in-memory test flash.
+
+  @param[in]     Lba       Ignored block number.
+  @param[in]     Offset    Offset in the test flash.
+  @param[in,out] NumBytes  Requested and actual byte count.
+  @param[out]    Buffer    Destination buffer.
+
+  @retval EFI_SUCCESS          The data was read.
+  @retval EFI_BAD_BUFFER_SIZE  The range is invalid.
+  @retval EFI_DEVICE_ERROR     An injected failure occurred.
+**/
 STATIC
 EFI_STATUS
 TestFlashRead (
@@ -79,6 +107,18 @@ TestFlashRead (
   return EFI_SUCCESS;
 }
 
+/**
+  Write to the in-memory test flash.
+
+  @param[in]     Lba       Ignored block number.
+  @param[in]     Offset    Offset in the test flash.
+  @param[in,out] NumBytes  Requested and actual byte count.
+  @param[in]     Buffer    Source buffer.
+
+  @retval EFI_SUCCESS          The data was written or a short write injected.
+  @retval EFI_BAD_BUFFER_SIZE  The range is invalid.
+  @retval EFI_DEVICE_ERROR     An injected failure occurred.
+**/
 STATIC
 EFI_STATUS
 TestFlashWrite (
@@ -106,6 +146,14 @@ TestFlashWrite (
   return EFI_SUCCESS;
 }
 
+/**
+  Erase the in-memory test flash.
+
+  @param[in] Lba  Ignored block number.
+
+  @retval EFI_SUCCESS       The block was erased.
+  @retval EFI_DEVICE_ERROR  An injected failure occurred.
+**/
 STATIC
 EFI_STATUS
 TestFlashErase (
@@ -121,6 +169,11 @@ TestFlashErase (
   return EFI_SUCCESS;
 }
 
+/**
+  Record a retry stall.
+
+  @param[in] Attempt  Ignored attempt number.
+**/
 STATIC
 VOID
 TestFlashStall (
@@ -137,6 +190,9 @@ STATIC CONST FMP_DEVICE_FLASH_IO  mTestFlashIo = {
   TestFlashStall
 };
 
+/**
+  Reset the in-memory flash test context.
+**/
 STATIC
 VOID
 ResetFlashContext (
@@ -146,6 +202,13 @@ ResetFlashContext (
   ZeroMem (&mFlashContext, sizeof (mFlashContext));
 }
 
+/**
+  Verify preserved variable storage keeps variable services enabled.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -157,6 +220,13 @@ PreservedStoreKeepsVariableServices (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify unproven variable storage disables variable services.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -168,6 +238,13 @@ UnprovenStoreDisablesVariableServices (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify overlapping flash ranges are detected.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -180,6 +257,13 @@ OverlappingRangesAreDetected (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify adjacent flash ranges are not treated as overlapping.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -192,6 +276,13 @@ AdjacentRangesDoNotOverlap (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify malformed flash ranges fail closed.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -204,6 +295,222 @@ MalformedRangesFailClosed (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify flash update steps are calculated across block boundaries.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+FlashRangeStepsAreCalculated (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       StepCount;
+
+  Status = FmpDeviceGetFlashRangeStepCount (15, 2, 16, &StepCount);
+
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+  UT_ASSERT_EQUAL (StepCount, 4);
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Verify flash update step arithmetic rejects overflow.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+FlashRangeStepOverflowFails (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINTN  StepCount;
+
+  UT_ASSERT_EQUAL (
+    FmpDeviceGetFlashRangeStepCount (MAX_UINTN, 2, 16, &StepCount),
+    EFI_BAD_BUFFER_SIZE
+    );
+  UT_ASSERT_EQUAL (
+    FmpDeviceGetFlashRangeStepCount (0, MAX_UINTN, 1, &StepCount),
+    EFI_BAD_BUFFER_SIZE
+    );
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Initialize a test image containing an RMAP manifest.
+
+  @param[out] Image       Image to initialize.
+  @param[in]  EntryCount  Manifest entry count.
+**/
+STATIC
+VOID
+InitializeManifestImage (
+  OUT TEST_MANIFEST_IMAGE  *Image,
+  IN  UINT16               EntryCount
+  )
+{
+  ZeroMem (Image, sizeof (*Image));
+  CopyMem (Image->Entries[0].RegionName, "COREBOOT", sizeof ("COREBOOT"));
+  CopyMem (Image->Entries[1].RegionName, "FW_MAIN_A", sizeof ("FW_MAIN_A"));
+  Image->Trailer.Signature  = REGION_MANIFEST_SIGNATURE;
+  Image->Trailer.Version    = REGION_MANIFEST_VERSION;
+  Image->Trailer.EntryCount = EntryCount;
+}
+
+/**
+  Verify an image without a manifest reports EFI_NOT_FOUND.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+AbsentManifestIsReported (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS                   Status;
+  UINT8                        Image[32];
+  UINTN                        EntryCount;
+  CONST REGION_MANIFEST_ENTRY  *Entries;
+  UINTN                        FirmwareImageSize;
+
+  ZeroMem (Image, sizeof (Image));
+  Status = FmpDeviceLocateRegionManifest (
+             Image,
+             sizeof (Image),
+             &EntryCount,
+             &Entries,
+             &FirmwareImageSize
+             );
+
+  UT_ASSERT_EQUAL (Status, EFI_NOT_FOUND);
+  UT_ASSERT_EQUAL (EntryCount, 0);
+  UT_ASSERT_EQUAL ((UINTN)Entries, (UINTN)NULL);
+  UT_ASSERT_EQUAL (FirmwareImageSize, sizeof (Image));
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Verify a valid manifest is located and decoded.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+ValidManifestIsLocated (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS                   Status;
+  TEST_MANIFEST_IMAGE          Image;
+  UINTN                        EntryCount;
+  CONST REGION_MANIFEST_ENTRY  *Entries;
+  UINTN                        FirmwareImageSize;
+
+  InitializeManifestImage (&Image, ARRAY_SIZE (Image.Entries));
+  Status = FmpDeviceLocateRegionManifest (
+             (CONST UINT8 *)&Image,
+             sizeof (Image),
+             &EntryCount,
+             &Entries,
+             &FirmwareImageSize
+             );
+
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+  UT_ASSERT_EQUAL (EntryCount, ARRAY_SIZE (Image.Entries));
+  UT_ASSERT_EQUAL ((UINTN)Entries, (UINTN)Image.Entries);
+  UT_ASSERT_EQUAL (FirmwareImageSize, sizeof (Image.Firmware));
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Verify malformed manifests are rejected.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+MalformedManifestFailsClosed (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS                   Status;
+  TEST_MANIFEST_IMAGE          Image;
+  UINTN                        EntryCount;
+  CONST REGION_MANIFEST_ENTRY  *Entries;
+  UINTN                        FirmwareImageSize;
+
+  InitializeManifestImage (&Image, ARRAY_SIZE (Image.Entries));
+  Image.Trailer.Version = REGION_MANIFEST_VERSION + 1;
+  Status                = FmpDeviceLocateRegionManifest (
+                            (CONST UINT8 *)&Image,
+                            sizeof (Image),
+                            &EntryCount,
+                            &Entries,
+                            &FirmwareImageSize
+                            );
+  UT_ASSERT_EQUAL (Status, EFI_COMPROMISED_DATA);
+
+  InitializeManifestImage (&Image, MAX_UINT16);
+  Status = FmpDeviceLocateRegionManifest (
+             (CONST UINT8 *)&Image,
+             sizeof (Image),
+             &EntryCount,
+             &Entries,
+             &FirmwareImageSize
+             );
+  UT_ASSERT_EQUAL (Status, EFI_COMPROMISED_DATA);
+
+  InitializeManifestImage (&Image, ARRAY_SIZE (Image.Entries));
+  CopyMem (Image.Entries[1].RegionName, Image.Entries[0].RegionName, sizeof (Image.Entries[1].RegionName));
+  Status = FmpDeviceLocateRegionManifest (
+             (CONST UINT8 *)&Image,
+             sizeof (Image),
+             &EntryCount,
+             &Entries,
+             &FirmwareImageSize
+             );
+  UT_ASSERT_EQUAL (Status, EFI_COMPROMISED_DATA);
+
+  InitializeManifestImage (&Image, ARRAY_SIZE (Image.Entries));
+  Image.Entries[0].RegionName[9] = 'X';
+  Status                         = FmpDeviceLocateRegionManifest (
+                                     (CONST UINT8 *)&Image,
+                                     sizeof (Image),
+                                     &EntryCount,
+                                     &Entries,
+                                     &FirmwareImageSize
+                                     );
+  UT_ASSERT_EQUAL (Status, EFI_COMPROMISED_DATA);
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Verify transient erase, write and verify failures recover.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -231,6 +538,13 @@ TransientFlashErrorsRecover (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify persistent read failures exhaust the retry limit.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -253,6 +567,13 @@ ReadErrorsExhaustRetryLimit (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify persistent erase failures exhaust the retry limit.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -272,6 +593,13 @@ EraseErrorsExhaustRetryLimit (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify persistent write failures exhaust the retry limit.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -294,6 +622,13 @@ WriteErrorsExhaustRetryLimit (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Verify repeated short writes exhaust the retry limit.
+
+  @param[in] Context  Unit test context.
+
+  @retval UNIT_TEST_PASSED  The test passed.
+**/
 STATIC
 UNIT_TEST_STATUS
 EFIAPI
@@ -317,6 +652,12 @@ ShortWritesExhaustRetryLimit (
   return UNIT_TEST_PASSED;
 }
 
+/**
+  Create and run the SMMSTORE update policy test suite.
+
+  @retval EFI_SUCCESS  All tests passed.
+  @retval Others       Test framework setup or execution failed.
+**/
 STATIC
 EFI_STATUS
 EFIAPI
@@ -359,6 +700,11 @@ UnitTestingEntry (
   AddTestCase (PolicyTests, "Overlapping ranges are detected", "Overlap", OverlappingRangesAreDetected, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Adjacent ranges do not overlap", "Adjacent", AdjacentRangesDoNotOverlap, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Malformed ranges fail closed", "Malformed", MalformedRangesFailClosed, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Flash range steps are calculated", "StepCount", FlashRangeStepsAreCalculated, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Flash range step overflow fails", "StepOverflow", FlashRangeStepOverflowFails, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Absent manifest is reported", "ManifestAbsent", AbsentManifestIsReported, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Valid manifest is located", "ManifestValid", ValidManifestIsLocated, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Malformed manifest fails closed", "ManifestMalformed", MalformedManifestFailsClosed, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Transient flash errors recover", "TransientIo", TransientFlashErrorsRecover, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Read errors exhaust retry limit", "ReadError", ReadErrorsExhaustRetryLimit, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Erase errors exhaust retry limit", "EraseError", EraseErrorsExhaustRetryLimit, NULL, NULL, NULL);
@@ -372,6 +718,15 @@ UnitTestingEntry (
 
 #define FmpDeviceSmmLibUnitTestMain  main
 
+/**
+  Host test application entry point.
+
+  @param[in] Argc  Command-line argument count.
+  @param[in] Argv  Command-line arguments.
+
+  @retval 0  All tests passed.
+  @retval 1  A test failed.
+**/
 INT32
 FmpDeviceSmmLibUnitTestMain (
   IN INT32  Argc,

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTest.c
@@ -12,14 +12,139 @@
 #include <cmocka.h>
 
 #include <Uefi.h>
+#include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UnitTestLib.h>
 
+#include "FmpDeviceSmmFlashRetry.h"
 #include "FmpDeviceSmmUpdatePolicy.h"
 
 #define UNIT_TEST_APP_NAME     "FmpDeviceSmmLib Unit Tests"
 #define UNIT_TEST_APP_VERSION  "1.0"
+#define TEST_BLOCK_SIZE        16
+
+typedef struct {
+  UINTN      ReadFailures;
+  UINTN      WriteFailures;
+  UINTN      EraseFailures;
+  UINTN      CorruptReads;
+  BOOLEAN    ShortWrites;
+  UINTN      ReadCalls;
+  UINTN      WriteCalls;
+  UINTN      EraseCalls;
+  UINTN      StallCalls;
+  UINT8      Storage[TEST_BLOCK_SIZE];
+} FLASH_IO_TEST_CONTEXT;
+
+STATIC FLASH_IO_TEST_CONTEXT  mFlashContext;
+
+STATIC
+BOOLEAN
+ConsumeFailure (
+  IN OUT UINTN  *Failures
+  )
+{
+  if (*Failures == 0) {
+    return FALSE;
+  }
+
+  (*Failures)--;
+  return TRUE;
+}
+
+STATIC
+EFI_STATUS
+TestFlashRead (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  OUT    UINT8    *Buffer
+  )
+{
+  mFlashContext.ReadCalls++;
+  if (ConsumeFailure (&mFlashContext.ReadFailures)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if ((Offset > sizeof (mFlashContext.Storage)) || (*NumBytes > (sizeof (mFlashContext.Storage) - Offset))) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  CopyMem (Buffer, mFlashContext.Storage + Offset, *NumBytes);
+  if (ConsumeFailure (&mFlashContext.CorruptReads) && (*NumBytes > 0)) {
+    Buffer[0] ^= 0xff;
+  }
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+TestFlashWrite (
+  IN     EFI_LBA  Lba,
+  IN     UINTN    Offset,
+  IN OUT UINTN    *NumBytes,
+  IN     UINT8    *Buffer
+  )
+{
+  mFlashContext.WriteCalls++;
+  if (ConsumeFailure (&mFlashContext.WriteFailures)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (mFlashContext.ShortWrites && (*NumBytes > 0)) {
+    (*NumBytes)--;
+    return EFI_SUCCESS;
+  }
+
+  if ((Offset > sizeof (mFlashContext.Storage)) || (*NumBytes > (sizeof (mFlashContext.Storage) - Offset))) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  CopyMem (mFlashContext.Storage + Offset, Buffer, *NumBytes);
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+TestFlashErase (
+  IN EFI_LBA  Lba
+  )
+{
+  mFlashContext.EraseCalls++;
+  if (ConsumeFailure (&mFlashContext.EraseFailures)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  SetMem (mFlashContext.Storage, sizeof (mFlashContext.Storage), 0xff);
+  return EFI_SUCCESS;
+}
+
+STATIC
+VOID
+TestFlashStall (
+  IN UINTN  Attempt
+  )
+{
+  mFlashContext.StallCalls++;
+}
+
+STATIC CONST FMP_DEVICE_FLASH_IO  mTestFlashIo = {
+  TestFlashRead,
+  TestFlashWrite,
+  TestFlashErase,
+  TestFlashStall
+};
+
+STATIC
+VOID
+ResetFlashContext (
+  VOID
+  )
+{
+  ZeroMem (&mFlashContext, sizeof (mFlashContext));
+}
 
 STATIC
 UNIT_TEST_STATUS
@@ -80,6 +205,119 @@ MalformedRangesFailClosed (
 }
 
 STATIC
+UNIT_TEST_STATUS
+EFIAPI
+TransientFlashErrorsRecover (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       Expected[TEST_BLOCK_SIZE];
+  UINT8       VerifyBuffer[TEST_BLOCK_SIZE];
+
+  ResetFlashContext ();
+  SetMem (Expected, sizeof (Expected), 0x5a);
+  mFlashContext.EraseFailures = 1;
+  mFlashContext.WriteFailures = 1;
+  mFlashContext.CorruptReads  = 1;
+
+  Status = FmpDeviceFlashProgramWithRetry (&mTestFlashIo, 0, Expected, VerifyBuffer, sizeof (Expected));
+
+  UT_ASSERT_NOT_EFI_ERROR (Status);
+  UT_ASSERT_EQUAL (mFlashContext.EraseCalls, 3);
+  UT_ASSERT_EQUAL (mFlashContext.WriteCalls, 3);
+  UT_ASSERT_EQUAL (mFlashContext.ReadCalls, 2);
+  UT_ASSERT_MEM_EQUAL (mFlashContext.Storage, Expected, sizeof (Expected));
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+ReadErrorsExhaustRetryLimit (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+  UINT8       Buffer[TEST_BLOCK_SIZE];
+
+  ResetFlashContext ();
+  mFlashContext.ReadFailures = FMP_DEVICE_SMM_FLASH_RETRY_COUNT;
+  NumBytes                   = sizeof (Buffer);
+
+  Status = FmpDeviceFlashReadWithRetry (&mTestFlashIo, 0, 0, &NumBytes, Buffer);
+
+  UT_ASSERT_EQUAL (Status, EFI_DEVICE_ERROR);
+  UT_ASSERT_EQUAL (mFlashContext.ReadCalls, FMP_DEVICE_SMM_FLASH_RETRY_COUNT);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+EraseErrorsExhaustRetryLimit (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+
+  ResetFlashContext ();
+  mFlashContext.EraseFailures = FMP_DEVICE_SMM_FLASH_RETRY_COUNT;
+
+  Status = FmpDeviceFlashEraseWithRetry (&mTestFlashIo, 0);
+
+  UT_ASSERT_EQUAL (Status, EFI_DEVICE_ERROR);
+  UT_ASSERT_EQUAL (mFlashContext.EraseCalls, FMP_DEVICE_SMM_FLASH_RETRY_COUNT);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+WriteErrorsExhaustRetryLimit (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+  UINT8       Buffer[TEST_BLOCK_SIZE];
+
+  ResetFlashContext ();
+  mFlashContext.WriteFailures = FMP_DEVICE_SMM_FLASH_RETRY_COUNT;
+  NumBytes                    = sizeof (Buffer);
+
+  Status = FmpDeviceFlashWriteWithRetry (&mTestFlashIo, 0, 0, &NumBytes, Buffer);
+
+  UT_ASSERT_EQUAL (Status, EFI_DEVICE_ERROR);
+  UT_ASSERT_EQUAL (mFlashContext.WriteCalls, FMP_DEVICE_SMM_FLASH_RETRY_COUNT);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+ShortWritesExhaustRetryLimit (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       NumBytes;
+  UINT8       Buffer[TEST_BLOCK_SIZE];
+
+  ResetFlashContext ();
+  mFlashContext.ShortWrites = TRUE;
+  NumBytes                  = sizeof (Buffer);
+
+  Status = FmpDeviceFlashWriteWithRetry (&mTestFlashIo, 0, 0, &NumBytes, Buffer);
+
+  UT_ASSERT_EQUAL (Status, EFI_DEVICE_ERROR);
+  UT_ASSERT_EQUAL (mFlashContext.WriteCalls, FMP_DEVICE_SMM_FLASH_RETRY_COUNT);
+  UT_ASSERT_EQUAL (NumBytes, sizeof (Buffer) - 1);
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
 EFI_STATUS
 EFIAPI
 UnitTestingEntry (
@@ -121,6 +359,11 @@ UnitTestingEntry (
   AddTestCase (PolicyTests, "Overlapping ranges are detected", "Overlap", OverlappingRangesAreDetected, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Adjacent ranges do not overlap", "Adjacent", AdjacentRangesDoNotOverlap, NULL, NULL, NULL);
   AddTestCase (PolicyTests, "Malformed ranges fail closed", "Malformed", MalformedRangesFailClosed, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Transient flash errors recover", "TransientIo", TransientFlashErrorsRecover, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Read errors exhaust retry limit", "ReadError", ReadErrorsExhaustRetryLimit, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Erase errors exhaust retry limit", "EraseError", EraseErrorsExhaustRetryLimit, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Write errors exhaust retry limit", "WriteError", WriteErrorsExhaustRetryLimit, NULL, NULL, NULL);
+  AddTestCase (PolicyTests, "Short writes exhaust retry limit", "ShortWrite", ShortWritesExhaustRetryLimit, NULL, NULL, NULL);
 
   Status = RunAllTestSuites (Framework);
   FreeUnitTestFramework (Framework);

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
@@ -1,6 +1,7 @@
 ## @file
 # Host unit tests for SMMSTORE-backed firmware update policy.
 #
+# Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -15,6 +16,8 @@
   FmpDeviceSmmLibUnitTest.c
   FmpDeviceSmmFlashRetry.c
   FmpDeviceSmmFlashRetry.h
+  FmpDeviceSmmManifest.c
+  FmpDeviceSmmManifest.h
   FmpDeviceSmmUpdatePolicy.c
   FmpDeviceSmmUpdatePolicy.h
 

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
@@ -1,0 +1,27 @@
+## @file
+# Host unit tests for SMMSTORE-backed firmware update policy.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = FmpDeviceSmmLibUnitTest
+  FILE_GUID           = 2A8F905F-D9DF-4292-99BB-1D5122260ADE
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = HOST_APPLICATION
+
+[Sources]
+  FmpDeviceSmmLibUnitTest.c
+  FmpDeviceSmmUpdatePolicy.c
+  FmpDeviceSmmUpdatePolicy.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  DebugLib
+  MemoryAllocationLib
+  UnitTestLib

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf
@@ -13,6 +13,8 @@
 
 [Sources]
   FmpDeviceSmmLibUnitTest.c
+  FmpDeviceSmmFlashRetry.c
+  FmpDeviceSmmFlashRetry.h
   FmpDeviceSmmUpdatePolicy.c
   FmpDeviceSmmUpdatePolicy.h
 
@@ -22,6 +24,7 @@
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
 
 [LibraryClasses]
+  BaseMemoryLib
   DebugLib
   MemoryAllocationLib
   UnitTestLib

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmManifest.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmManifest.c
@@ -1,0 +1,177 @@
+/** @file
+  Internal RMAP manifest parsing for SMMSTORE-backed firmware updates.
+
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+
+#include <Library/BaseMemoryLib.h>
+
+#include "FmpDeviceSmmManifest.h"
+
+/**
+  Check that a manifest region name is printable and NUL-padded.
+
+  @param[in] Name  Region name to validate.
+
+  @retval TRUE   The region name is valid.
+  @retval FALSE  The region name is invalid.
+**/
+STATIC
+BOOLEAN
+RegionNameIsValid (
+  IN CONST CHAR8  Name[REGION_MANIFEST_NAME_LEN]
+  )
+{
+  BOOLEAN  HasCharacter;
+  BOOLEAN  Terminated;
+  UINTN    Index;
+
+  HasCharacter = FALSE;
+  Terminated   = FALSE;
+
+  for (Index = 0; Index < REGION_MANIFEST_NAME_LEN; ++Index) {
+    if (Name[Index] == '\0') {
+      Terminated = TRUE;
+      continue;
+    }
+
+    if (Terminated || (Name[Index] <= ' ') || (Name[Index] > '~')) {
+      return FALSE;
+    }
+
+    HasCharacter = TRUE;
+  }
+
+  return HasCharacter;
+}
+
+/**
+  Locate and validate an RMAP manifest appended to a firmware image.
+
+  @param[in]  Image              Firmware image.
+  @param[in]  ImageSize          Size of Image, in bytes.
+  @param[out] EntryCount         Number of manifest entries.
+  @param[out] Entries            Pointer to the manifest entries.
+  @param[out] FirmwareImageSize  Size of the firmware data before the manifest.
+
+  @retval EFI_SUCCESS           A valid manifest was found.
+  @retval EFI_NOT_FOUND         The image has no manifest.
+  @retval EFI_COMPROMISED_DATA  The manifest is malformed.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+**/
+EFI_STATUS
+FmpDeviceLocateRegionManifest (
+  IN  CONST UINT8                  *Image,
+  IN  UINTN                        ImageSize,
+  OUT UINTN                        *EntryCount,
+  OUT CONST REGION_MANIFEST_ENTRY  **Entries,
+  OUT UINTN                        *FirmwareImageSize
+  )
+{
+  REGION_MANIFEST_TRAILER      Trailer;
+  CONST REGION_MANIFEST_ENTRY  *ManifestEntries;
+  UINTN                        EntriesSize;
+  UINTN                        ManifestStart;
+  UINTN                        EntryIndex;
+  UINTN                        OtherIndex;
+
+  if ((Image == NULL) || (EntryCount == NULL) || (Entries == NULL) || (FirmwareImageSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *EntryCount        = 0;
+  *Entries           = NULL;
+  *FirmwareImageSize = ImageSize;
+
+  if (ImageSize < sizeof (Trailer)) {
+    return EFI_NOT_FOUND;
+  }
+
+  CopyMem (&Trailer, Image + ImageSize - sizeof (Trailer), sizeof (Trailer));
+  if (Trailer.Signature != REGION_MANIFEST_SIGNATURE) {
+    return EFI_NOT_FOUND;
+  }
+
+  if ((Trailer.Version != REGION_MANIFEST_VERSION) || (Trailer.EntryCount == 0)) {
+    return EFI_COMPROMISED_DATA;
+  }
+
+  if (Trailer.EntryCount > ((ImageSize - sizeof (Trailer)) / sizeof (REGION_MANIFEST_ENTRY))) {
+    return EFI_COMPROMISED_DATA;
+  }
+
+  EntriesSize   = (UINTN)Trailer.EntryCount * sizeof (REGION_MANIFEST_ENTRY);
+  ManifestStart = ImageSize - sizeof (Trailer) - EntriesSize;
+  if (ManifestStart == 0) {
+    return EFI_COMPROMISED_DATA;
+  }
+
+  ManifestEntries = (CONST REGION_MANIFEST_ENTRY *)(Image + ManifestStart);
+  for (EntryIndex = 0; EntryIndex < Trailer.EntryCount; ++EntryIndex) {
+    if (!RegionNameIsValid (ManifestEntries[EntryIndex].RegionName)) {
+      return EFI_COMPROMISED_DATA;
+    }
+
+    for (OtherIndex = 0; OtherIndex < EntryIndex; ++OtherIndex) {
+      if (CompareMem (
+            ManifestEntries[EntryIndex].RegionName,
+            ManifestEntries[OtherIndex].RegionName,
+            sizeof (ManifestEntries[EntryIndex].RegionName)
+            ) == 0)
+      {
+        return EFI_COMPROMISED_DATA;
+      }
+    }
+  }
+
+  *EntryCount        = Trailer.EntryCount;
+  *Entries           = ManifestEntries;
+  *FirmwareImageSize = ManifestStart;
+  return EFI_SUCCESS;
+}
+
+/**
+  Calculate the erase and write steps needed to update a flash range.
+
+  @param[in]  Offset     Flash range offset.
+  @param[in]  Size       Flash range size.
+  @param[in]  BlockSize  Flash erase block size.
+  @param[out] StepCount  Number of erase and write steps.
+
+  @retval EFI_SUCCESS           StepCount was calculated.
+  @retval EFI_BAD_BUFFER_SIZE   The range or step count overflows.
+  @retval EFI_INVALID_PARAMETER A parameter is invalid.
+**/
+EFI_STATUS
+FmpDeviceGetFlashRangeStepCount (
+  IN  UINTN  Offset,
+  IN  UINTN  Size,
+  IN  UINTN  BlockSize,
+  OUT UINTN  *StepCount
+  )
+{
+  UINTN  FirstBlock;
+  UINTN  LastBlock;
+  UINTN  BlockCount;
+
+  if ((Size == 0) || (BlockSize == 0) || (StepCount == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Offset > (MAX_UINTN - (Size - 1))) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  FirstBlock = Offset / BlockSize;
+  LastBlock  = (Offset + Size - 1) / BlockSize;
+  BlockCount = LastBlock - FirstBlock + 1;
+  if (BlockCount > (MAX_UINTN / 2)) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  *StepCount = BlockCount * 2;
+  return EFI_SUCCESS;
+}

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmManifest.h
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmManifest.h
@@ -1,0 +1,43 @@
+/** @file
+  Internal RMAP manifest parsing for SMMSTORE-backed firmware updates.
+
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Base.h>
+
+#define REGION_MANIFEST_SIGNATURE  SIGNATURE_32 ('R', 'M', 'A', 'P')
+#define REGION_MANIFEST_VERSION    1
+#define REGION_MANIFEST_NAME_LEN   16
+
+#pragma pack(1)
+typedef struct {
+  UINT32    Signature;
+  UINT16    Version;
+  UINT16    EntryCount;
+} REGION_MANIFEST_TRAILER;
+
+typedef struct {
+  CHAR8    RegionName[REGION_MANIFEST_NAME_LEN];
+} REGION_MANIFEST_ENTRY;
+#pragma pack()
+
+EFI_STATUS
+FmpDeviceLocateRegionManifest (
+  IN  CONST UINT8                  *Image,
+  IN  UINTN                        ImageSize,
+  OUT UINTN                        *EntryCount,
+  OUT CONST REGION_MANIFEST_ENTRY  **Entries,
+  OUT UINTN                        *FirmwareImageSize
+  );
+
+EFI_STATUS
+FmpDeviceGetFlashRangeStepCount (
+  IN  UINTN  Offset,
+  IN  UINTN  Size,
+  IN  UINTN  BlockSize,
+  OUT UINTN  *StepCount
+  );

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.c
@@ -1,11 +1,23 @@
 /** @file
   Internal policy helpers for SMMSTORE-backed firmware updates.
 
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include "FmpDeviceSmmUpdatePolicy.h"
 
+/**
+  Check whether two flash ranges overlap or are malformed.
+
+  @param[in] FirstOffset   First range offset.
+  @param[in] FirstSize     First range size.
+  @param[in] SecondOffset  Second range offset.
+  @param[in] SecondSize    Second range size.
+
+  @retval TRUE   The ranges overlap or are malformed.
+  @retval FALSE  The ranges are valid and separate.
+**/
 BOOLEAN
 FmpDeviceFlashRangesOverlap (
   IN UINTN  FirstOffset,
@@ -25,6 +37,14 @@ FmpDeviceFlashRangesOverlap (
          (SecondOffset < (FirstOffset + FirstSize));
 }
 
+/**
+  Determine whether variable services must be disabled after an update.
+
+  @param[in] VariableStorePreserved  Whether the variable store was preserved.
+
+  @retval TRUE   Disable variable services.
+  @retval FALSE  Keep variable services enabled.
+**/
 BOOLEAN
 FmpDeviceShouldDisableVariableServices (
   IN BOOLEAN  VariableStorePreserved

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.c
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.c
@@ -1,0 +1,34 @@
+/** @file
+  Internal policy helpers for SMMSTORE-backed firmware updates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "FmpDeviceSmmUpdatePolicy.h"
+
+BOOLEAN
+FmpDeviceFlashRangesOverlap (
+  IN UINTN  FirstOffset,
+  IN UINTN  FirstSize,
+  IN UINTN  SecondOffset,
+  IN UINTN  SecondSize
+  )
+{
+  if ((FirstSize == 0) || (SecondSize == 0) ||
+      (FirstOffset > (MAX_UINTN - FirstSize)) ||
+      (SecondOffset > (MAX_UINTN - SecondSize)))
+  {
+    return TRUE;
+  }
+
+  return (FirstOffset < (SecondOffset + SecondSize)) &&
+         (SecondOffset < (FirstOffset + FirstSize));
+}
+
+BOOLEAN
+FmpDeviceShouldDisableVariableServices (
+  IN BOOLEAN  VariableStorePreserved
+  )
+{
+  return !VariableStorePreserved;
+}

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.h
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.h
@@ -1,0 +1,22 @@
+/** @file
+  Internal policy helpers for SMMSTORE-backed firmware updates.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Base.h>
+
+BOOLEAN
+FmpDeviceFlashRangesOverlap (
+  IN UINTN  FirstOffset,
+  IN UINTN  FirstSize,
+  IN UINTN  SecondOffset,
+  IN UINTN  SecondSize
+  );
+
+BOOLEAN
+FmpDeviceShouldDisableVariableServices (
+  IN BOOLEAN  VariableStorePreserved
+  );

--- a/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.h
+++ b/UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmUpdatePolicy.h
@@ -1,6 +1,7 @@
 /** @file
   Internal policy helpers for SMMSTORE-backed firmware updates.
 
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 

--- a/UefiPayloadPkg/Test/UefiPayloadPkgHostTest.dsc
+++ b/UefiPayloadPkg/Test/UefiPayloadPkgHostTest.dsc
@@ -1,0 +1,20 @@
+## @file
+# UefiPayloadPkg host-based unit tests.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  PLATFORM_NAME           = UefiPayloadPkgHostTest
+  PLATFORM_GUID           = 890D9F9C-1D24-45FE-B88B-8E3D06CF5795
+  PLATFORM_VERSION        = 0.1
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/UefiPayloadPkg/HostTest
+  SUPPORTED_ARCHITECTURES = IA32|X64
+  BUILD_TARGETS           = NOOPT
+  SKUID_IDENTIFIER        = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+[Components]
+  UefiPayloadPkg/Library/FmpDeviceSmmLib/FmpDeviceSmmLibUnitTestHost.inf

--- a/UefiPayloadPkg/Test/UefiPayloadPkgHostTest.dsc
+++ b/UefiPayloadPkg/Test/UefiPayloadPkgHostTest.dsc
@@ -1,6 +1,7 @@
 ## @file
 # UefiPayloadPkg host-based unit tests.
 #
+# Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 

--- a/UefiPayloadPkg/Tools/AppendRmapManifest.py
+++ b/UefiPayloadPkg/Tools/AppendRmapManifest.py
@@ -1,0 +1,137 @@
+## @file
+# Append an RMAP region manifest trailer to a firmware image.
+#
+# The manifest is a simple list of FMAP region names the firmware update
+# should program. It is consumed by the UefiPayloadPkg FMP device library.
+# If the manifest is absent, firmware falls back to full-flash updates.
+#
+# Copyright (c) 2025, 3mdeb Sp. z o.o. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import argparse
+import os
+import struct
+import sys
+import subprocess
+
+#
+# Globals for help information
+#
+__prog__        = 'AppendRmapManifest'
+__description__ = 'Append an RMAP manifest trailer listing FMAP regions to flash.'
+__copyright__   = 'Copyright (c) 2025, 3mdeb Sp. z o.o. All rights reserved.'
+
+# SIGNATURE_32('R','M','A','P')
+RMAP_SIGNATURE = 0x50414D52
+RMAP_VERSION   = 1
+ENTRY_SIZE     = 16
+
+
+def build_manifest(region_names):
+    """Return the encoded manifest bytes for the given region names."""
+    entries = []
+    for name in region_names:
+        try:
+            encoded = name.encode('ascii')
+        except UnicodeError:
+            raise ValueError("Region name '{}' is not ASCII".format(name))
+        if len(encoded) > ENTRY_SIZE:
+            raise ValueError("Region name '{}' longer than {} bytes".format(name, ENTRY_SIZE))
+        entries.append(struct.pack('<{}s'.format(ENTRY_SIZE), encoded))
+
+    trailer = struct.pack('<IHH', RMAP_SIGNATURE, RMAP_VERSION, len(entries))
+    return b''.join(entries) + trailer
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__description__)
+    parser.add_argument('input', help='Input firmware image (FMP payload)')
+    parser.add_argument('-o', '--output', help='Output path (default: overwrite input)')
+    parser.add_argument(
+        '-r',
+        '--region',
+        action='append',
+        dest='regions',
+        required=True,
+        help='FMAP region name to flash (repeat for multiple regions)'
+    )
+    parser.add_argument('--fmp-guid', help='FMP/ESRT ImageTypeId GUID for the capsule payload')
+    parser.add_argument('--fw-version', type=int, default=1, help='Firmware version for capsule payload')
+    parser.add_argument('--lsv', type=int, default=0, help='Lowest supported version for capsule payload')
+    parser.add_argument('--update-image-index', type=int, help='UpdateImageIndex for the capsule payload')
+    parser.add_argument('--capsule-guid', help='(Deprecated) Ignored when using GenerateCapsule')
+    parser.add_argument('--embedded-driver', help='Optional embedded driver (.efi) to include in capsule')
+    parser.add_argument('--capflag', default='PersistAcrossReset',
+                        choices=['PersistAcrossReset', 'InitiateReset'],
+                        help='Capsule flag (default: PersistAcrossReset)')
+    parser.add_argument('--cap-output', help='Optional .cap output; enables capsule build via GenerateCapsule')
+    parser.add_argument('--generatecapsule', default='BaseTools/BinWrappers/PosixLike/GenerateCapsule',
+                        help='Path to GenerateCapsule wrapper')
+
+    args = parser.parse_args()
+
+    out_path = args.output or args.input
+    try:
+        with open(args.input, 'rb') as infile:
+            image = infile.read()
+    except IOError as exc:
+        print("error: failed to read '{}': {}".format(args.input, exc), file=sys.stderr)
+        return 1
+
+    try:
+        manifest = build_manifest(args.regions)
+    except ValueError as exc:
+        print("error: {}".format(exc), file=sys.stderr)
+        return 1
+
+    try:
+        with open(out_path, 'wb') as outfile:
+            outfile.write(image)
+            outfile.write(manifest)
+    except IOError as exc:
+        print("error: failed to write '{}': {}".format(out_path, exc), file=sys.stderr)
+        return 1
+
+    print("Appended {} region(s) manifest to {}".format(len(args.regions), os.path.abspath(out_path)))
+
+    if not args.cap_output:
+        return 0
+
+    if not args.fmp_guid:
+        print("error: --fmp-guid is required when building a capsule", file=sys.stderr)
+        return 1
+
+    if args.capsule_guid:
+        print("warning: --capsule-guid is deprecated and ignored by GenerateCapsule", file=sys.stderr)
+
+    generate_capsule_cmd = [
+        args.generatecapsule,
+        '-e',
+        '--guid', args.fmp_guid,
+        '--fw-version', str(args.fw_version),
+        '--lsv', str(args.lsv),
+        '--capflag', args.capflag,
+        '-o', args.cap_output,
+    ]
+
+    if args.update_image_index is not None:
+        generate_capsule_cmd += ['--update-image-index', str(args.update_image_index)]
+
+    if args.embedded_driver:
+        generate_capsule_cmd += ['--embedded-driver', args.embedded_driver]
+
+    generate_capsule_cmd += [out_path]
+
+    try:
+        subprocess.check_call(generate_capsule_cmd)
+    except subprocess.CalledProcessError as exc:
+        print("error: GenerateCapsule failed: {}".format(exc), file=sys.stderr)
+        return 1
+
+    print("Built capsule {}".format(os.path.abspath(args.cap_output)))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/UefiPayloadPkg/Tools/AppendRmapManifest.py
+++ b/UefiPayloadPkg/Tools/AppendRmapManifest.py
@@ -31,13 +31,22 @@ ENTRY_SIZE     = 16
 def build_manifest(region_names):
     """Return the encoded manifest bytes for the given region names."""
     entries = []
+    encoded_names = set()
+    if not region_names or len(region_names) > 0xffff:
+        raise ValueError("Manifest must contain between 1 and 65535 regions")
+
     for name in region_names:
         try:
             encoded = name.encode('ascii')
         except UnicodeError:
             raise ValueError("Region name '{}' is not ASCII".format(name))
+        if not encoded or any(character <= 0x20 or character > 0x7e for character in encoded):
+            raise ValueError("Region name '{}' contains invalid characters".format(name))
         if len(encoded) > ENTRY_SIZE:
             raise ValueError("Region name '{}' longer than {} bytes".format(name, ENTRY_SIZE))
+        if encoded in encoded_names:
+            raise ValueError("Region name '{}' is duplicated".format(name))
+        encoded_names.add(encoded)
         entries.append(struct.pack('<{}s'.format(ENTRY_SIZE), encoded))
 
     trailer = struct.pack('<IHH', RMAP_SIGNATURE, RMAP_VERSION, len(entries))

--- a/UefiPayloadPkg/UefiPayloadPkg.ci.yaml
+++ b/UefiPayloadPkg/UefiPayloadPkg.ci.yaml
@@ -18,6 +18,7 @@
         ##     "<ErrorID>", "<KeyWord>"
         ## ]
         "ExceptionList": [
+            "8001", "FmpDeviceSmmLibUnitTestMain"
         ],
         ## Both file path and directory path are accepted.
         "IgnoreFiles": [


### PR DESCRIPTION
Supersedes #12053 with the capsule flashing changes separated from FMP packaging and graphical progress policy.

Add an RMAP v1 trailer that names the FMAP regions a signed firmware image should update. Validate the capsule and live layouts before writing, use SI_BIOS or Intel descriptor metadata for BIOS-region fallback, and retain the legacy full-flash path only when no scoped path can be established. A present but malformed manifest now fails closed instead of widening the write scope.

The writer retries and verifies flash operations. Runtime variable services remain available only when the live FMAP proves that the selected regions preserve SMMSTORE, allowing FmpDxe to persist the final result. Host tests cover manifest validation, checked progress arithmetic, preservation policy, malformed or overlapping ranges, transient failures, terminal failures and retry exhaustion.

Validation:
- PatchCheck.py on all 13 commits
- Tianocore uncrustify and package ECC checks
- UefiPayloadPkg X64 Stuart FIT build
- DEBUG GCC X64 UefiPayloadPkg build with coreboot, SMMSTORE and capsules
- RELEASE GCC IA32/X64 UefiPayloadPkg build with SMMSTORE and capsules
- ASan host tests: 15/15 passed
- RMAP generator validation and trailer encoding checks
- Lite GLK capsule-on-disk marker and restore updates