### PR TITLE
.pytool: Include the British English dictionary

### DIFF
--- a/.pytool/Plugin/SpellCheck/cspell.base.yaml
+++ b/.pytool/Plugin/SpellCheck/cspell.base.yaml
@@ -6,9 +6,9 @@
 ##
 {
     "version": "0.1",
-    "language": "en",
+    "language": "en,en-GB",
     "dictionaries": [
-        "companies ",
+        "companies",
         "softwareTerms",
         "python",
         "cpp"


### PR DESCRIPTION
# Description

Prevent British English words from being flagged as spelling errors.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Ran `SpellCheck` on each edk2 package before and after the change. Failing word count decreased by ~4.64%.

### Before

Failing word counts per package:

- ArmPkg: 8
- ArmPlatformPkg: 3
- ArmVirtPkg: 7
- EmbeddedPkg: 33
- EmulatorPkg: 94
- IntelFsp2Pkg: 16
- IntelFsp2WrapperPkg: 11
- ManageabilityPkg: 2
- MdeModulePkg: 337
- NetworkPkg: 116
- OvmfPkg: 259
- RedfishPkg: 83
- SecurityPkg: 326
- ShellPkg: 141
- UefiCpuPkg: 85
- UefiPayloadPkg: 132

**Total**: 1653

### After

Failing word counts per package:

- ArmPkg: 7
- ArmPlatformPkg: 3
- ArmVirtPkg: 7
- EmbeddedPkg: 32
- EmulatorPkg: 91
- IntelFsp2Pkg: 16
- IntelFsp2WrapperPkg: 11
- ManageabilityPkg: 2
- MdeModulePkg: 307
- NetworkPkg: 107
- OvmfPkg: 249
- RedfishPkg: 81
- SecurityPkg: 313
- ShellPkg: 139
- UefiCpuPkg: 84
- UefiPayloadPkg: 129

**Total**: 1578

## Integration Instructions

- N/A