### PR TITLE
BdsDxe: clear timeout text before boot

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -332,6 +332,7 @@ BdsWait (
     if (HotkeyTriggered != NULL) {
       Status = BdsWaitForSingleEvent (HotkeyTriggered, EFI_TIMER_PERIOD_SECONDS (1));
       if (!EFI_ERROR (Status)) {
+        TimeoutRemain = 0;
         break;
       }
     } else {

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -383,6 +383,11 @@ PlatformBootManagerWaitCallback (
   UINT16  TimeoutRemain
   )
 {
+  /* Clear text from screen once timeout expires */
+  if (TimeoutRemain == 0) {
+    gST->ConOut->ClearScreen (gST->ConOut);
+    BootLogoEnableLogo ();
+  }
   return;
 }
 


### PR DESCRIPTION
# Description

Clear the timeout text before starting the default boot option and immediately after a boot hotkey is detected.

This rebases the two commits from #10746, which had approval from Guo Dong and Ruiyu Ni before it was closed as stale. The original spelling and commit subjects have been corrected.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

`PatchCheck.py` passed for both commits.

An X64 DEBUG UefiPayloadPkg build passed with GCC using the coreboot bootloader target.

## Integration Instructions

N/A