### PR TITLE
ArmVirtPkg: add QemuFwCfg null library instances to common DSC

### DIFF
--- a/ArmVirtPkg/ArmVirt.dsc.inc
+++ b/ArmVirtPkg/ArmVirt.dsc.inc
@@ -121,6 +121,8 @@ DEFINE FD_SIZE_IN_MB    = 3
   # Virtio Support
   VirtioLib|OvmfPkg/Library/VirtioLib/VirtioLib.inf
   VirtioMmioDeviceLib|OvmfPkg/Library/VirtioMmioDeviceLib/VirtioMmioDeviceLib.inf
+  QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibNull.inf
+  QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
 
   #
   # Misc

--- a/ArmVirtPkg/ArmVirtCloudHv.dsc
+++ b/ArmVirtPkg/ArmVirtCloudHv.dsc
@@ -46,8 +46,6 @@
 
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
   ArmTransferListLib|ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
-  QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibNull.inf
-  QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
 
 !include MdePkg/MdeLibs.dsc.inc
 


### PR DESCRIPTION
# Description

PlatformPeiLib consumes QemuFwCfgSimpleParserLib, but ArmVirtXen.dsc
provided no resolution for it or its dependency QemuFwCfgLib, causing:

  error 4000: Instance of library class [QemuFwCfgSimpleParserLib]
  is not found for module [ArmVirtPrePiUniCoreRelocatable.inf],
  consumed by PlatformPeiLib.inf

Wire up QemuFwCfgLibNull and QemuFwCfgSimpleParserLib in the common
ArmVirt.dsc.inc so all platforms without fw_cfg fail gracefully.
ArmVirtCloudHv.dsc already carried the same null pair; both per-DSC
copies are removed now that the common default covers them.
ArmVirtQemu and ArmVirtQemuKernel continue to override with their
real MMIO implementations.

Fixes: https://github.com/tianocore/edk2/commit/f4bbef1dd7c15bec5ac164802842d55d740c36fe ("ArmVirtPkg: introduce compile and runtime control of serial debug log level")
Reported-by: Pierre Gondois <pierre.gondois@arm.com>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

build ArmVirtXen pkg

`build -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtXen.dsc`

## Integration Instructions

N/A

/cc @pierregondois 
