### PR TITLE
PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe: Avoid torn RTC time reads

### DIFF
--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
@@ -189,6 +189,137 @@ RtcWrite (
 }
 
 /**
+  Read the RTC time/date or alarm registers once, reporting whether an update
+  cycle crossed the read.
+
+  Time is written unconditionally, so the caller must not pass its own output
+  structure.
+
+  @param  Time       Receives the raw register values.
+  @param  ReadAlarm  TRUE to read the alarm registers, FALSE to read the time.
+
+  @retval EFI_SUCCESS       The registers were read with no intervening update.
+  @retval EFI_NOT_READY     An update crossed the read; the values are invalid.
+  @retval EFI_DEVICE_ERROR  The RTC is not functioning.
+
+**/
+static
+EFI_STATUS
+RtcReadTimeDateOrFail (
+  IN OUT EFI_TIME  *Time,
+  IN     BOOLEAN   ReadAlarm
+  )
+{
+  EFI_STATUS      Status;
+  UINT8           SecondsAtStart;
+  RTC_REGISTER_A  RegisterA;
+
+  //
+  // Locations 0-9 return undefined data during the update cycle, and a clear
+  // UIP bit guarantees only a documented minimum interval that a slow read can
+  // exceed. Enter a fresh update-free window; this also validates VRT.
+  //
+  Status = RtcWaitToUpdate (PcdGet32 (PcdRealTimeClockUpdateTimeout));
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Sample Seconds as a witness: the update cycle increments it, so it changes
+  // if and only if an update occurred.
+  //
+  SecondsAtStart = RtcRead (RTC_ADDRESS_SECONDS);
+
+  if (ReadAlarm) {
+    Time->Second = RtcRead (RTC_ADDRESS_SECONDS_ALARM);
+    Time->Minute = RtcRead (RTC_ADDRESS_MINUTES_ALARM);
+    Time->Hour   = RtcRead (RTC_ADDRESS_HOURS_ALARM);
+  } else {
+    Time->Second = SecondsAtStart;
+    Time->Minute = RtcRead (RTC_ADDRESS_MINUTES);
+    Time->Hour   = RtcRead (RTC_ADDRESS_HOURS);
+  }
+
+  Time->Day   = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
+  Time->Month = RtcRead (RTC_ADDRESS_MONTH);
+  Time->Year  = RtcRead (RTC_ADDRESS_YEAR);
+
+  //
+  // If UIP is set an update is in progress or imminent, so the Seconds value
+  // read below could not be trusted as a witness.
+  //
+  RegisterA.Data = RtcRead (RTC_ADDRESS_REGISTER_A);
+  if (RegisterA.Bits.Uip == 1) {
+    return EFI_NOT_READY;
+  }
+
+  //
+  // UIP is clear, so this Seconds read is inside a guaranteed update-free
+  // window. A value different from the one sampled above means an update
+  // crossed the read.
+  //
+  if (RtcRead (RTC_ADDRESS_SECONDS) != SecondsAtStart) {
+    return EFI_NOT_READY;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Safely read the RTC time/date or alarm registers into Time.
+
+  Either Time contains values read with no intervening update cycle, or Time is
+  returned unmodified with an error status.
+
+  @param  Time       Receives the raw register values on success.
+  @param  ReadAlarm  TRUE to read the alarm registers, FALSE to read the time.
+
+  @retval EFI_SUCCESS       The registers were read with no intervening update.
+  @retval EFI_DEVICE_ERROR  The RTC is not functioning, or the registers could
+                            not be read without an intervening update.
+
+**/
+static
+EFI_STATUS
+RtcReadRegistersSafe (
+  IN OUT EFI_TIME  *Time,
+  IN     BOOLEAN   ReadAlarm
+  )
+{
+  EFI_STATUS  Status;
+  EFI_TIME    SafeTime;
+
+  Status = RtcReadTimeDateOrFail (&SafeTime, ReadAlarm);
+  if (Status == EFI_NOT_READY) {
+    //
+    // Retry once. The update cycle that crossed the first attempt has now
+    // completed, so the next one is nearly a second away.
+    //
+    Status = RtcReadTimeDateOrFail (&SafeTime, ReadAlarm);
+    if (Status == EFI_NOT_READY) {
+      //
+      // A second failure means the RTC is not functioning correctly. Fold it
+      // here so EFI_NOT_READY stays internal to this file.
+      //
+      Status = EFI_DEVICE_ERROR;
+    }
+  }
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Time->Second = SafeTime.Second;
+  Time->Minute = SafeTime.Minute;
+  Time->Hour   = SafeTime.Hour;
+  Time->Day    = SafeTime.Day;
+  Time->Month  = SafeTime.Month;
+  Time->Year   = SafeTime.Year;
+
+  return EFI_SUCCESS;
+}
+
+/**
   Sets the current local timezone & daylight information.
 
   @param  TimeZone         Timezone info.
@@ -309,9 +440,11 @@ PcRtcInit (
   RtcWrite (RTC_ADDRESS_REGISTER_D, RegisterD.Data);
 
   //
-  // Wait for up to 0.1 seconds for the RTC to be updated
+  // Get the Time/Date/Daylight Savings values. RtcReadRegistersSafe enters its
+  // own update-free window and validates VRT, so no separate RtcWaitToUpdate is
+  // needed here.
   //
-  Status = RtcWaitToUpdate (PcdGet32 (PcdRealTimeClockUpdateTimeout));
+  Status = RtcReadRegistersSafe (&Time, FALSE);
   if (EFI_ERROR (Status)) {
     //
     // Set the variable with default value if the RTC is functioning incorrectly.
@@ -324,16 +457,6 @@ PcRtcInit (
 
     return EFI_DEVICE_ERROR;
   }
-
-  //
-  // Get the Time/Date/Daylight Savings values.
-  //
-  Time.Second = RtcRead (RTC_ADDRESS_SECONDS);
-  Time.Minute = RtcRead (RTC_ADDRESS_MINUTES);
-  Time.Hour   = RtcRead (RTC_ADDRESS_HOURS);
-  Time.Day    = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
-  Time.Month  = RtcRead (RTC_ADDRESS_MONTH);
-  Time.Year   = RtcRead (RTC_ADDRESS_YEAR);
 
   //
   // Release RTC Lock.
@@ -548,9 +671,17 @@ PcRtcGetTime (
   }
 
   //
-  // Wait for up to 0.1 seconds for the RTC to be updated
+  // Read Register B (format/mode info, not affected by the update cycle, so it
+  // needs no update-free window of its own).
   //
-  Status = RtcWaitToUpdate (PcdGet32 (PcdRealTimeClockUpdateTimeout));
+  RegisterB.Data = RtcRead (RTC_ADDRESS_REGISTER_B);
+
+  //
+  // Get the Time/Date/Daylight Savings values. RtcReadRegistersSafe enters its
+  // own update-free window and validates VRT, so no separate RtcWaitToUpdate is
+  // needed here.
+  //
+  Status = RtcReadRegistersSafe (Time, FALSE);
   if (EFI_ERROR (Status)) {
     if (!EfiAtRuntime ()) {
       EfiReleaseLock (&Global->RtcLock);
@@ -558,21 +689,6 @@ PcRtcGetTime (
 
     return Status;
   }
-
-  //
-  // Read Register B
-  //
-  RegisterB.Data = RtcRead (RTC_ADDRESS_REGISTER_B);
-
-  //
-  // Get the Time/Date/Daylight Savings values.
-  //
-  Time->Second = RtcRead (RTC_ADDRESS_SECONDS);
-  Time->Minute = RtcRead (RTC_ADDRESS_MINUTES);
-  Time->Hour   = RtcRead (RTC_ADDRESS_HOURS);
-  Time->Day    = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
-  Time->Month  = RtcRead (RTC_ADDRESS_MONTH);
-  Time->Year   = RtcRead (RTC_ADDRESS_YEAR);
 
   //
   // Release RTC Lock.
@@ -798,12 +914,18 @@ PcRtcGetWakeupTime (
   *Enabled = RegisterB.Bits.Aie;
   *Pending = RegisterC.Bits.Af;
 
-  Time->Second   = RtcRead (RTC_ADDRESS_SECONDS_ALARM);
-  Time->Minute   = RtcRead (RTC_ADDRESS_MINUTES_ALARM);
-  Time->Hour     = RtcRead (RTC_ADDRESS_HOURS_ALARM);
-  Time->Day      = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
-  Time->Month    = RtcRead (RTC_ADDRESS_MONTH);
-  Time->Year     = RtcRead (RTC_ADDRESS_YEAR);
+  //
+  // Read the alarm and date registers safely (see RtcReadRegistersSafe).
+  //
+  Status = RtcReadRegistersSafe (Time, TRUE);
+  if (EFI_ERROR (Status)) {
+    if (!EfiAtRuntime ()) {
+      EfiReleaseLock (&Global->RtcLock);
+    }
+
+    return EFI_DEVICE_ERROR;
+  }
+
   Time->TimeZone = Global->SavedTimeZone;
   Time->Daylight = Global->Daylight;
 
@@ -943,12 +1065,18 @@ PcRtcSetWakeupTime (
     //
     // if the alarm is disable, record the current setting.
     //
-    RtcTime.Second   = RtcRead (RTC_ADDRESS_SECONDS_ALARM);
-    RtcTime.Minute   = RtcRead (RTC_ADDRESS_MINUTES_ALARM);
-    RtcTime.Hour     = RtcRead (RTC_ADDRESS_HOURS_ALARM);
-    RtcTime.Day      = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
-    RtcTime.Month    = RtcRead (RTC_ADDRESS_MONTH);
-    RtcTime.Year     = RtcRead (RTC_ADDRESS_YEAR);
+    //
+    // Read the alarm and date registers safely (see RtcReadRegistersSafe).
+    //
+    Status = RtcReadRegistersSafe (&RtcTime, TRUE);
+    if (EFI_ERROR (Status)) {
+      if (!EfiAtRuntime ()) {
+        EfiReleaseLock (&Global->RtcLock);
+      }
+
+      return EFI_DEVICE_ERROR;
+    }
+
     RtcTime.TimeZone = Global->SavedTimeZone;
     RtcTime.Daylight = Global->Daylight;
   }

--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
@@ -60,6 +60,18 @@ IsWithinOneDay (
   );
 
 /**
+  Safely read a set of RTC time/date registers (indices 0-9), retrying if an
+  update cycle crosses the read.  See definition for full description.
+**/
+STATIC
+EFI_STATUS
+RtcReadRegistersSafe (
+  IN  CONST UINT8  *Addresses,
+  OUT UINT8        *Values,
+  IN  UINTN        Count
+  );
+
+/**
   Read RTC content through its registers using IO access.
 
   @param  Address   Address offset of RTC. It is recommended to use
@@ -309,31 +321,38 @@ PcRtcInit (
   RtcWrite (RTC_ADDRESS_REGISTER_D, RegisterD.Data);
 
   //
-  // Wait for up to 0.1 seconds for the RTC to be updated
+  // Get the Time/Date/Daylight Savings values.  RtcReadRegistersSafe enters its
+  // own update-free window and validates VRT, so no separate RtcWaitToUpdate is
+  // needed here.
   //
-  Status = RtcWaitToUpdate (PcdGet32 (PcdRealTimeClockUpdateTimeout));
-  if (EFI_ERROR (Status)) {
-    //
-    // Set the variable with default value if the RTC is functioning incorrectly.
-    //
-    Global->SavedTimeZone = EFI_UNSPECIFIED_TIMEZONE;
-    Global->Daylight      = 0;
-    if (!EfiAtRuntime ()) {
-      EfiReleaseLock (&Global->RtcLock);
+  {
+    CONST UINT8  ReadAddr[] = {
+      RTC_ADDRESS_SECONDS,          RTC_ADDRESS_MINUTES, RTC_ADDRESS_HOURS,
+      RTC_ADDRESS_DAY_OF_THE_MONTH, RTC_ADDRESS_MONTH,   RTC_ADDRESS_YEAR
+    };
+    UINT8        ReadVal[ARRAY_SIZE (ReadAddr)];
+
+    Status = RtcReadRegistersSafe (ReadAddr, ReadVal, ARRAY_SIZE (ReadAddr));
+    if (EFI_ERROR (Status)) {
+      //
+      // Set the variable with default value if the RTC is functioning incorrectly.
+      //
+      Global->SavedTimeZone = EFI_UNSPECIFIED_TIMEZONE;
+      Global->Daylight      = 0;
+      if (!EfiAtRuntime ()) {
+        EfiReleaseLock (&Global->RtcLock);
+      }
+
+      return EFI_DEVICE_ERROR;
     }
 
-    return EFI_DEVICE_ERROR;
+    Time.Second = ReadVal[0];
+    Time.Minute = ReadVal[1];
+    Time.Hour   = ReadVal[2];
+    Time.Day    = ReadVal[3];
+    Time.Month  = ReadVal[4];
+    Time.Year   = ReadVal[5];
   }
-
-  //
-  // Get the Time/Date/Daylight Savings values.
-  //
-  Time.Second = RtcRead (RTC_ADDRESS_SECONDS);
-  Time.Minute = RtcRead (RTC_ADDRESS_MINUTES);
-  Time.Hour   = RtcRead (RTC_ADDRESS_HOURS);
-  Time.Day    = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
-  Time.Month  = RtcRead (RTC_ADDRESS_MONTH);
-  Time.Year   = RtcRead (RTC_ADDRESS_YEAR);
 
   //
   // Release RTC Lock.
@@ -548,31 +567,39 @@ PcRtcGetTime (
   }
 
   //
-  // Wait for up to 0.1 seconds for the RTC to be updated
-  //
-  Status = RtcWaitToUpdate (PcdGet32 (PcdRealTimeClockUpdateTimeout));
-  if (EFI_ERROR (Status)) {
-    if (!EfiAtRuntime ()) {
-      EfiReleaseLock (&Global->RtcLock);
-    }
-
-    return Status;
-  }
-
-  //
-  // Read Register B
+  // Read Register B (format/mode info, not affected by the update cycle, so it
+  // needs no update-free window of its own).
   //
   RegisterB.Data = RtcRead (RTC_ADDRESS_REGISTER_B);
 
   //
-  // Get the Time/Date/Daylight Savings values.
+  // Get the Time/Date/Daylight Savings values.  RtcReadRegistersSafe enters its
+  // own update-free window and validates VRT, so no separate RtcWaitToUpdate is
+  // needed here.
   //
-  Time->Second = RtcRead (RTC_ADDRESS_SECONDS);
-  Time->Minute = RtcRead (RTC_ADDRESS_MINUTES);
-  Time->Hour   = RtcRead (RTC_ADDRESS_HOURS);
-  Time->Day    = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
-  Time->Month  = RtcRead (RTC_ADDRESS_MONTH);
-  Time->Year   = RtcRead (RTC_ADDRESS_YEAR);
+  {
+    CONST UINT8  ReadAddr[] = {
+      RTC_ADDRESS_SECONDS,          RTC_ADDRESS_MINUTES, RTC_ADDRESS_HOURS,
+      RTC_ADDRESS_DAY_OF_THE_MONTH, RTC_ADDRESS_MONTH,   RTC_ADDRESS_YEAR
+    };
+    UINT8        ReadVal[ARRAY_SIZE (ReadAddr)];
+
+    Status = RtcReadRegistersSafe (ReadAddr, ReadVal, ARRAY_SIZE (ReadAddr));
+    if (EFI_ERROR (Status)) {
+      if (!EfiAtRuntime ()) {
+        EfiReleaseLock (&Global->RtcLock);
+      }
+
+      return Status;
+    }
+
+    Time->Second = ReadVal[0];
+    Time->Minute = ReadVal[1];
+    Time->Hour   = ReadVal[2];
+    Time->Day    = ReadVal[3];
+    Time->Month  = ReadVal[4];
+    Time->Year   = ReadVal[5];
+  }
 
   //
   // Release RTC Lock.
@@ -798,12 +825,32 @@ PcRtcGetWakeupTime (
   *Enabled = RegisterB.Bits.Aie;
   *Pending = RegisterC.Bits.Af;
 
-  Time->Second   = RtcRead (RTC_ADDRESS_SECONDS_ALARM);
-  Time->Minute   = RtcRead (RTC_ADDRESS_MINUTES_ALARM);
-  Time->Hour     = RtcRead (RTC_ADDRESS_HOURS_ALARM);
-  Time->Day      = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
-  Time->Month    = RtcRead (RTC_ADDRESS_MONTH);
-  Time->Year     = RtcRead (RTC_ADDRESS_YEAR);
+  //
+  // Read the alarm and date registers safely (see RtcReadRegistersSafe).
+  //
+  {
+    CONST UINT8  ReadAddr[] = {
+      RTC_ADDRESS_SECONDS_ALARM,    RTC_ADDRESS_MINUTES_ALARM, RTC_ADDRESS_HOURS_ALARM,
+      RTC_ADDRESS_DAY_OF_THE_MONTH, RTC_ADDRESS_MONTH,         RTC_ADDRESS_YEAR
+    };
+    UINT8        ReadVal[ARRAY_SIZE (ReadAddr)];
+
+    Status = RtcReadRegistersSafe (ReadAddr, ReadVal, ARRAY_SIZE (ReadAddr));
+    if (EFI_ERROR (Status)) {
+      if (!EfiAtRuntime ()) {
+        EfiReleaseLock (&Global->RtcLock);
+      }
+
+      return EFI_DEVICE_ERROR;
+    }
+
+    Time->Second = ReadVal[0];
+    Time->Minute = ReadVal[1];
+    Time->Hour   = ReadVal[2];
+    Time->Day    = ReadVal[3];
+    Time->Month  = ReadVal[4];
+    Time->Year   = ReadVal[5];
+  }
   Time->TimeZone = Global->SavedTimeZone;
   Time->Daylight = Global->Daylight;
 
@@ -943,12 +990,32 @@ PcRtcSetWakeupTime (
     //
     // if the alarm is disable, record the current setting.
     //
-    RtcTime.Second   = RtcRead (RTC_ADDRESS_SECONDS_ALARM);
-    RtcTime.Minute   = RtcRead (RTC_ADDRESS_MINUTES_ALARM);
-    RtcTime.Hour     = RtcRead (RTC_ADDRESS_HOURS_ALARM);
-    RtcTime.Day      = RtcRead (RTC_ADDRESS_DAY_OF_THE_MONTH);
-    RtcTime.Month    = RtcRead (RTC_ADDRESS_MONTH);
-    RtcTime.Year     = RtcRead (RTC_ADDRESS_YEAR);
+    //
+    // Read the alarm and date registers safely (see RtcReadRegistersSafe).
+    //
+    {
+      CONST UINT8  ReadAddr[] = {
+        RTC_ADDRESS_SECONDS_ALARM,    RTC_ADDRESS_MINUTES_ALARM, RTC_ADDRESS_HOURS_ALARM,
+        RTC_ADDRESS_DAY_OF_THE_MONTH, RTC_ADDRESS_MONTH,         RTC_ADDRESS_YEAR
+      };
+      UINT8        ReadVal[ARRAY_SIZE (ReadAddr)];
+
+      Status = RtcReadRegistersSafe (ReadAddr, ReadVal, ARRAY_SIZE (ReadAddr));
+      if (EFI_ERROR (Status)) {
+        if (!EfiAtRuntime ()) {
+          EfiReleaseLock (&Global->RtcLock);
+        }
+
+        return EFI_DEVICE_ERROR;
+      }
+
+      RtcTime.Second = ReadVal[0];
+      RtcTime.Minute = ReadVal[1];
+      RtcTime.Hour   = ReadVal[2];
+      RtcTime.Day    = ReadVal[3];
+      RtcTime.Month  = ReadVal[4];
+      RtcTime.Year   = ReadVal[5];
+    }
     RtcTime.TimeZone = Global->SavedTimeZone;
     RtcTime.Daylight = Global->Daylight;
   }
@@ -1154,6 +1221,86 @@ RtcWaitToUpdate (
   }
 
   return EFI_SUCCESS;
+}
+
+/**
+  Safely read a set of RTC time/date registers (indices 0-9).
+
+  RTC RAM locations 0-9 are disconnected from the external bus during an update
+  cycle, so a read that spans the update returns wrong-register / undefined
+  data.  Where a single RTC access is slow, the multi-register read can exceed
+  the guaranteed update-free window after the UIP bit reads 0, so a single
+  up-front RtcWaitToUpdate() is not sufficient.
+
+  Each attempt enters a fresh update-free window (RtcWaitToUpdate), records the
+  Seconds register, reads the requested registers, then confirms no update
+  crossed the read: the UIP bit must still be clear AND Seconds must be
+  unchanged.  Because every update increments Seconds, the Seconds comparison
+  detects an update anywhere in the read regardless of where the momentary UIP
+  pulse fell - unlike a mid-read UIP poll, it does not depend on observing UIP
+  at the instant of the update.  If either check fails, all values are discarded
+  and the read is retried, bounded by RTC_SAFE_READ_MAX_RETRY.
+
+  Seconds is usable as the witness because the update cycle is specified to
+  increment the stored time and date, so it changes if and only if an update
+  occurred; and because the guaranteed update-free window is a documented
+  minimum, not a promise that the whole read will fit inside it.
+
+  The RtcLock, if used, must be held by the caller.
+
+  @param  Addresses  Array of RTC register indices to read.
+  @param  Values     Array receiving the value read from each index.
+  @param  Count      Number of registers to read.
+
+  @retval EFI_SUCCESS       All registers were read from one update-free window.
+  @retval EFI_DEVICE_ERROR  RTC not ready, VRT invalid, or retries exhausted.
+**/
+STATIC
+EFI_STATUS
+RtcReadRegistersSafe (
+  IN  CONST UINT8  *Addresses,
+  OUT UINT8        *Values,
+  IN  UINTN        Count
+  )
+{
+  EFI_STATUS      Status;
+  RTC_REGISTER_A  RegisterA;
+  UINTN           Retry;
+  UINTN           Index;
+  UINT8           SecondsAtStart;
+
+  for (Retry = 0; Retry < RTC_SAFE_READ_MAX_RETRY; Retry++) {
+    //
+    // Enter a fresh update-free window (also validates VRT).
+    //
+    Status = RtcWaitToUpdate (PcdGet32 (PcdRealTimeClockUpdateTimeout));
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    //
+    // Snapshot Seconds, read the whole set, then confirm no update crossed the
+    // read: UIP must still be clear AND Seconds must be unchanged.  Seconds
+    // increments on every update, so an update anywhere in the read is detected
+    // by the Seconds comparison regardless of where the momentary UIP pulse
+    // fell; the UIP check ensures the final Seconds read was not itself taken
+    // mid-update.
+    //
+    SecondsAtStart = RtcRead (RTC_ADDRESS_SECONDS);
+
+    for (Index = 0; Index < Count; Index++) {
+      Values[Index] = RtcRead (Addresses[Index]);
+    }
+
+    RegisterA.Data = RtcRead (RTC_ADDRESS_REGISTER_A);
+    if ((RegisterA.Bits.Uip == 0) &&
+        (RtcRead (RTC_ADDRESS_SECONDS) == SecondsAtStart))
+    {
+      return EFI_SUCCESS;
+    }
+  }
+
+  return EFI_DEVICE_ERROR;
 }
 
 /**

--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.h
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.h
@@ -41,6 +41,12 @@ typedef struct {
 extern PC_RTC_MODULE_GLOBALS  mModuleGlobal;
 
 //
+// Maximum number of times RtcReadRegistersSafe () retries the read when an
+// update collision is detected before returning EFI_DEVICE_ERROR.
+//
+#define RTC_SAFE_READ_MAX_RETRY  5
+
+//
 // Dallas DS12C887 Real Time Clock
 //
 #define RTC_ADDRESS_SECONDS           0   // R/W  Range 0..59


### PR DESCRIPTION
## Summary

`GetTime()` / `GetWakeupTime()` wait for the RTC Update-In-Progress (UIP) bit to
clear, then read the time/date registers (offsets 0-9) back to back. A clear UIP
bit only guarantees a documented minimum interval before the next update cycle
begins - it is not a promise that the whole read fits inside it. On platforms
where a single RTC access is slow the read overruns that window and overlaps the
update cycle, during which locations 0-9 are disconnected from the bus and return
undefined data. A corrupted field (e.g. `Month` outside 1-12) then fails the range
check and `GetTime()` returns `EFI_DEVICE_ERROR`, which can intermittently fail OS
boot and resume.

## Fix

`RtcReadTimeDateOrFail()` performs a single attempt: it enters a fresh update-free
window, samples the Seconds register, reads the requested registers, then requires
that UIP is still clear **and** that Seconds is unchanged. The update cycle is
specified to increment the stored time and date, so Seconds changes if and only if
an update occurred - which detects a collision anywhere inside the read, regardless
of where the momentary UIP pulse fell, without having to catch UIP at the instant
of the update.

`RtcReadRegistersSafe()` drives that with at most one retry, and folds
`EFI_NOT_READY` into `EFI_DEVICE_ERROR` in a single place. Values are read into a
local `EFI_TIME` and copied out only on success, so the caller's structure is
either fully updated or left untouched.

The four read paths - `PcRtcGetTime`, `PcRtcInit`, `PcRtcGetWakeupTime`, and the
`PcRtcSetWakeupTime` disable-alarm path - use the helper. Write paths already
inhibit the update cycle via the Register B SET bit and are unchanged.

Because the helper enters its own update-free window and validates VRT, the
up-front `RtcWaitToUpdate()` in `PcRtcGetTime()` and in the `PcRtcInit()` read path
is now redundant and is removed; `PcRtcInit()`'s default-value handling for a
non-functioning RTC moves to the helper's failure path. `PcRtcGetWakeupTime()` and
`PcRtcSetWakeupTime()` keep their up-front wait - in the latter it also covers the
alarm write path, which does not use the helper.

Per @niruiyu's review the detailed reasoning - the timing that makes the overrun
possible, why Seconds is a valid witness, and why one retry is sufficient - now
lives in comments at those two functions rather than in the commit message.

## Validation

This version has been validated on real hardware, in a platform BIOS built from
this patch.

## Notes

- `PcRtcGetWakeupTime()` samples the read-to-clear Register C before the read. This
  patch lengthens the window between that sample and the returned time, so an alarm
  firing during a retry is reported on the next call rather than this one.
  Pre-existing behaviour; left for a separate change.
