### PR TITLE
UefiPayloadPkg: make FmpDxe capsule placement configurable

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -241,6 +241,9 @@
   BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+!if $(CAPSULE_SUPPORT) == TRUE
+  FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
+!endif
   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
 !if $(PCIE_BASE_SUPPORT) == FALSE

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -53,9 +53,12 @@
   #
   # CAPSULE_MAIN_FW_GUID specifies GUID to be used by FmpDxe when
   # CAPSULE_SUPPORT is set to TRUE
+  # CAPSULE_EMBED_FMP_DXE permits FmpDxe to be embedded in update capsules
+  # in addition to including it in the payload FV.
   #
   DEFINE CAPSULE_SUPPORT              = FALSE
   DEFINE CAPSULE_MAIN_FW_GUID         =
+  DEFINE CAPSULE_EMBED_FMP_DXE        = FALSE
 
   #
   # Crypto Support
@@ -635,6 +638,8 @@
 
   ## Whether FMP capsules are enabled.
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleFmpSupport|$(CAPSULE_SUPPORT)
+  ## Whether embedded drivers in FMP capsules are supported.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleEmbeddedDriverSupport|$(CAPSULE_EMBED_FMP_DXE)
 
 !if $(CRYPTO_PROTOCOL_SUPPORT) == TRUE
 !if $(CRYPTO_DRIVER_EXTERNAL_SUPPORT) == FALSE
@@ -988,7 +993,10 @@
   }
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
 !if $(CAPSULE_SUPPORT) == TRUE
-  # Build FmpDxe meant for the inclusion into an update capsule as an embedded driver.
+!if "$(CAPSULE_MAIN_FW_GUID)" == ""
+  !error "CAPSULE_MAIN_FW_GUID must be set when CAPSULE_SUPPORT is TRUE"
+!endif
+  # Build FmpDxe for the payload FV or inclusion in an update capsule.
   FmpDevicePkg/FmpDxe/FmpDxe.inf {
     <Defines>
       # FmpDxe interprets its FILE_GUID as firmware GUID.  This allows including

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -373,6 +373,7 @@ INF ShellPkg/Application/Shell/Shell.inf
 # Capsules
 #
 !if $(CAPSULE_SUPPORT) == TRUE
+INF  FILE_GUID = $(CAPSULE_MAIN_FW_GUID) FmpDevicePkg/FmpDxe/FmpDxe.inf
 INF MdeModulePkg/Universal/EsrtDxe/EsrtDxe.inf
 !endif
 


### PR DESCRIPTION
Capsule builds need FileHandleLib, and FmpDxe placement must match whether capsule embedded drivers are dispatched.

Make the two modes explicit:

- Keep FmpDxe in the firmware volume by default.
- When CAPSULE_EMBED_FMP_DXE is enabled, build FmpDxe for capsule embedding, omit it from the firmware volume, and enable embedded-driver dispatch.
- Require CAPSULE_MAIN_FW_GUID for capsule-enabled builds.

Tested with PatchCheck, the official Stuart X64 FIT build, and IA32/X64 capsule builds in both placement modes. The generated PCD value and FmpDxe firmware-volume membership were checked in each mode.