### PR TITLE
UefiPayloadPkg: initialize graphics before capsule update

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -231,6 +231,8 @@ PlatformBootManagerBeforeConsole (
   EFI_INPUT_KEY                 CustomKey;
   EFI_INPUT_KEY                 Down;
   EFI_BOOT_MANAGER_LOAD_OPTION  BootOption;
+  EDKII_PLATFORM_LOGO_PROTOCOL  *PlatformLogo;
+  BOOLEAN                       ConsoleInitialized;
 
   //
   // Register ENTER as CONTINUE key
@@ -267,8 +269,18 @@ PlatformBootManagerBeforeConsole (
   //
   // Process update capsules that don't contain embedded drivers.
   //
+  ConsoleInitialized = FALSE;
   if (GetBootModeHob () == BOOT_ON_FLASH_UPDATE) {
     // TODO: when enabling capsule support for laptops, add a battery check here
+    PlatformConsoleInit ();
+    ConsoleInitialized = TRUE;
+
+    Status = gBS->LocateProtocol (&gEdkiiPlatformLogoProtocolGuid, NULL, (VOID **)&PlatformLogo);
+    if (!EFI_ERROR (Status) && (gST != NULL) && (gST->ConOut != NULL)) {
+      gST->ConOut->ClearScreen (gST->ConOut);
+      BootLogoEnableLogo ();
+    }
+
     Status = ProcessCapsules ();
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a(): ProcessCapsule() failed with: %r\n", __func__, Status));
@@ -286,7 +298,9 @@ PlatformBootManagerBeforeConsole (
   //
   EfiBootManagerDispatchDeferredImages ();
 
-  PlatformConsoleInit ();
+  if (!ConsoleInitialized) {
+    PlatformConsoleInit ();
+  }
 }
 
 /**

--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -144,6 +144,14 @@ APRIORI DXE {
   INF  MdeModulePkg/Universal/ReportStatusCodeRouter/RuntimeDxe/ReportStatusCodeRouterRuntimeDxe.inf
   INF  MdeModulePkg/Universal/StatusCodeHandler/RuntimeDxe/StatusCodeHandlerRuntimeDxe.inf
   INF  UefiPayloadPkg/BlSupportDxe/BlSupportDxe.inf
+!if $(CAPSULE_SUPPORT) == TRUE
+  !if $(BOOTSPLASH_IMAGE)
+    INF  UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutputDxe.inf
+    INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+    INF  MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
+    INF  MdeModulePkg/Logo/LogoDxe.inf
+  !endif
+!endif
 }
 
 #


### PR DESCRIPTION
Graphical capsule progress needs GOP and the logo stack before
`ProcessCapsules()` runs. Dispatch those drivers early for boot-splash builds
and initialize the console before processing a flash-update boot.

The existing text progress path remains unchanged for builds without a boot
splash.

`PlatformConsoleInit()` starts the PCI root bridge and video controller before
`EndOfDxe` so that the first capsule pass can draw progress. This is earlier
than UefiPayloadPkg's normal `ReadyToLock` boundary and may allow PCI option
ROM dispatch. A narrower framebuffer-only startup path would avoid that, but
is not part of this release-derived change.

Tested with PatchCheck, the official Stuart X64 FIT build, and X64 capsule
builds with `BOOTSPLASH_IMAGE` both `TRUE` and `FALSE`. The same path is in the
26.07 payload: a StarBook MTL same-version capsule reached 100%, completed
`Fmp->SetImage`, rebooted, and reported ESRT success; the graphical progress
bar also reached completion during the Byte Cezanne Y1 EC-FMP test.