### PR TITLE
MdeModulePkg,UefiPayloadPkg: scale HiDPI firmware UI

### DIFF
--- a/MdeModulePkg/Library/BootLogoLib/BootLogoLib.c
+++ b/MdeModulePkg/Library/BootLogoLib/BootLogoLib.c
@@ -18,9 +18,92 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/UefiBootServicesTableLib.h>
-#include <Library/PcdLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/DebugLib.h>
+
+#define BOOT_LOGO_HIDPI_HORIZONTAL_RESOLUTION  1920
+#define BOOT_LOGO_HIDPI_VERTICAL_RESOLUTION    1080
+
+STATIC
+BOOLEAN
+ShouldScaleBootLogoForHiDpi (
+  IN EFI_GRAPHICS_OUTPUT_PROTOCOL  *GraphicsOutput
+  )
+{
+  UINT32  HorizontalResolution;
+  UINT32  VerticalResolution;
+
+  if ((GraphicsOutput == NULL) ||
+      (GraphicsOutput->Mode == NULL) ||
+      (GraphicsOutput->Mode->Info == NULL) ||
+      (GraphicsOutput->Mode->FrameBufferBase == 0))
+  {
+    return FALSE;
+  }
+
+  HorizontalResolution = GraphicsOutput->Mode->Info->HorizontalResolution;
+  VerticalResolution   = GraphicsOutput->Mode->Info->VerticalResolution;
+
+  return (HorizontalResolution > BOOT_LOGO_HIDPI_HORIZONTAL_RESOLUTION) &&
+         (VerticalResolution > BOOT_LOGO_HIDPI_VERTICAL_RESOLUTION) &&
+         ((HorizontalResolution % 2) == 0) &&
+         ((VerticalResolution % 2) == 0);
+}
+
+STATIC
+EFI_STATUS
+ScaleLogoBlt2x (
+  IN  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Source,
+  IN  UINTN                          SourceWidth,
+  IN  UINTN                          SourceHeight,
+  OUT EFI_GRAPHICS_OUTPUT_BLT_PIXEL  **Destination
+  )
+{
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *ScaledBitmap;
+  UINTN                          DestinationWidth;
+  UINTN                          Row;
+  UINTN                          Column;
+
+  if ((Source == NULL) || (Destination == NULL) || (SourceWidth == 0) || (SourceHeight == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((SourceWidth > (MAX_UINTN / 2)) || (SourceHeight > (MAX_UINTN / 2))) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  DestinationWidth = SourceWidth * 2;
+  if (DestinationWidth > (MAX_UINTN / (SourceHeight * 2) / sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL))) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ScaledBitmap = AllocateZeroPool (DestinationWidth * (SourceHeight * 2) * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
+  if (ScaledBitmap == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  for (Row = 0; Row < SourceHeight; Row++) {
+    UINTN  DestinationRow0;
+    UINTN  DestinationRow1;
+
+    DestinationRow0 = (Row * 2) * DestinationWidth;
+    DestinationRow1 = DestinationRow0 + DestinationWidth;
+    for (Column = 0; Column < SourceWidth; Column++) {
+      EFI_GRAPHICS_OUTPUT_BLT_PIXEL  Pixel;
+      UINTN                          DestinationColumn;
+
+      Pixel             = Source[Row * SourceWidth + Column];
+      DestinationColumn = Column * 2;
+      ScaledBitmap[DestinationRow0 + DestinationColumn]     = Pixel;
+      ScaledBitmap[DestinationRow0 + DestinationColumn + 1] = Pixel;
+      ScaledBitmap[DestinationRow1 + DestinationColumn]     = Pixel;
+      ScaledBitmap[DestinationRow1 + DestinationColumn + 1] = Pixel;
+    }
+  }
+
+  *Destination = ScaledBitmap;
+  return EFI_SUCCESS;
+}
 
 /**
   Show LOGO returned from Edkii Platform Logo protocol on all consoles.
@@ -128,6 +211,25 @@ BootLogoEnableLogo (
     }
 
     Blt = Image.Bitmap;
+
+    if (ShouldScaleBootLogoForHiDpi (GraphicsOutput)) {
+      EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *ScaledBlt;
+
+      ScaledBlt = NULL;
+      Status    = ScaleLogoBlt2x (Blt, Image.Width, Image.Height, &ScaledBlt);
+      if (!EFI_ERROR (Status)) {
+        FreePool (Blt);
+        Blt          = ScaledBlt;
+        Image.Bitmap = ScaledBlt;
+        Image.Width *= 2;
+        Image.Height *= 2;
+        OffsetX *= 2;
+        OffsetY *= 2;
+      } else {
+        DEBUG ((DEBUG_INFO, "%a: failed to scale logo for HiDPI boot GOP: %r\n", __func__, Status));
+        Status = EFI_SUCCESS;
+      }
+    }
 
     //
     // Calculate the display position according to Attribute.

--- a/MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
+++ b/MdeModulePkg/Library/BootLogoLib/BootLogoLib.inf
@@ -38,7 +38,6 @@
   BaseMemoryLib
   DebugLib
   PrintLib
-  PcdLib
 
 [Protocols]
   gEfiGraphicsOutputProtocolGuid                ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
+++ b/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
@@ -92,6 +92,15 @@ EFI_NARROW_GLYPH  mCursorGlyph = {
 
 CHAR16  SpaceStr[] = { NARROW_CHAR, ' ', 0 };
 
+#define GRAPHICS_CONSOLE_MIN_TEXT_SCALE  1
+#define GRAPHICS_CONSOLE_MAX_TEXT_SCALE  2
+#define GRAPHICS_CONSOLE_HIDPI_HORIZONTAL_RESOLUTION  1920
+#define GRAPHICS_CONSOLE_HIDPI_VERTICAL_RESOLUTION    1080
+#define GRAPHICS_CONSOLE_MAX_GLYPH_WIDTH \
+  (EFI_GLYPH_WIDTH * GRAPHICS_CONSOLE_MAX_TEXT_SCALE)
+#define GRAPHICS_CONSOLE_MAX_GLYPH_HEIGHT \
+  (EFI_GLYPH_HEIGHT * GRAPHICS_CONSOLE_MAX_TEXT_SCALE)
+
 EFI_DRIVER_BINDING_PROTOCOL  gGraphicsConsoleDriverBinding = {
   GraphicsConsoleControllerDriverSupported,
   GraphicsConsoleControllerDriverStart,
@@ -100,6 +109,143 @@ EFI_DRIVER_BINDING_PROTOCOL  gGraphicsConsoleDriverBinding = {
   NULL,
   NULL
 };
+
+STATIC
+UINTN
+GetGraphicsConsoleTextScale (
+  IN  UINT32  HorizontalResolution,
+  IN  UINT32  VerticalResolution
+  )
+{
+  UINTN  TextScale;
+  UINTN  GlyphWidth;
+  UINTN  GlyphHeight;
+
+  TextScale = ((HorizontalResolution > GRAPHICS_CONSOLE_HIDPI_HORIZONTAL_RESOLUTION) &&
+               (VerticalResolution > GRAPHICS_CONSOLE_HIDPI_VERTICAL_RESOLUTION)) ? 2 : 1;
+  if ((TextScale < GRAPHICS_CONSOLE_MIN_TEXT_SCALE) || (TextScale > GRAPHICS_CONSOLE_MAX_TEXT_SCALE)) {
+    DEBUG ((DEBUG_WARN, "%a: unsupported text scale %u, using 1x\n", __func__, (UINT32)TextScale));
+    return 1;
+  }
+
+  GlyphWidth  = EFI_GLYPH_WIDTH * TextScale;
+  GlyphHeight = EFI_GLYPH_HEIGHT * TextScale;
+  if (((HorizontalResolution / GlyphWidth) < 80) || ((VerticalResolution / GlyphHeight) < 25)) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: %ux%u cannot support 80x25 at %ux, using 1x\n",
+      __func__,
+      HorizontalResolution,
+      VerticalResolution,
+      (UINT32)TextScale
+      ));
+    return 1;
+  }
+
+  return TextScale;
+}
+
+/**
+  Fill a graphics output BLT buffer with one color.
+
+  @param[out] Buffer  The BLT buffer to fill.
+  @param[in]  Width   The width of Buffer in pixels.
+  @param[in]  Height  The height of Buffer in pixels.
+  @param[in]  Color   The color to write into each pixel.
+
+**/
+STATIC
+VOID
+FillBltBuffer (
+  OUT EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Buffer,
+  IN  UINTN                          Width,
+  IN  UINTN                          Height,
+  IN  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Color
+  )
+{
+  UINTN  Index;
+  UINTN  Size;
+
+  Size = Width * Height;
+  for (Index = 0; Index < Size; Index++) {
+    Buffer[Index] = *Color;
+  }
+}
+
+/**
+  Scale a graphics output BLT buffer to twice its source width and height.
+
+  @param[in]  Source       The source BLT buffer.
+  @param[in]  SourceWidth  The source width in pixels.
+  @param[in]  SourceHeight The source height in pixels.
+  @param[in]  SourceStride The source row stride in pixels.
+  @param[out] Destination  The allocated scaled BLT buffer.
+
+  @retval EFI_SUCCESS            The destination buffer was allocated and filled.
+  @retval EFI_INVALID_PARAMETER  A required parameter is invalid.
+  @retval EFI_OUT_OF_RESOURCES   The destination buffer could not be allocated.
+
+**/
+STATIC
+EFI_STATUS
+ScaleBltBuffer2x (
+  IN  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Source,
+  IN  UINTN                          SourceWidth,
+  IN  UINTN                          SourceHeight,
+  IN  UINTN                          SourceStride,
+  OUT EFI_GRAPHICS_OUTPUT_BLT_PIXEL  **Destination
+  )
+{
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *ScaledBuffer;
+  UINTN                          Row;
+  UINTN                          Column;
+  UINTN                          DestinationWidth;
+
+  if ((Source == NULL) || (Destination == NULL) || (SourceWidth == 0) || (SourceHeight == 0) ||
+      (SourceStride < SourceWidth))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((SourceWidth > (MAX_UINTN / 2)) || (SourceHeight > (MAX_UINTN / 2))) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  DestinationWidth = SourceWidth * 2;
+  if (DestinationWidth > (MAX_UINTN / (SourceHeight * 2) / sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL))) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ScaledBuffer = AllocateZeroPool (
+                   DestinationWidth * (SourceHeight * 2) * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)
+                   );
+  if (ScaledBuffer == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  for (Row = 0; Row < SourceHeight; Row++) {
+    UINTN  DestinationRow0;
+    UINTN  DestinationRow1;
+
+    DestinationRow0 = (Row * 2) * DestinationWidth;
+    DestinationRow1 = DestinationRow0 + DestinationWidth;
+    for (Column = 0; Column < SourceWidth; Column++) {
+      EFI_GRAPHICS_OUTPUT_BLT_PIXEL  Pixel;
+      UINTN                          DestinationColumn;
+
+      Pixel             = Source[Row * SourceStride + Column];
+      DestinationColumn = Column * 2;
+
+      ScaledBuffer[DestinationRow0 + DestinationColumn]     = Pixel;
+      ScaledBuffer[DestinationRow0 + DestinationColumn + 1] = Pixel;
+      ScaledBuffer[DestinationRow1 + DestinationColumn]     = Pixel;
+      ScaledBuffer[DestinationRow1 + DestinationColumn + 1] = Pixel;
+    }
+  }
+
+  *Destination = ScaledBuffer;
+  return EFI_SUCCESS;
+}
 
 /**
   Test to see if Graphics Console could be supported on the Controller.
@@ -222,6 +368,9 @@ InitializeGraphicsConsoleTextMode (
   UINTN                       ValidIndex;
   UINTN                       MaxColumns;
   UINTN                       MaxRows;
+  UINTN                       TextScale;
+  UINTN                       GlyphWidth;
+  UINTN                       GlyphHeight;
 
   if ((TextModeCount == NULL) || (TextModeData == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -233,8 +382,11 @@ InitializeGraphicsConsoleTextMode (
   // Compute the maximum number of text Rows and Columns that this current graphics mode can support.
   // To make graphics console work well, MaxColumns and MaxRows should not be zero.
   //
-  MaxColumns = HorizontalResolution / EFI_GLYPH_WIDTH;
-  MaxRows    = VerticalResolution / EFI_GLYPH_HEIGHT;
+  TextScale   = GetGraphicsConsoleTextScale (HorizontalResolution, VerticalResolution);
+  GlyphWidth  = EFI_GLYPH_WIDTH * TextScale;
+  GlyphHeight = EFI_GLYPH_HEIGHT * TextScale;
+  MaxColumns  = HorizontalResolution / GlyphWidth;
+  MaxRows     = VerticalResolution / GlyphHeight;
 
   //
   // According to UEFI spec, all output devices support at least 80x25 text mode.
@@ -273,20 +425,28 @@ InitializeGraphicsConsoleTextMode (
   NewModeBuffer[ValidCount].GopWidth      = HorizontalResolution;
   NewModeBuffer[ValidCount].GopHeight     = VerticalResolution;
   NewModeBuffer[ValidCount].GopModeNumber = GopModeNumber;
-  NewModeBuffer[ValidCount].DeltaX        = (HorizontalResolution - (NewModeBuffer[ValidCount].Columns * EFI_GLYPH_WIDTH)) >> 1;
-  NewModeBuffer[ValidCount].DeltaY        = (VerticalResolution - (NewModeBuffer[ValidCount].Rows * EFI_GLYPH_HEIGHT)) >> 1;
+  NewModeBuffer[ValidCount].GlyphWidth    = GlyphWidth;
+  NewModeBuffer[ValidCount].GlyphHeight   = GlyphHeight;
+  NewModeBuffer[ValidCount].TextScale     = TextScale;
+  NewModeBuffer[ValidCount].DeltaX =
+    (HorizontalResolution - (NewModeBuffer[ValidCount].Columns * GlyphWidth)) >> 1;
+  NewModeBuffer[ValidCount].DeltaY =
+    (VerticalResolution - (NewModeBuffer[ValidCount].Rows * GlyphHeight)) >> 1;
   ValidCount++;
 
   if ((MaxColumns >= 80) && (MaxRows >= 50)) {
     NewModeBuffer[ValidCount].Columns = 80;
     NewModeBuffer[ValidCount].Rows    = 50;
-    NewModeBuffer[ValidCount].DeltaX  = (HorizontalResolution - (80 * EFI_GLYPH_WIDTH)) >> 1;
-    NewModeBuffer[ValidCount].DeltaY  = (VerticalResolution - (50 * EFI_GLYPH_HEIGHT)) >> 1;
+    NewModeBuffer[ValidCount].DeltaX  = (HorizontalResolution - (80 * GlyphWidth)) >> 1;
+    NewModeBuffer[ValidCount].DeltaY  = (VerticalResolution - (50 * GlyphHeight)) >> 1;
   }
 
   NewModeBuffer[ValidCount].GopWidth      = HorizontalResolution;
   NewModeBuffer[ValidCount].GopHeight     = VerticalResolution;
   NewModeBuffer[ValidCount].GopModeNumber = GopModeNumber;
+  NewModeBuffer[ValidCount].GlyphWidth    = GlyphWidth;
+  NewModeBuffer[ValidCount].GlyphHeight   = GlyphHeight;
+  NewModeBuffer[ValidCount].TextScale     = TextScale;
   ValidCount++;
 
   //
@@ -319,8 +479,13 @@ InitializeGraphicsConsoleTextMode (
       NewModeBuffer[ValidCount].GopWidth      = HorizontalResolution;
       NewModeBuffer[ValidCount].GopHeight     = VerticalResolution;
       NewModeBuffer[ValidCount].GopModeNumber = GopModeNumber;
-      NewModeBuffer[ValidCount].DeltaX        = (HorizontalResolution - (NewModeBuffer[ValidCount].Columns * EFI_GLYPH_WIDTH)) >> 1;
-      NewModeBuffer[ValidCount].DeltaY        = (VerticalResolution - (NewModeBuffer[ValidCount].Rows * EFI_GLYPH_HEIGHT)) >> 1;
+      NewModeBuffer[ValidCount].GlyphWidth    = GlyphWidth;
+      NewModeBuffer[ValidCount].GlyphHeight   = GlyphHeight;
+      NewModeBuffer[ValidCount].TextScale     = TextScale;
+      NewModeBuffer[ValidCount].DeltaX =
+        (HorizontalResolution - (NewModeBuffer[ValidCount].Columns * GlyphWidth)) >> 1;
+      NewModeBuffer[ValidCount].DeltaY =
+        (VerticalResolution - (NewModeBuffer[ValidCount].Rows * GlyphHeight)) >> 1;
       ValidCount++;
     }
   }
@@ -329,10 +494,11 @@ InitializeGraphicsConsoleTextMode (
   for (Index = 0; Index < ValidCount; Index++) {
     DEBUG ((
       DEBUG_INFO,
-      "Graphics - Mode %d, Column = %d, Row = %d\n",
+      "Graphics - Mode %d, Column = %d, Row = %d, TextScale = %d\n",
       Index,
       NewModeBuffer[Index].Columns,
-      NewModeBuffer[Index].Rows
+      NewModeBuffer[Index].Rows,
+      (UINT32)NewModeBuffer[Index].TextScale
       ));
   }
 
@@ -853,8 +1019,11 @@ GraphicsConsoleConOutOutputString (
   BOOLEAN                        Warning;
   EFI_GRAPHICS_OUTPUT_BLT_PIXEL  Foreground;
   EFI_GRAPHICS_OUTPUT_BLT_PIXEL  Background;
+  GRAPHICS_CONSOLE_MODE_DATA     *ModeData;
   UINTN                          DeltaX;
   UINTN                          DeltaY;
+  UINTN                          GlyphWidth;
+  UINTN                          GlyphHeight;
   UINTN                          Count;
   UINTN                          Index;
   INT32                          OriginAttribute;
@@ -877,13 +1046,16 @@ GraphicsConsoleConOutOutputString (
   Private        = GRAPHICS_CONSOLE_CON_OUT_DEV_FROM_THIS (This);
   GraphicsOutput = Private->GraphicsOutput;
 
-  MaxColumn = Private->ModeData[Mode].Columns;
-  MaxRow    = Private->ModeData[Mode].Rows;
-  DeltaX    = (UINTN)Private->ModeData[Mode].DeltaX;
-  DeltaY    = (UINTN)Private->ModeData[Mode].DeltaY;
-  Width     = MaxColumn * EFI_GLYPH_WIDTH;
-  Height    = (MaxRow - 1) * EFI_GLYPH_HEIGHT;
-  Delta     = Width * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL);
+  ModeData    = &Private->ModeData[Mode];
+  MaxColumn   = ModeData->Columns;
+  MaxRow      = ModeData->Rows;
+  DeltaX      = (UINTN)ModeData->DeltaX;
+  DeltaY      = (UINTN)ModeData->DeltaY;
+  GlyphWidth  = ModeData->GlyphWidth;
+  GlyphHeight = ModeData->GlyphHeight;
+  Width       = MaxColumn * GlyphWidth;
+  Height      = (MaxRow - 1) * GlyphHeight;
+  Delta       = Width * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL);
 
   //
   // The Attributes won't change when during the time OutputString is called
@@ -940,7 +1112,7 @@ GraphicsConsoleConOutOutputString (
                             NULL,
                             EfiBltVideoToVideo,
                             DeltaX,
-                            DeltaY + EFI_GLYPH_HEIGHT,
+                            DeltaY + GlyphHeight,
                             DeltaX,
                             DeltaY,
                             Width,
@@ -960,7 +1132,7 @@ GraphicsConsoleConOutOutputString (
                             DeltaX,
                             DeltaY + Height,
                             Width,
-                            EFI_GLYPH_HEIGHT,
+                            GlyphHeight,
                             Delta
                             );
         }
@@ -1026,7 +1198,7 @@ GraphicsConsoleConOutOutputString (
         }
       }
 
-      Status = DrawUnicodeWeightAtCursorN (This, WString, Count);
+      Status = DrawUnicodeWeightAtCursorN (This, WString, Count, Index);
       if (EFI_ERROR (Status)) {
         Warning = TRUE;
       }
@@ -1206,6 +1378,7 @@ GraphicsConsoleConOutSetMode (
   EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *NewLineBuffer;
   EFI_GRAPHICS_OUTPUT_PROTOCOL   *GraphicsOutput;
   EFI_TPL                        OldTpl;
+  UINTN                          LineBufferSize;
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
@@ -1255,7 +1428,20 @@ GraphicsConsoleConOutSetMode (
   //
   // Attempt to allocate a line buffer for the requested mode number
   //
-  NewLineBuffer = AllocatePool (sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL) * ModeData->Columns * EFI_GLYPH_WIDTH * EFI_GLYPH_HEIGHT);
+  if ((ModeData->GlyphWidth == 0) ||
+      (ModeData->GlyphHeight == 0) ||
+      (ModeData->Columns >
+       (MAX_UINTN / ModeData->GlyphWidth / ModeData->GlyphHeight / sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL))))
+  {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Done;
+  }
+
+  LineBufferSize = sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL) *
+                   ModeData->Columns *
+                   ModeData->GlyphWidth *
+                   ModeData->GlyphHeight;
+  NewLineBuffer = AllocatePool (LineBufferSize);
 
   if (NewLineBuffer == NULL) {
     //
@@ -1580,10 +1766,12 @@ GetTextColors (
   @param  This                  Protocol instance pointer.
   @param  UnicodeWeight         One Unicode string to be displayed.
   @param  Count                 The count of Unicode string.
+  @param  CellCount             The number of text cells to clear and display.
 
   @retval EFI_OUT_OF_RESOURCES  If no memory resource to use.
   @retval EFI_UNSUPPORTED       If no Graphics Output protocol
                                 protocol exist.
+  @retval EFI_DEVICE_ERROR      If the current text scale is invalid.
   @retval EFI_SUCCESS           Drawing Unicode string implemented successfully.
 
 **/
@@ -1591,23 +1779,42 @@ EFI_STATUS
 DrawUnicodeWeightAtCursorN (
   IN  EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
   IN  CHAR16                           *UnicodeWeight,
-  IN  UINTN                            Count
+  IN  UINTN                            Count,
+  IN  UINTN                            CellCount
   )
 {
-  EFI_STATUS             Status;
-  GRAPHICS_CONSOLE_DEV   *Private;
-  EFI_IMAGE_OUTPUT       *Blt;
-  EFI_STRING             String;
-  EFI_FONT_DISPLAY_INFO  *FontInfo;
+  EFI_STATUS                     Status;
+  GRAPHICS_CONSOLE_DEV           *Private;
+  GRAPHICS_CONSOLE_MODE_DATA     *ModeData;
+  EFI_IMAGE_OUTPUT               *Blt;
+  EFI_STRING                     String;
+  EFI_FONT_DISPLAY_INFO          *FontInfo;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *ScaledBitmap;
+  UINTN                          TextScale;
+  UINTN                          SourceWidth;
+  UINTN                          SourceHeight;
+  UINTN                          PointX;
+  UINTN                          PointY;
+  UINTN                          BltWidth;
+  UINTN                          BltHeight;
+  UINTN                          BltDelta;
 
-  Private = GRAPHICS_CONSOLE_CON_OUT_DEV_FROM_THIS (This);
-  Blt     = (EFI_IMAGE_OUTPUT *)AllocateZeroPool (sizeof (EFI_IMAGE_OUTPUT));
+  if (Count == 0) {
+    return EFI_SUCCESS;
+  }
+
+  Private   = GRAPHICS_CONSOLE_CON_OUT_DEV_FROM_THIS (This);
+  ModeData  = &Private->ModeData[This->Mode->Mode];
+  TextScale = ModeData->TextScale;
+  if ((TextScale < GRAPHICS_CONSOLE_MIN_TEXT_SCALE) || (TextScale > GRAPHICS_CONSOLE_MAX_TEXT_SCALE)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  ScaledBitmap = NULL;
+  Blt          = (EFI_IMAGE_OUTPUT *)AllocateZeroPool (sizeof (EFI_IMAGE_OUTPUT));
   if (Blt == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
-
-  Blt->Width  = (UINT16)(Private->ModeData[This->Mode->Mode].GopWidth);
-  Blt->Height = (UINT16)(Private->ModeData[This->Mode->Mode].GopHeight);
 
   String = AllocateCopyPool ((Count + 1) * sizeof (CHAR16), UnicodeWeight);
   if (String == NULL) {
@@ -1633,25 +1840,111 @@ DrawUnicodeWeightAtCursorN (
   GetTextColors (This, &FontInfo->ForegroundColor, &FontInfo->BackgroundColor);
 
   if (Private->GraphicsOutput != NULL) {
-    //
-    // If Graphics Output protocol exists, using HII Font protocol to draw.
-    //
-    Blt->Image.Screen = Private->GraphicsOutput;
+    PointX = (This->Mode->CursorColumn * ModeData->GlyphWidth) + ModeData->DeltaX;
+    PointY = (This->Mode->CursorRow * ModeData->GlyphHeight) + ModeData->DeltaY;
 
-    Status = mHiiFont->StringToImage (
-                         mHiiFont,
-                         EFI_HII_IGNORE_IF_NO_GLYPH | EFI_HII_DIRECT_TO_SCREEN | EFI_HII_IGNORE_LINE_BREAK,
-                         String,
-                         FontInfo,
-                         &Blt,
-                         This->Mode->CursorColumn * EFI_GLYPH_WIDTH + Private->ModeData[This->Mode->Mode].DeltaX,
-                         This->Mode->CursorRow * EFI_GLYPH_HEIGHT + Private->ModeData[This->Mode->Mode].DeltaY,
-                         NULL,
-                         NULL,
-                         NULL
-                         );
+    if (TextScale == 1) {
+      //
+      // If Graphics Output protocol exists, using HII Font protocol to draw.
+      //
+      Blt->Width        = (UINT16)(ModeData->GopWidth);
+      Blt->Height       = (UINT16)(ModeData->GopHeight);
+      Blt->Image.Screen = Private->GraphicsOutput;
+
+      Status = mHiiFont->StringToImage (
+                           mHiiFont,
+                           EFI_HII_IGNORE_IF_NO_GLYPH | EFI_HII_DIRECT_TO_SCREEN | EFI_HII_IGNORE_LINE_BREAK,
+                           String,
+                           FontInfo,
+                           &Blt,
+                           PointX,
+                           PointY,
+                           NULL,
+                           NULL,
+                           NULL
+                           );
+    } else {
+      SourceHeight = EFI_GLYPH_HEIGHT;
+      if ((CellCount > (MAX_UINTN / EFI_GLYPH_WIDTH)) ||
+          (SourceHeight > MAX_UINT16))
+      {
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Done;
+      }
+
+      SourceWidth = CellCount * EFI_GLYPH_WIDTH;
+      if ((SourceWidth > MAX_UINT16) ||
+          (SourceWidth > (MAX_UINTN / SourceHeight / sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL))))
+      {
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Done;
+      }
+
+      Blt->Width        = (UINT16)SourceWidth;
+      Blt->Height       = (UINT16)SourceHeight;
+      Blt->Image.Bitmap = AllocateZeroPool (SourceWidth * SourceHeight * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
+      if (Blt->Image.Bitmap == NULL) {
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Done;
+      }
+
+      FillBltBuffer (Blt->Image.Bitmap, SourceWidth, SourceHeight, &FontInfo->BackgroundColor);
+
+      Status = mHiiFont->StringToImage (
+                           mHiiFont,
+                           EFI_HII_IGNORE_IF_NO_GLYPH | EFI_HII_OUT_FLAG_CLIP | EFI_HII_OUT_FLAG_CLIP_CLEAN_X |
+                           EFI_HII_OUT_FLAG_CLIP_CLEAN_Y | EFI_HII_IGNORE_LINE_BREAK,
+                           String,
+                           FontInfo,
+                           &Blt,
+                           0,
+                           0,
+                           NULL,
+                           NULL,
+                           NULL
+                           );
+      if (EFI_ERROR (Status)) {
+        goto Done;
+      }
+
+      Status = ScaleBltBuffer2x (
+                 Blt->Image.Bitmap,
+                 SourceWidth,
+                 SourceHeight,
+                 SourceWidth,
+                 &ScaledBitmap
+                 );
+      if (EFI_ERROR (Status)) {
+        goto Done;
+      }
+
+      BltWidth  = SourceWidth * 2;
+      BltHeight = SourceHeight * 2;
+      BltDelta  = BltWidth * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL);
+      Status    = Private->GraphicsOutput->Blt (
+                                             Private->GraphicsOutput,
+                                             ScaledBitmap,
+                                             EfiBltBufferToVideo,
+                                             0,
+                                             0,
+                                             PointX,
+                                             PointY,
+                                             BltWidth,
+                                             BltHeight,
+                                             BltDelta
+                                             );
+    }
   } else {
     Status = EFI_UNSUPPORTED;
+  }
+
+Done:
+  if ((TextScale != 1) && (Blt != NULL) && (Blt->Image.Bitmap != NULL)) {
+    FreePool (Blt->Image.Bitmap);
+  }
+
+  if (ScaledBitmap != NULL) {
+    FreePool (ScaledBitmap);
   }
 
   if (Blt != NULL) {
@@ -1689,14 +1982,22 @@ FlushCursor (
 {
   GRAPHICS_CONSOLE_DEV                 *Private;
   EFI_SIMPLE_TEXT_OUTPUT_MODE          *CurrentMode;
+  GRAPHICS_CONSOLE_MODE_DATA           *ModeData;
   INTN                                 GlyphX;
   INTN                                 GlyphY;
   EFI_GRAPHICS_OUTPUT_PROTOCOL         *GraphicsOutput;
   EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  Foreground;
   EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  Background;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  BltChar[EFI_GLYPH_HEIGHT][EFI_GLYPH_WIDTH];
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  BltChar[GRAPHICS_CONSOLE_MAX_GLYPH_HEIGHT][GRAPHICS_CONSOLE_MAX_GLYPH_WIDTH];
   UINTN                                PosX;
   UINTN                                PosY;
+  UINTN                                ScaleX;
+  UINTN                                ScaleY;
+  UINTN                                CursorColumn;
+  UINTN                                CursorRow;
+  UINTN                                GlyphWidth;
+  UINTN                                GlyphHeight;
+  UINTN                                TextScale;
 
   CurrentMode = This->Mode;
 
@@ -1706,6 +2007,14 @@ FlushCursor (
 
   Private        = GRAPHICS_CONSOLE_CON_OUT_DEV_FROM_THIS (This);
   GraphicsOutput = Private->GraphicsOutput;
+  ModeData       = &Private->ModeData[CurrentMode->Mode];
+  GlyphWidth     = ModeData->GlyphWidth;
+  GlyphHeight    = ModeData->GlyphHeight;
+  TextScale      = ModeData->TextScale;
+
+  if ((TextScale < GRAPHICS_CONSOLE_MIN_TEXT_SCALE) || (TextScale > GRAPHICS_CONSOLE_MAX_TEXT_SCALE)) {
+    return EFI_DEVICE_ERROR;
+  }
 
   //
   // In this driver, only narrow character was supported.
@@ -1713,8 +2022,8 @@ FlushCursor (
   //
   // Blt a character to the screen
   //
-  GlyphX = (CurrentMode->CursorColumn * EFI_GLYPH_WIDTH) + Private->ModeData[CurrentMode->Mode].DeltaX;
-  GlyphY = (CurrentMode->CursorRow * EFI_GLYPH_HEIGHT) + Private->ModeData[CurrentMode->Mode].DeltaY;
+  GlyphX = (CurrentMode->CursorColumn * GlyphWidth) + ModeData->DeltaX;
+  GlyphY = (CurrentMode->CursorRow * GlyphHeight) + ModeData->DeltaY;
   if (GraphicsOutput != NULL) {
     GraphicsOutput->Blt (
                       GraphicsOutput,
@@ -1724,9 +2033,9 @@ FlushCursor (
                       GlyphY,
                       0,
                       0,
-                      EFI_GLYPH_WIDTH,
-                      EFI_GLYPH_HEIGHT,
-                      EFI_GLYPH_WIDTH * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)
+                      GlyphWidth,
+                      GlyphHeight,
+                      GlyphWidth * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)
                       );
   }
 
@@ -1738,7 +2047,13 @@ FlushCursor (
   for (PosY = 0; PosY < EFI_GLYPH_HEIGHT; PosY++) {
     for (PosX = 0; PosX < EFI_GLYPH_WIDTH; PosX++) {
       if ((mCursorGlyph.GlyphCol1[PosY] & (BIT0 << PosX)) != 0) {
-        BltChar[PosY][EFI_GLYPH_WIDTH - PosX - 1].Raw ^= Foreground.Raw;
+        for (ScaleY = 0; ScaleY < TextScale; ScaleY++) {
+          for (ScaleX = 0; ScaleX < TextScale; ScaleX++) {
+            CursorRow    = (PosY * TextScale) + ScaleY;
+            CursorColumn = ((EFI_GLYPH_WIDTH - PosX - 1) * TextScale) + ScaleX;
+            BltChar[CursorRow][CursorColumn].Raw ^= Foreground.Raw;
+          }
+        }
       }
     }
   }
@@ -1752,9 +2067,9 @@ FlushCursor (
                       0,
                       GlyphX,
                       GlyphY,
-                      EFI_GLYPH_WIDTH,
-                      EFI_GLYPH_HEIGHT,
-                      EFI_GLYPH_WIDTH * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)
+                      GlyphWidth,
+                      GlyphHeight,
+                      GlyphWidth * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)
                       );
   }
 

--- a/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.h
+++ b/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.h
@@ -52,6 +52,9 @@ typedef struct {
   UINT32    GopWidth;
   UINT32    GopHeight;
   UINT32    GopModeNumber;
+  UINTN     GlyphWidth;
+  UINTN     GlyphHeight;
+  UINTN     TextScale;
 } GRAPHICS_CONSOLE_MODE_DATA;
 
 typedef struct {
@@ -527,7 +530,8 @@ EFI_STATUS
 DrawUnicodeWeightAtCursorN (
   IN  EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
   IN  CHAR16                           *UnicodeWeight,
-  IN  UINTN                            Count
+  IN  UINTN                            Count,
+  IN  UINTN                            CellCount
   );
 
 /**

--- a/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.c
+++ b/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.c
@@ -7,6 +7,56 @@
 
 **/
 #include "BlSupportDxe.h"
+#include <Library/PcdLib.h>
+
+#define PAYLOAD_HIDPI_HORIZONTAL_RESOLUTION  1920
+#define PAYLOAD_HIDPI_VERTICAL_RESOLUTION    1080
+
+STATIC
+BOOLEAN
+TryGetWideAspectCappedViewportWidth (
+  IN  UINT32  HorizontalResolution,
+  IN  UINT32  VerticalResolution,
+  IN  UINT32  CapAspectWidth,
+  IN  UINT32  CapAspectHeight,
+  OUT UINT32  *ViewportWidth
+  )
+{
+  UINT64  CandidateWidth;
+
+  if ((ViewportWidth == NULL) ||
+      (HorizontalResolution == 0) ||
+      (VerticalResolution == 0) ||
+      (CapAspectWidth == 0) ||
+      (CapAspectHeight == 0))
+  {
+    return FALSE;
+  }
+
+  if (((UINT64)HorizontalResolution * CapAspectHeight) <= ((UINT64)VerticalResolution * CapAspectWidth)) {
+    return FALSE;
+  }
+
+  CandidateWidth = ((UINT64)VerticalResolution * CapAspectWidth) / CapAspectHeight;
+  CandidateWidth &= ~1ULL;
+  if ((CandidateWidth == 0) || (CandidateWidth >= HorizontalResolution)) {
+    return FALSE;
+  }
+
+  *ViewportWidth = (UINT32)CandidateWidth;
+  return TRUE;
+}
+
+STATIC
+BOOLEAN
+IsHiDpiFramebuffer (
+  IN UINT32  HorizontalResolution,
+  IN UINT32  VerticalResolution
+  )
+{
+  return (HorizontalResolution > PAYLOAD_HIDPI_HORIZONTAL_RESOLUTION) &&
+         (VerticalResolution > PAYLOAD_HIDPI_VERTICAL_RESOLUTION);
+}
 
 /**
   Main entry for the bootloader support DXE module.
@@ -32,20 +82,49 @@ BlDxeEntryPoint (
   FIRMWARE_INFO              *FirmwareInfo;
   EFI_SYSTEM_RESOURCE_TABLE  *Esrt;
   EFI_SYSTEM_RESOURCE_ENTRY  *Esre;
+  UINT32                     HorizontalResolution;
+  UINT32                     VerticalResolution;
+  UINT32                     SetupHorizontalResolution;
+  UINT32                     SetupVerticalResolution;
+  UINT32                     ViewportWidth;
 
   //
   // Find the frame buffer information and update PCDs
   //
   GuidHob = GetFirstGuidHob (&gEfiGraphicsInfoHobGuid);
   if (GuidHob != NULL) {
-    GfxInfo = (EFI_PEI_GRAPHICS_INFO_HOB *)GET_GUID_HOB_DATA (GuidHob);
-    Status  = PcdSet32S (PcdVideoHorizontalResolution, GfxInfo->GraphicsMode.HorizontalResolution);
+    GfxInfo              = (EFI_PEI_GRAPHICS_INFO_HOB *)GET_GUID_HOB_DATA (GuidHob);
+    HorizontalResolution = GfxInfo->GraphicsMode.HorizontalResolution;
+    VerticalResolution   = GfxInfo->GraphicsMode.VerticalResolution;
+    SetupHorizontalResolution = HorizontalResolution;
+    SetupVerticalResolution   = VerticalResolution;
+
+    if (FeaturePcdGet (PcdPayloadFbHiDpiWideAspectCapSupport) &&
+        TryGetWideAspectCappedViewportWidth (
+          SetupHorizontalResolution,
+          SetupVerticalResolution,
+          PcdGet32 (PcdPayloadFbHiDpiWideAspectCapWidth),
+          PcdGet32 (PcdPayloadFbHiDpiWideAspectCapHeight),
+          &ViewportWidth
+          ))
+    {
+      SetupHorizontalResolution = ViewportWidth;
+    }
+
+    if (IsHiDpiFramebuffer (HorizontalResolution, VerticalResolution) &&
+        ((SetupHorizontalResolution & 1) == 0) && ((SetupVerticalResolution & 1) == 0))
+    {
+      SetupHorizontalResolution /= 2;
+      SetupVerticalResolution   /= 2;
+    }
+
+    Status = PcdSet32S (PcdVideoHorizontalResolution, HorizontalResolution);
     ASSERT_EFI_ERROR (Status);
-    Status = PcdSet32S (PcdVideoVerticalResolution, GfxInfo->GraphicsMode.VerticalResolution);
+    Status = PcdSet32S (PcdVideoVerticalResolution, VerticalResolution);
     ASSERT_EFI_ERROR (Status);
-    Status = PcdSet32S (PcdSetupVideoHorizontalResolution, GfxInfo->GraphicsMode.HorizontalResolution);
+    Status = PcdSet32S (PcdSetupVideoHorizontalResolution, SetupHorizontalResolution);
     ASSERT_EFI_ERROR (Status);
-    Status = PcdSet32S (PcdSetupVideoVerticalResolution, GfxInfo->GraphicsMode.VerticalResolution);
+    Status = PcdSet32S (PcdSetupVideoVerticalResolution, SetupVerticalResolution);
     ASSERT_EFI_ERROR (Status);
   }
 

--- a/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.inf
+++ b/UefiPayloadPkg/BlSupportDxe/BlSupportDxe.inf
@@ -64,6 +64,9 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoHorizontalResolution
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapSupport
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapWidth
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapHeight
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseSize
 

--- a/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
+++ b/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
@@ -8,6 +8,17 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include "GraphicsOutput.h"
+
+#include <Guid/EventGroup.h>
+
+#include <Library/PcdLib.h>
+#include <Protocol/BootLogo2.h>
+
+#define GRAPHICS_OUTPUT_MODE_PHYSICAL  0
+#define GRAPHICS_OUTPUT_MODE_HIDPI     1
+#define GRAPHICS_OUTPUT_HIDPI_HORIZONTAL_RESOLUTION  1920
+#define GRAPHICS_OUTPUT_HIDPI_VERTICAL_RESOLUTION    1080
+
 CONST ACPI_ADR_DEVICE_PATH  mGraphicsOutputAdrNode = {
   {
     ACPI_DEVICE_PATH,
@@ -26,6 +37,65 @@ EFI_PEI_GRAPHICS_DEVICE_INFO_HOB  mDefaultGraphicsDeviceInfo = {
 // So a global flag is used to remember that the driver is already started.
 //
 BOOLEAN  mDriverStarted = FALSE;
+
+/**
+  Return TRUE if the framebuffer is wider than the configured cap aspect and can
+  be cropped to a centered viewport with left/right black bars.
+
+  @param[in]  HorizontalResolution  Physical framebuffer width.
+  @param[in]  VerticalResolution    Physical framebuffer height.
+  @param[in]  CapAspectWidth        Maximum viewport aspect numerator.
+  @param[in]  CapAspectHeight       Maximum viewport aspect denominator.
+  @param[out] ViewportWidth         Cropped viewport width.
+
+  @retval TRUE   A centered capped viewport can be created.
+  @retval FALSE  No horizontal crop should be applied.
+**/
+STATIC
+BOOLEAN
+TryGetWideAspectCappedViewportWidth (
+  IN  UINT32  HorizontalResolution,
+  IN  UINT32  VerticalResolution,
+  IN  UINT32  CapAspectWidth,
+  IN  UINT32  CapAspectHeight,
+  OUT UINT32  *ViewportWidth
+  )
+{
+  UINT64  CandidateWidth;
+
+  if ((ViewportWidth == NULL) ||
+      (HorizontalResolution == 0) ||
+      (VerticalResolution == 0) ||
+      (CapAspectWidth == 0) ||
+      (CapAspectHeight == 0))
+  {
+    return FALSE;
+  }
+
+  if (((UINT64)HorizontalResolution * CapAspectHeight) <= ((UINT64)VerticalResolution * CapAspectWidth)) {
+    return FALSE;
+  }
+
+  CandidateWidth = ((UINT64)VerticalResolution * CapAspectWidth) / CapAspectHeight;
+  CandidateWidth &= ~1ULL;
+  if ((CandidateWidth == 0) || (CandidateWidth >= HorizontalResolution)) {
+    return FALSE;
+  }
+
+  *ViewportWidth = (UINT32)CandidateWidth;
+  return TRUE;
+}
+
+STATIC
+BOOLEAN
+IsHiDpiFramebuffer (
+  IN UINT32  HorizontalResolution,
+  IN UINT32  VerticalResolution
+  )
+{
+  return (HorizontalResolution > GRAPHICS_OUTPUT_HIDPI_HORIZONTAL_RESOLUTION) &&
+         (VerticalResolution > GRAPHICS_OUTPUT_HIDPI_VERTICAL_RESOLUTION);
+}
 
 /**
   Returns information for an available graphics mode that the graphics device
@@ -50,13 +120,192 @@ GraphicsOutputQueryMode (
   OUT EFI_GRAPHICS_OUTPUT_MODE_INFORMATION  **Info
   )
 {
+  GRAPHICS_OUTPUT_PRIVATE_DATA                *Private;
+  CONST EFI_GRAPHICS_OUTPUT_MODE_INFORMATION  *ModeInfo;
+
   if ((This == NULL) || (Info == NULL) || (SizeOfInfo == NULL) || (ModeNumber >= This->Mode->MaxMode)) {
     return EFI_INVALID_PARAMETER;
   }
 
-  *SizeOfInfo = This->Mode->SizeOfInfo;
-  *Info       = AllocateCopyPool (*SizeOfInfo, This->Mode->Info);
+  Private = GRAPHICS_OUTPUT_PRIVATE_FROM_THIS (This);
+
+  ModeInfo = NULL;
+  if (ModeNumber == GRAPHICS_OUTPUT_MODE_PHYSICAL) {
+    ModeInfo = &Private->PhysicalModeInfo;
+  } else if ((ModeNumber == GRAPHICS_OUTPUT_MODE_HIDPI) && Private->HasHiDpiMode) {
+    ModeInfo = &Private->LogicalModeInfo;
+  }
+
+  if (ModeInfo == NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  *SizeOfInfo = sizeof (EFI_GRAPHICS_OUTPUT_MODE_INFORMATION);
+  *Info       = AllocateCopyPool (*SizeOfInfo, ModeInfo);
+  return (*Info != NULL) ? EFI_SUCCESS : EFI_OUT_OF_RESOURCES;
+}
+
+/**
+  Set the video device into the specified mode.
+
+  @param  This        The EFI_GRAPHICS_OUTPUT_PROTOCOL instance.
+  @param  ModeNumber  Abstraction that defines the current video mode.
+  @param  ClearScreen TRUE to clear the screen to black in physical mode.
+
+  @retval EFI_SUCCESS           The graphics mode specified by ModeNumber was selected.
+  @retval EFI_INVALID_PARAMETER One or more parameters are invalid.
+  @retval EFI_UNSUPPORTED       ModeNumber is not supported by this device.
+
+**/
+static EFI_STATUS
+GraphicsOutputSetModeInternal (
+  IN EFI_GRAPHICS_OUTPUT_PROTOCOL  *This,
+  IN UINT32                        ModeNumber,
+  IN BOOLEAN                       ClearScreen
+  )
+{
+  GRAPHICS_OUTPUT_PRIVATE_DATA                *Private;
+  CONST EFI_GRAPHICS_OUTPUT_MODE_INFORMATION  *ModeInfo;
+  UINT32                                      Scale;
+
+  Private = GRAPHICS_OUTPUT_PRIVATE_FROM_THIS (This);
+
+  ModeInfo = NULL;
+  Scale    = 1;
+  if (ModeNumber == GRAPHICS_OUTPUT_MODE_PHYSICAL) {
+    ModeInfo = &Private->PhysicalModeInfo;
+    Scale    = 1;
+  } else if ((ModeNumber == GRAPHICS_OUTPUT_MODE_HIDPI) && Private->HasHiDpiMode) {
+    ModeInfo = &Private->LogicalModeInfo;
+    Scale    = Private->LogicalModeScale;
+  }
+
+  if (ModeInfo == NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  This->Mode->Mode       = ModeNumber;
+  This->Mode->Info       = (EFI_GRAPHICS_OUTPUT_MODE_INFORMATION *)ModeInfo;
+  This->Mode->SizeOfInfo = sizeof (EFI_GRAPHICS_OUTPUT_MODE_INFORMATION);
+
+  if (ModeNumber == GRAPHICS_OUTPUT_MODE_PHYSICAL) {
+    This->Mode->FrameBufferBase = Private->PhysicalFrameBufferBase;
+    This->Mode->FrameBufferSize = Private->PhysicalFrameBufferSize;
+  } else {
+    This->Mode->FrameBufferBase = 0;
+    This->Mode->FrameBufferSize = 0;
+  }
+
+  Private->FrameBufferScale = Scale;
+
+  if (ClearScreen) {
+    RETURN_STATUS                  Status;
+    EFI_GRAPHICS_OUTPUT_BLT_PIXEL  Black;
+
+    Black.Blue     = 0;
+    Black.Green    = 0;
+    Black.Red      = 0;
+    Black.Reserved = 0;
+
+    Status = FrameBufferBlt (
+               Private->FrameBufferBltLibConfigure,
+               &Black,
+               EfiBltVideoFill,
+               0,
+               0,
+               0,
+               0,
+               Private->PhysicalModeInfo.HorizontalResolution,
+               Private->PhysicalModeInfo.VerticalResolution,
+               0
+               );
+    return RETURN_ERROR (Status) ? EFI_DEVICE_ERROR : EFI_SUCCESS;
+  }
+
   return EFI_SUCCESS;
+}
+
+/**
+  Redraw the registered boot logo into the current graphics mode.
+
+  BootLogoLib registers the physical BGRT image with BootLogo2.  When this
+  driver drops the software HiDPI GOP mode at ReadyToBoot, redraw that same
+  image so the handed-off framebuffer still matches the BGRT coordinates.
+
+  @param  GraphicsOutput  The Graphics Output Protocol instance.
+
+**/
+static VOID
+RestoreBootLogo (
+  IN EFI_GRAPHICS_OUTPUT_PROTOCOL  *GraphicsOutput
+  )
+{
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Logo;
+  EDKII_BOOT_LOGO2_PROTOCOL      *BootLogo;
+  EFI_STATUS                     Status;
+  UINTN                          DestinationX;
+  UINTN                          DestinationY;
+  UINTN                          Height;
+  UINTN                          Width;
+
+  if ((GraphicsOutput == NULL) ||
+      (GraphicsOutput->Mode == NULL) ||
+      (GraphicsOutput->Mode->Info == NULL))
+  {
+    return;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gEdkiiBootLogo2ProtocolGuid,
+                  NULL,
+                  (VOID **)&BootLogo
+                  );
+  if (EFI_ERROR (Status) || (BootLogo == NULL)) {
+    return;
+  }
+
+  Logo         = NULL;
+  DestinationX = 0;
+  DestinationY = 0;
+  Width        = 0;
+  Height       = 0;
+  Status       = BootLogo->GetBootLogo (
+                             BootLogo,
+                             &Logo,
+                             &DestinationX,
+                             &DestinationY,
+                             &Width,
+                             &Height
+                             );
+  if (EFI_ERROR (Status) || (Logo == NULL) || (Width == 0) || (Height == 0)) {
+    return;
+  }
+
+  if ((DestinationX > GraphicsOutput->Mode->Info->HorizontalResolution) ||
+      (DestinationY > GraphicsOutput->Mode->Info->VerticalResolution) ||
+      (Width > (GraphicsOutput->Mode->Info->HorizontalResolution - DestinationX)) ||
+      (Height > (GraphicsOutput->Mode->Info->VerticalResolution - DestinationY)) ||
+      (Width > (MAX_UINTN / sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL))))
+  {
+    DEBUG ((DEBUG_VERBOSE, "[%a]: boot logo does not fit current GOP mode\n", gEfiCallerBaseName));
+    return;
+  }
+
+  Status = GraphicsOutput->Blt (
+                             GraphicsOutput,
+                             Logo,
+                             EfiBltBufferToVideo,
+                             0,
+                             0,
+                             DestinationX,
+                             DestinationY,
+                             Width,
+                             Height,
+                             Width * sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL)
+                             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_VERBOSE, "[%a]: boot logo restore failed: %r\n", gEfiCallerBaseName, Status));
+  }
 }
 
 /**
@@ -78,34 +327,188 @@ GraphicsOutputSetMode (
   IN  UINT32                        ModeNumber
   )
 {
-  RETURN_STATUS                  Status;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  Black;
-  GRAPHICS_OUTPUT_PRIVATE_DATA   *Private;
-
-  if (ModeNumber >= This->Mode->MaxMode) {
+  if ((This == NULL) || (ModeNumber >= This->Mode->MaxMode)) {
     return EFI_UNSUPPORTED;
   }
 
-  Private = GRAPHICS_OUTPUT_PRIVATE_FROM_THIS (This);
+  return GraphicsOutputSetModeInternal (This, ModeNumber, TRUE);
+}
 
-  Black.Blue     = 0;
-  Black.Green    = 0;
-  Black.Red      = 0;
-  Black.Reserved = 0;
+/**
+  ReadyToBoot notification.
 
-  Status = FrameBufferBlt (
-             Private->FrameBufferBltLibConfigure,
-             &Black,
-             EfiBltVideoFill,
-             0,
-             0,
-             0,
-             0,
-             This->Mode->Info->HorizontalResolution,
-             This->Mode->Info->VerticalResolution,
-             0
-             );
-  return RETURN_ERROR (Status) ? EFI_DEVICE_ERROR : EFI_SUCCESS;
+  Switch back to a mode that provides a direct framebuffer before launching the
+  OS (e.g. for users that write directly to the framebuffer).
+
+  @param  Event    The event signaled.
+  @param  Context  The event context.
+
+**/
+static VOID
+EFIAPI
+GraphicsOutputReadyToBoot (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  GRAPHICS_OUTPUT_PRIVATE_DATA  *Private;
+  EFI_STATUS                    Status;
+
+  (VOID)Event;
+
+  Private = (GRAPHICS_OUTPUT_PRIVATE_DATA *)Context;
+  if ((Private == NULL) || !Private->HasHiDpiMode) {
+    return;
+  }
+
+  if (Private->GraphicsOutput.Mode->Mode == GRAPHICS_OUTPUT_MODE_HIDPI) {
+    //
+    // Switch back to a mode that provides a direct framebuffer before
+    // launching the OS (e.g. for efifb or other direct-writes users).
+    //
+    Status = GraphicsOutputSetModeInternal (&Private->GraphicsOutput, GRAPHICS_OUTPUT_MODE_PHYSICAL, FALSE);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_VERBOSE, "[%a]: physical GOP restore failed: %r\n", gEfiCallerBaseName, Status));
+      return;
+    }
+
+    RestoreBootLogo (&Private->GraphicsOutput);
+
+    //
+    // Restore the physical-mode resolution PCDs so late DXE text/graphics code
+    // sees the real framebuffer geometry after the HiDPI GOP mode is dropped.
+    //
+    Status = PcdSet32S (PcdVideoHorizontalResolution, Private->PhysicalModeInfo.HorizontalResolution);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_VERBOSE, "[%a]: PcdVideoHorizontalResolution update failed: %r\n", gEfiCallerBaseName, Status));
+    }
+
+    Status = PcdSet32S (PcdVideoVerticalResolution, Private->PhysicalModeInfo.VerticalResolution);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_VERBOSE, "[%a]: PcdVideoVerticalResolution update failed: %r\n", gEfiCallerBaseName, Status));
+    }
+
+    Status = PcdSet32S (PcdSetupVideoHorizontalResolution, Private->PhysicalModeInfo.HorizontalResolution);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_VERBOSE, "[%a]: PcdSetupVideoHorizontalResolution update failed: %r\n", gEfiCallerBaseName, Status));
+    }
+
+    Status = PcdSet32S (PcdSetupVideoVerticalResolution, Private->PhysicalModeInfo.VerticalResolution);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_VERBOSE, "[%a]: PcdSetupVideoVerticalResolution update failed: %r\n", gEfiCallerBaseName, Status));
+    }
+  }
+}
+
+/**
+  Scale a BLT buffer by 2x.
+
+  @param  Src            Pointer to the source buffer.
+  @param  SrcWidth       Source buffer width in pixels.
+  @param  SrcHeight      Source buffer height in pixels.
+  @param  SrcDeltaBytes  Source buffer stride in bytes.
+  @param  Dst            Pointer to the destination buffer.
+
+  @retval EFI_SUCCESS           The buffer was scaled successfully.
+  @retval EFI_INVALID_PARAMETER One or more parameters are invalid.
+
+**/
+static EFI_STATUS
+ScaleBltBuffer2x (
+  IN  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Src,
+  IN  UINTN                          SrcWidth,
+  IN  UINTN                          SrcHeight,
+  IN  UINTN                          SrcDeltaBytes,
+  OUT EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Dst
+  )
+{
+  UINTN  Row;
+  UINTN  Col;
+
+  if ((Src == NULL) || (Dst == NULL) || (SrcWidth == 0) || (SrcHeight == 0) || (SrcDeltaBytes == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Row = 0; Row < SrcHeight; Row++) {
+    EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *SrcRow;
+    EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *DstRow0;
+    EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *DstRow1;
+
+    SrcRow  = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL *)((UINT8 *)Src + Row * SrcDeltaBytes);
+    DstRow0 = Dst + (Row * 2) * (SrcWidth * 2);
+    DstRow1 = DstRow0 + (SrcWidth * 2);
+
+    for (Col = 0; Col < SrcWidth; Col++) {
+      EFI_GRAPHICS_OUTPUT_BLT_PIXEL  P;
+      UINTN                          DstX;
+
+      P    = SrcRow[Col];
+      DstX = Col * 2;
+
+      DstRow0[DstX]     = P;
+      DstRow0[DstX + 1] = P;
+      DstRow1[DstX]     = P;
+      DstRow1[DstX + 1] = P;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Downscale a BLT buffer by 2x.
+
+  @param  Src            Pointer to the source buffer.
+  @param  SrcWidth       Source buffer width in pixels.
+  @param  SrcHeight      Source buffer height in pixels.
+  @param  SrcDeltaBytes  Source buffer stride in bytes.
+  @param  Dst            Pointer to the destination buffer.
+  @param  DstWidth       Destination buffer width in pixels.
+  @param  DstHeight      Destination buffer height in pixels.
+  @param  DstDeltaBytes  Destination buffer stride in bytes.
+
+  @retval EFI_SUCCESS           The buffer was downscaled successfully.
+  @retval EFI_INVALID_PARAMETER One or more parameters are invalid.
+
+**/
+static EFI_STATUS
+DownscaleBltBuffer2x (
+  IN  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Src,
+  IN  UINTN                          SrcWidth,
+  IN  UINTN                          SrcHeight,
+  IN  UINTN                          SrcDeltaBytes,
+  OUT EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Dst,
+  IN  UINTN                          DstWidth,
+  IN  UINTN                          DstHeight,
+  IN  UINTN                          DstDeltaBytes
+  )
+{
+  UINTN  Row;
+  UINTN  Col;
+
+  if ((Src == NULL) || (Dst == NULL) || (DstWidth == 0) || (DstHeight == 0) ||
+      (SrcDeltaBytes == 0) || (DstDeltaBytes == 0))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((SrcWidth < DstWidth * 2) || (SrcHeight < DstHeight * 2)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Row = 0; Row < DstHeight; Row++) {
+    EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *DstRow;
+    EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *SrcRow;
+
+    DstRow = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL *)((UINT8 *)Dst + Row * DstDeltaBytes);
+    SrcRow = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL *)((UINT8 *)Src + (Row * 2) * SrcDeltaBytes);
+
+    for (Col = 0; Col < DstWidth; Col++) {
+      DstRow[Col] = SrcRow[Col * 2];
+    }
+  }
+
+  return EFI_SUCCESS;
 }
 
 /**
@@ -149,26 +552,224 @@ GraphicsOutputBlt (
   RETURN_STATUS                 Status;
   EFI_TPL                       Tpl;
   GRAPHICS_OUTPUT_PRIVATE_DATA  *Private;
+  UINT32                        Scale;
+  UINT32                        ViewportOffsetX;
+  UINT32                        ViewportOffsetY;
 
   Private = GRAPHICS_OUTPUT_PRIVATE_FROM_THIS (This);
+  Scale   = Private->FrameBufferScale;
+
+  if (Scale == 0) {
+    Scale = 1;
+  }
+
+  if ((Scale != 1) && (Scale != 2)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (This->Mode->Mode == GRAPHICS_OUTPUT_MODE_PHYSICAL) {
+    ViewportOffsetX = 0;
+    ViewportOffsetY = 0;
+  } else {
+    ViewportOffsetX = Private->ViewportOffsetX;
+    ViewportOffsetY = Private->ViewportOffsetY;
+  }
+
   //
   // We have to raise to TPL_NOTIFY, so we make an atomic write to the frame buffer.
   // We would not want a timer based event (Cursor, ...) to come in while we are
   // doing this operation.
   //
-  Tpl    = gBS->RaiseTPL (TPL_NOTIFY);
-  Status = FrameBufferBlt (
-             Private->FrameBufferBltLibConfigure,
-             BltBuffer,
-             BltOperation,
-             SourceX,
-             SourceY,
-             DestinationX,
-             DestinationY,
-             Width,
-             Height,
-             Delta
-             );
+  Tpl = gBS->RaiseTPL (TPL_NOTIFY);
+  if (Scale == 1) {
+    Status = FrameBufferBlt (
+               Private->FrameBufferBltLibConfigure,
+               BltBuffer,
+               BltOperation,
+               SourceX + ViewportOffsetX,
+               SourceY + ViewportOffsetY,
+               DestinationX + ViewportOffsetX,
+               DestinationY + ViewportOffsetY,
+               Width,
+               Height,
+               Delta
+               );
+  } else {
+    switch (BltOperation) {
+      case EfiBltVideoFill:
+      case EfiBltVideoToVideo:
+        Status = FrameBufferBlt (
+                   Private->FrameBufferBltLibConfigure,
+                   BltBuffer,
+                   BltOperation,
+                   SourceX * Scale + ViewportOffsetX,
+                   SourceY * Scale + ViewportOffsetY,
+                   DestinationX * Scale + ViewportOffsetX,
+                   DestinationY * Scale + ViewportOffsetY,
+                   Width * Scale,
+                   Height * Scale,
+                   Delta
+                   );
+        break;
+
+      case EfiBltBufferToVideo:
+      {
+        EFI_STATUS                     EfiStatus;
+        EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Temp;
+        UINTN                          PixelSize;
+        UINTN                          SrcDeltaBytes;
+        UINTN                          TempWidth;
+        UINTN                          TempHeight;
+        UINTN                          TempSize;
+        UINTN                          TempDeltaBytes;
+        EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *SrcBase;
+
+        if (BltBuffer == NULL) {
+          Status = RETURN_INVALID_PARAMETER;
+          break;
+        }
+
+        PixelSize  = sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL);
+        TempWidth  = Width * Scale;
+        TempHeight = Height * Scale;
+
+        if ((TempWidth / Scale != Width) || (TempHeight / Scale != Height)) {
+          Status = RETURN_INVALID_PARAMETER;
+          break;
+        }
+
+        SrcDeltaBytes = Delta;
+        if (SrcDeltaBytes == 0) {
+          if ((SourceX != 0) || (SourceY != 0)) {
+            Status = RETURN_INVALID_PARAMETER;
+            break;
+          }
+
+          SrcDeltaBytes = Width * PixelSize;
+        }
+
+        TempDeltaBytes = TempWidth * PixelSize;
+        TempSize       = TempHeight * TempDeltaBytes;
+        Temp           = AllocatePool (TempSize);
+        if (Temp == NULL) {
+          Status = RETURN_OUT_OF_RESOURCES;
+          break;
+        }
+
+        SrcBase   = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL *)((UINT8 *)BltBuffer + SourceY * SrcDeltaBytes + SourceX * PixelSize);
+        EfiStatus = ScaleBltBuffer2x (
+                      SrcBase,
+                      Width,
+                      Height,
+                      SrcDeltaBytes,
+                      Temp
+                      );
+        if (EFI_ERROR (EfiStatus)) {
+          FreePool (Temp);
+          Status = RETURN_INVALID_PARAMETER;
+          break;
+        }
+
+        Status = FrameBufferBlt (
+                   Private->FrameBufferBltLibConfigure,
+                   Temp,
+                   EfiBltBufferToVideo,
+                   0,
+                   0,
+                   DestinationX * Scale + ViewportOffsetX,
+                   DestinationY * Scale + ViewportOffsetY,
+                   TempWidth,
+                   TempHeight,
+                   TempDeltaBytes
+                   );
+
+        FreePool (Temp);
+        break;
+      }
+
+      case EfiBltVideoToBltBuffer:
+      {
+        EFI_STATUS                     EfiStatus;
+        EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *Temp;
+        UINTN                          PixelSize;
+        UINTN                          DstDeltaBytes;
+        UINTN                          TempWidth;
+        UINTN                          TempHeight;
+        UINTN                          TempSize;
+        UINTN                          TempDeltaBytes;
+        EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *DstBase;
+
+        if (BltBuffer == NULL) {
+          Status = RETURN_INVALID_PARAMETER;
+          break;
+        }
+
+        PixelSize  = sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL);
+        TempWidth  = Width * Scale;
+        TempHeight = Height * Scale;
+
+        if ((TempWidth / Scale != Width) || (TempHeight / Scale != Height)) {
+          Status = RETURN_INVALID_PARAMETER;
+          break;
+        }
+
+        DstDeltaBytes = Delta;
+        if (DstDeltaBytes == 0) {
+          if ((DestinationX != 0) || (DestinationY != 0)) {
+            Status = RETURN_INVALID_PARAMETER;
+            break;
+          }
+
+          DstDeltaBytes = Width * PixelSize;
+        }
+
+        TempDeltaBytes = TempWidth * PixelSize;
+        TempSize       = TempHeight * TempDeltaBytes;
+        Temp           = AllocatePool (TempSize);
+        if (Temp == NULL) {
+          Status = RETURN_OUT_OF_RESOURCES;
+          break;
+        }
+
+        Status = FrameBufferBlt (
+                   Private->FrameBufferBltLibConfigure,
+                   Temp,
+                   EfiBltVideoToBltBuffer,
+                   SourceX * Scale + ViewportOffsetX,
+                   SourceY * Scale + ViewportOffsetY,
+                   0,
+                   0,
+                   TempWidth,
+                   TempHeight,
+                   TempDeltaBytes
+                   );
+        if (RETURN_ERROR (Status)) {
+          FreePool (Temp);
+          break;
+        }
+
+        DstBase   = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL *)((UINT8 *)BltBuffer + DestinationY * DstDeltaBytes + DestinationX * PixelSize);
+        EfiStatus = DownscaleBltBuffer2x (
+                      Temp,
+                      TempWidth,
+                      TempHeight,
+                      TempDeltaBytes,
+                      DstBase,
+                      Width,
+                      Height,
+                      DstDeltaBytes
+                      );
+        FreePool (Temp);
+        Status = EFI_ERROR (EfiStatus) ? RETURN_INVALID_PARAMETER : RETURN_SUCCESS;
+        break;
+      }
+
+      default:
+        Status = RETURN_INVALID_PARAMETER;
+        break;
+    }
+  }
+
   gBS->RestoreTPL (Tpl);
 
   return RETURN_ERROR (Status) ? EFI_INVALID_PARAMETER : EFI_SUCCESS;
@@ -191,6 +792,18 @@ CONST GRAPHICS_OUTPUT_PRIVATE_DATA  mGraphicsOutputInstanceTemplate = {
     0,                                             // FrameBufferBase
     0                                              // FrameBufferSize
   },
+  { 0 },                                           // LogicalModeInfo
+  { 0 },                                           // PhysicalModeInfo
+  0,                                               // FrameBufferScale
+  0,                                               // LogicalModeScale
+  0,                                               // ViewportOffsetX
+  0,                                               // ViewportOffsetY
+  0,                                               // ViewportWidth
+  0,                                               // ViewportHeight
+  FALSE,                                           // HasHiDpiMode
+  NULL,                                            // ReadyToBootEvent
+  0,                                               // PhysicalFrameBufferBase
+  0,                                               // PhysicalFrameBufferSize
   NULL,                                            // DevicePath
   NULL,                                            // PciIo
   0,                                               // PciAttributes
@@ -321,6 +934,7 @@ GraphicsOutputDriverBindingStart (
   EFI_PEI_GRAPHICS_INFO_HOB          *GraphicsInfo;
   EFI_PEI_GRAPHICS_DEVICE_INFO_HOB   *DeviceInfo;
   EFI_PHYSICAL_ADDRESS               FrameBufferBase;
+  UINT32                             ViewportWidth;
 
   FrameBufferBase = 0;
 
@@ -468,14 +1082,108 @@ GraphicsOutputDriverBindingStart (
     goto CloseProtocols;
   }
 
-  Private->GraphicsOutputMode.FrameBufferBase = FrameBufferBase;
-  Private->GraphicsOutputMode.FrameBufferSize = GraphicsInfo->FrameBufferSize;
-  Private->GraphicsOutputMode.Info            = &GraphicsInfo->GraphicsMode;
+  Private->PhysicalFrameBufferBase = FrameBufferBase;
+  Private->PhysicalFrameBufferSize = GraphicsInfo->FrameBufferSize;
+
+  CopyMem (&Private->PhysicalModeInfo, &GraphicsInfo->GraphicsMode, sizeof (Private->PhysicalModeInfo));
+  CopyMem (&Private->LogicalModeInfo, &Private->PhysicalModeInfo, sizeof (Private->LogicalModeInfo));
+
+  Private->ViewportOffsetX = 0;
+  Private->ViewportOffsetY = 0;
+  Private->ViewportWidth   = Private->PhysicalModeInfo.HorizontalResolution;
+  Private->ViewportHeight  = Private->PhysicalModeInfo.VerticalResolution;
+  Private->HasHiDpiMode     = FALSE;
+  Private->FrameBufferScale = 1;
+  Private->LogicalModeScale = 1;
+
+  if (FeaturePcdGet (PcdPayloadFbHiDpiWideAspectCapSupport) &&
+      TryGetWideAspectCappedViewportWidth (
+        Private->PhysicalModeInfo.HorizontalResolution,
+        Private->PhysicalModeInfo.VerticalResolution,
+        PcdGet32 (PcdPayloadFbHiDpiWideAspectCapWidth),
+        PcdGet32 (PcdPayloadFbHiDpiWideAspectCapHeight),
+        &ViewportWidth
+        ))
+  {
+    Private->ViewportWidth   = ViewportWidth;
+    Private->ViewportOffsetX = (Private->PhysicalModeInfo.HorizontalResolution - ViewportWidth) / 2;
+  }
+
+  if (IsHiDpiFramebuffer (
+        Private->PhysicalModeInfo.HorizontalResolution,
+        Private->PhysicalModeInfo.VerticalResolution
+        ) &&
+      ((Private->PhysicalModeInfo.HorizontalResolution % 2) == 0) &&
+      ((Private->PhysicalModeInfo.VerticalResolution % 2) == 0))
+  {
+    Private->HasHiDpiMode                         = TRUE;
+    Private->LogicalModeScale                      = 2;
+    Private->LogicalModeInfo.HorizontalResolution = Private->ViewportWidth / 2;
+    Private->LogicalModeInfo.VerticalResolution   = Private->ViewportHeight / 2;
+    Private->LogicalModeInfo.PixelsPerScanLine    = Private->LogicalModeInfo.HorizontalResolution;
+    Private->LogicalModeInfo.PixelFormat          = PixelBltOnly;
+    ZeroMem (&Private->LogicalModeInfo.PixelInformation, sizeof (Private->LogicalModeInfo.PixelInformation));
+
+    DEBUG ((
+      DEBUG_INFO,
+      "[%a]: Enabling GOP 2x framebuffer scaling (physical %ux%u, logical %ux%u)\n",
+      gEfiCallerBaseName,
+      Private->PhysicalModeInfo.HorizontalResolution,
+      Private->PhysicalModeInfo.VerticalResolution,
+      Private->LogicalModeInfo.HorizontalResolution,
+      Private->LogicalModeInfo.VerticalResolution
+      ));
+
+    if (Private->ViewportOffsetX != 0) {
+      DEBUG ((
+        DEBUG_INFO,
+        "[%a]: Centering HiDPI viewport at +%u, viewport %ux%u inside physical %ux%u\n",
+        gEfiCallerBaseName,
+        Private->ViewportOffsetX,
+        Private->ViewportWidth,
+        Private->ViewportHeight,
+        Private->PhysicalModeInfo.HorizontalResolution,
+        Private->PhysicalModeInfo.VerticalResolution
+        ));
+    }
+  }
+
+  if (!Private->HasHiDpiMode && (Private->ViewportOffsetX != 0)) {
+    Private->HasHiDpiMode                          = TRUE;
+    Private->LogicalModeScale                     = 1;
+    Private->LogicalModeInfo.HorizontalResolution = Private->ViewportWidth;
+    Private->LogicalModeInfo.VerticalResolution   = Private->ViewportHeight;
+    Private->LogicalModeInfo.PixelsPerScanLine    = Private->LogicalModeInfo.HorizontalResolution;
+    Private->LogicalModeInfo.PixelFormat          = PixelBltOnly;
+    ZeroMem (&Private->LogicalModeInfo.PixelInformation, sizeof (Private->LogicalModeInfo.PixelInformation));
+
+    DEBUG ((
+      DEBUG_INFO,
+      "[%a]: Enabling centered viewport mode (physical %ux%u, logical %ux%u, offset +%u)\n",
+      gEfiCallerBaseName,
+      Private->PhysicalModeInfo.HorizontalResolution,
+      Private->PhysicalModeInfo.VerticalResolution,
+      Private->LogicalModeInfo.HorizontalResolution,
+      Private->LogicalModeInfo.VerticalResolution,
+      Private->ViewportOffsetX
+      ));
+  }
+
+  Private->GraphicsOutputMode.MaxMode = Private->HasHiDpiMode ? 2 : 1;
 
   //
   // Fix up Mode pointer in GraphicsOutput
   //
   Private->GraphicsOutput.Mode = &Private->GraphicsOutputMode;
+
+  Status = GraphicsOutputSetModeInternal (
+             &Private->GraphicsOutput,
+             GRAPHICS_OUTPUT_MODE_PHYSICAL,
+             FALSE
+             );
+  if (EFI_ERROR (Status)) {
+    goto FreeMemory;
+  }
 
   //
   // Set attributes
@@ -503,8 +1211,8 @@ GraphicsOutputDriverBindingStart (
   // Create the FrameBufferBltLib configuration.
   //
   ReturnStatus = FrameBufferBltConfigure (
-                   (VOID *)(UINTN)Private->GraphicsOutput.Mode->FrameBufferBase,
-                   Private->GraphicsOutput.Mode->Info,
+                   (VOID *)(UINTN)Private->PhysicalFrameBufferBase,
+                   &Private->PhysicalModeInfo,
                    Private->FrameBufferBltLibConfigure,
                    &Private->FrameBufferBltLibConfigureSize
                    );
@@ -512,8 +1220,8 @@ GraphicsOutputDriverBindingStart (
     Private->FrameBufferBltLibConfigure = AllocatePool (Private->FrameBufferBltLibConfigureSize);
     if (Private->FrameBufferBltLibConfigure != NULL) {
       ReturnStatus = FrameBufferBltConfigure (
-                       (VOID *)(UINTN)Private->GraphicsOutput.Mode->FrameBufferBase,
-                       Private->GraphicsOutput.Mode->Info,
+                       (VOID *)(UINTN)Private->PhysicalFrameBufferBase,
+                       &Private->PhysicalModeInfo,
                        Private->FrameBufferBltLibConfigure,
                        &Private->FrameBufferBltLibConfigureSize
                        );
@@ -541,6 +1249,28 @@ GraphicsOutputDriverBindingStart (
                   );
 
   if (!EFI_ERROR (Status)) {
+    if (Private->HasHiDpiMode) {
+      Status = gBS->CreateEventEx (
+                      EVT_NOTIFY_SIGNAL,
+                      TPL_NOTIFY,
+                      GraphicsOutputReadyToBoot,
+                      Private,
+                      &gEfiEventReadyToBootGuid,
+                      &Private->ReadyToBootEvent
+                      );
+      if (EFI_ERROR (Status)) {
+        gBS->UninstallMultipleProtocolInterfaces (
+               Private->GraphicsOutputHandle,
+               &gEfiGraphicsOutputProtocolGuid,
+               &Private->GraphicsOutput,
+               &gEfiDevicePathProtocolGuid,
+               Private->DevicePath,
+               NULL
+               );
+        goto RestorePciAttributes;
+      }
+    }
+
     Status = gBS->OpenProtocol (
                     Controller,
                     &gEfiPciIoProtocolGuid,
@@ -552,6 +1282,11 @@ GraphicsOutputDriverBindingStart (
     if (!EFI_ERROR (Status)) {
       mDriverStarted = TRUE;
     } else {
+      if (Private->ReadyToBootEvent != NULL) {
+        gBS->CloseEvent (Private->ReadyToBootEvent);
+        Private->ReadyToBootEvent = NULL;
+      }
+
       gBS->UninstallMultipleProtocolInterfaces (
              Private->GraphicsOutputHandle,
              &gEfiGraphicsOutputProtocolGuid,
@@ -678,6 +1413,11 @@ GraphicsOutputDriverBindingStop (
   }
 
   Private = GRAPHICS_OUTPUT_PRIVATE_FROM_THIS (Gop);
+
+  if (Private->ReadyToBootEvent != NULL) {
+    gBS->CloseEvent (Private->ReadyToBootEvent);
+    Private->ReadyToBootEvent = NULL;
+  }
 
   Status = gBS->CloseProtocol (
                   Controller,

--- a/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.h
+++ b/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.h
@@ -34,15 +34,27 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define MAX_PCI_BAR  6
 
 typedef struct {
-  UINT32                               Signature;
-  EFI_HANDLE                           GraphicsOutputHandle;
-  EFI_GRAPHICS_OUTPUT_PROTOCOL         GraphicsOutput;
-  EFI_GRAPHICS_OUTPUT_PROTOCOL_MODE    GraphicsOutputMode;
-  EFI_DEVICE_PATH_PROTOCOL             *DevicePath;
-  EFI_PCI_IO_PROTOCOL                  *PciIo;
-  UINT64                               PciAttributes;
-  FRAME_BUFFER_CONFIGURE               *FrameBufferBltLibConfigure;
-  UINTN                                FrameBufferBltLibConfigureSize;
+  UINT32                                  Signature;
+  EFI_HANDLE                              GraphicsOutputHandle;
+  EFI_GRAPHICS_OUTPUT_PROTOCOL            GraphicsOutput;
+  EFI_GRAPHICS_OUTPUT_PROTOCOL_MODE       GraphicsOutputMode;
+  EFI_GRAPHICS_OUTPUT_MODE_INFORMATION    LogicalModeInfo;
+  EFI_GRAPHICS_OUTPUT_MODE_INFORMATION    PhysicalModeInfo;
+  UINT32                                  FrameBufferScale;
+  UINT32                                  LogicalModeScale;
+  UINT32                                  ViewportOffsetX;
+  UINT32                                  ViewportOffsetY;
+  UINT32                                  ViewportWidth;
+  UINT32                                  ViewportHeight;
+  BOOLEAN                                 HasHiDpiMode;
+  EFI_EVENT                               ReadyToBootEvent;
+  UINT64                                  PhysicalFrameBufferBase;
+  UINTN                                   PhysicalFrameBufferSize;
+  EFI_DEVICE_PATH_PROTOCOL                *DevicePath;
+  EFI_PCI_IO_PROTOCOL                     *PciIo;
+  UINT64                                  PciAttributes;
+  FRAME_BUFFER_CONFIGURE                  *FrameBufferBltLibConfigure;
+  UINTN                                   FrameBufferBltLibConfigureSize;
 } GRAPHICS_OUTPUT_PRIVATE_DATA;
 
 #define GRAPHICS_OUTPUT_PRIVATE_DATA_SIGNATURE  SIGNATURE_32 ('g', 'g', 'o', 'p')

--- a/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutputDxe.inf
+++ b/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutputDxe.inf
@@ -30,6 +30,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  UefiPayloadPkg/UefiPayloadPkg.dec
 
 [LibraryClasses]
   UefiDriverEntryPoint
@@ -42,12 +43,24 @@
   FrameBufferBltLib
   UefiLib
   HobLib
+  PcdLib
 
 [Guids]
   gEfiGraphicsInfoHobGuid                       ## CONSUMES ## HOB
   gEfiGraphicsDeviceInfoHobGuid                 ## CONSUMES ## HOB
+  gEfiEventReadyToBootGuid                      ## CONSUMES
 
 [Protocols]
+  gEdkiiBootLogo2ProtocolGuid                   ## SOMETIMES_CONSUMES
   gEfiGraphicsOutputProtocolGuid                ## BY_START
   gEfiDevicePathProtocolGuid                    ## BY_START
   gEfiPciIoProtocolGuid                         ## TO_START
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoHorizontalResolution
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVideoVerticalResolution
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoHorizontalResolution
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapSupport
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapWidth
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapHeight

--- a/UefiPayloadPkg/UefiPayloadPkg.dec
+++ b/UefiPayloadPkg/UefiPayloadPkg.dec
@@ -116,3 +116,16 @@ gUefiPayloadPkgTokenSpaceGuid.PcdUseUniversalPayloadSerialPort|TRUE|BOOLEAN|0x00
 
 ## Indicates whether allows PCI Root Bridge to allocate DMA memory resource above 4G
 gUefiPayloadPkgTokenSpaceGuid.PcdPciAllocateMemoryAbove4GB|FALSE|BOOLEAN|0x0000002E
+
+## Indicates whether the alternate setup GOP mode should cap wide displays to a
+## centered viewport when the physical framebuffer is wider than the configured
+## aspect ratio.
+[PcdsFeatureFlag]
+gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapSupport|FALSE|BOOLEAN|0x00000032
+
+[PcdsFixedAtBuild]
+## If PcdPayloadFbHiDpiWideAspectCapSupport is enabled and the physical
+## framebuffer is wider than the configured aspect ratio, the alternate setup GOP
+## mode crops to a centered viewport.
+gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapWidth|16|UINT32|0x00000033
+gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapHeight|9|UINT32|0x00000034

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -47,6 +47,9 @@
   DEFINE NVME_ENABLE                  = TRUE
   DEFINE LOCKBOX_SUPPORT              = FALSE
   DEFINE LOAD_OPTION_ROMS             = FALSE
+  DEFINE PAYLOAD_FB_HIDPI_WIDE_ASPECT_CAP_SUPPORT = FALSE
+  DEFINE PAYLOAD_FB_HIDPI_WIDE_ASPECT_CAP_WIDTH   = 16
+  DEFINE PAYLOAD_FB_HIDPI_WIDE_ASPECT_CAP_HEIGHT  = 9
 
   #
   # Capsule updates
@@ -586,6 +589,7 @@
 ################################################################################
 [PcdsFeatureFlag]
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutGopSupport|TRUE
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapSupport|$(PAYLOAD_FB_HIDPI_WIDE_ASPECT_CAP_SUPPORT)
   ## This PCD specified whether ACPI SDT protocol is installed.
   gEfiMdeModulePkgTokenSpaceGuid.PcdInstallAcpiSdtProtocol|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdHiiOsRuntimeSupport|FALSE
@@ -625,6 +629,8 @@
   gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask       | 0x1
 !endif
   gEfiMdeModulePkgTokenSpaceGuid.PcdSdMmcGenericTimeoutValue|$(SD_MMC_TIMEOUT)
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapWidth|$(PAYLOAD_FB_HIDPI_WIDE_ASPECT_CAP_WIDTH)
+  gUefiPayloadPkgTokenSpaceGuid.PcdPayloadFbHiDpiWideAspectCapHeight|$(PAYLOAD_FB_HIDPI_WIDE_ASPECT_CAP_HEIGHT)
 
   gUefiPayloadPkgTokenSpaceGuid.PcdBootManagerEscape|$(BOOT_MANAGER_ESCAPE)
 


### PR DESCRIPTION
Keep the physical GOP active for normal boot and OS handoff. Use a logical alternate mode for setup, scale GraphicsConsole glyphs and cursors, and scale the logo before display and BGRT registration.

An optional centered viewport limits ultrawide setup layouts.

This restores the implementation hardware-tested in release_26.07. It replaces the previous patchsets that made the logical PixelBltOnly mode active during normal boot and switched modes at ReadyToBoot.

Tested with PatchCheck and on Lite ADL with a 2160x1440 display.