### PR TITLE
DynamicTablesPkg/AmlLib: Support generating method that return a buffer or no return value

### DIFF
--- a/DynamicTablesPkg/Include/Library/AmlLib/AmlLib.h
+++ b/DynamicTablesPkg/Include/Library/AmlLib/AmlLib.h
@@ -1591,6 +1591,57 @@ AmlCodeGenMethodRetInteger (
   OUT       AML_OBJECT_NODE_HANDLE  *NewObjectNode        OPTIONAL
   );
 
+/** AML code generation for a method returning a Buffer.
+
+  AmlCodeGenMethodRetBuffer (
+    "_MAT", ReturnedBuffer, ReturnedBufferSize, 1, TRUE, 0, ParentNode, NewObjectNode
+    );
+  is equivalent of the following ASL code:
+    Method(_MAT, 1, Serialized, 0) {
+      Return (Buffer (ReturnedBufferSize) {...})
+    }
+
+  To return an empty buffer, call the function with
+  (ReturnedBuffer=NULL, ReturnedBufferSize=0).
+
+  @param [in]  MethodNameString     The new Method's name.
+                                    Must be a NULL-terminated ASL NameString
+                                    e.g.: "MET0", "_SB.MET0", etc.
+                                    The input string is copied.
+  @param [in]  ReturnedBuffer       The buffer returned by the method.
+                                    The input buffer is copied.
+                                    NULL if an empty buffer is returned.
+  @param [in]  ReturnedBufferSize   Size of ReturnedBuffer.
+                                    Must be 0 if ReturnedBuffer is NULL.
+  @param [in]  NumArgs              Number of arguments.
+                                    Must be 0 <= NumArgs <= 6.
+  @param [in]  IsSerialized         TRUE is equivalent to Serialized.
+                                    FALSE is equivalent to NotSerialized.
+                                    Default is NotSerialized in ASL spec.
+  @param [in]  SyncLevel            Synchronization level for the method.
+                                    Must be 0 <= SyncLevel <= 15.
+                                    Default is 0 in ASL.
+  @param [in]  ParentNode           If provided, set ParentNode as the parent
+                                    of the node created.
+  @param [out] NewObjectNode        If success, contains the created node.
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+AmlCodeGenMethodRetBuffer (
+  IN  CONST CHAR8                   *MethodNameString,
+  IN  CONST UINT8                   *ReturnedBuffer,
+  IN        UINT32                  ReturnedBufferSize,
+  IN        UINT8                   NumArgs,
+  IN        BOOLEAN                 IsSerialized,
+  IN        UINT8                   SyncLevel,
+  IN        AML_NODE_HANDLE         ParentNode           OPTIONAL,
+  OUT       AML_OBJECT_NODE_HANDLE  *NewObjectNode        OPTIONAL
+  );
+
 /** AML code generation for a method returning a NameString that takes an
     integer argument.
 

--- a/DynamicTablesPkg/Include/Library/AmlLib/AmlLib.h
+++ b/DynamicTablesPkg/Include/Library/AmlLib/AmlLib.h
@@ -1447,6 +1447,50 @@ AmlCodeGenScope (
   OUT       AML_OBJECT_NODE_HANDLE  *NewObjectNode   OPTIONAL
   );
 
+/** AML code generation for a Method object node.
+
+  AmlCodeGenMethod ("MET0", 1, TRUE, 3, ParentNode, NewObjectNode) is
+  equivalent of the following ASL code:
+    Method(MET0, 1, Serialized, 3) {}
+
+  ACPI 6.4, s20.2.5.2 "Named Objects Encoding":
+    DefMethod := MethodOp PkgLength NameString MethodFlags TermList
+    MethodOp := 0x14
+
+  The ASL parameters "ReturnType" and "ParameterTypes" are not asked
+  in this function. They are optional parameters in ASL.
+
+  @param [in]  NameString     The new Method's name.
+                              Must be a NULL-terminated ASL NameString
+                              e.g.: "MET0", "_SB.MET0", etc.
+                              The input string is copied.
+  @param [in]  NumArgs        Number of arguments.
+                              Must be 0 <= NumArgs <= 6.
+  @param [in]  IsSerialized   TRUE is equivalent to Serialized.
+                              FALSE is equivalent to NotSerialized.
+                              Default is NotSerialized in ASL spec.
+  @param [in]  SyncLevel      Synchronization level for the method.
+                              Must be 0 <= SyncLevel <= 15.
+                              Default is 0 in ASL.
+  @param [in]  ParentNode     If provided, set ParentNode as the parent
+                              of the node created.
+  @param [out] NewObjectNode  If success, contains the created node.
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+AmlCodeGenMethod (
+  IN  CONST CHAR8                   *NameString,
+  IN        UINT8                   NumArgs,
+  IN        BOOLEAN                 IsSerialized,
+  IN        UINT8                   SyncLevel,
+  IN        AML_NODE_HANDLE         ParentNode      OPTIONAL,
+  OUT       AML_OBJECT_NODE_HANDLE  *NewObjectNode   OPTIONAL
+  );
+
 /** AML code generation for a method returning a NameString.
 
   AmlCodeGenMethodRetNameString (

--- a/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlCodeGen.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlCodeGen.c
@@ -1568,16 +1568,15 @@ error_handler1:
   @retval EFI_INVALID_PARAMETER   Invalid parameter.
   @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
 **/
-STATIC
 EFI_STATUS
 EFIAPI
 AmlCodeGenMethod (
-  IN  CONST CHAR8            *NameString,
-  IN        UINT8            NumArgs,
-  IN        BOOLEAN          IsSerialized,
-  IN        UINT8            SyncLevel,
-  IN        AML_NODE_HEADER  *ParentNode      OPTIONAL,
-  OUT       AML_OBJECT_NODE  **NewObjectNode   OPTIONAL
+  IN  CONST CHAR8                   *NameString,
+  IN        UINT8                   NumArgs,
+  IN        BOOLEAN                 IsSerialized,
+  IN        UINT8                   SyncLevel,
+  IN        AML_NODE_HANDLE         ParentNode      OPTIONAL,
+  OUT       AML_OBJECT_NODE_HANDLE  *NewObjectNode   OPTIONAL
   )
 {
   EFI_STATUS       Status;

--- a/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlCodeGen.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlCodeGen.c
@@ -2414,6 +2414,120 @@ error_handler:
   return Status;
 }
 
+/** AML code generation for a method returning a Buffer.
+
+  AmlCodeGenMethodRetBuffer (
+    "_MAT", ReturnedBuffer, ReturnedBufferSize, 1, TRUE, 0, ParentNode, NewObjectNode
+    );
+  is equivalent of the following ASL code:
+    Method(_MAT, 1, Serialized, 0) {
+      Return (Buffer (ReturnedBufferSize) {...})
+    }
+
+  To return an empty buffer, call the function with
+  (ReturnedBuffer=NULL, ReturnedBufferSize=0).
+
+  @param [in]  MethodNameString     The new Method's name.
+                                    Must be a NULL-terminated ASL NameString
+                                    e.g.: "MET0", "_SB.MET0", etc.
+                                    The input string is copied.
+  @param [in]  ReturnedBuffer       The buffer returned by the method.
+                                    The input buffer is copied.
+                                    NULL if an empty buffer is returned.
+  @param [in]  ReturnedBufferSize   Size of ReturnedBuffer.
+                                    Must be 0 if ReturnedBuffer is NULL.
+  @param [in]  NumArgs              Number of arguments.
+                                    Must be 0 <= NumArgs <= 6.
+  @param [in]  IsSerialized         TRUE is equivalent to Serialized.
+                                    FALSE is equivalent to NotSerialized.
+                                    Default is NotSerialized in ASL spec.
+  @param [in]  SyncLevel            Synchronization level for the method.
+                                    Must be 0 <= SyncLevel <= 15.
+                                    Default is 0 in ASL.
+  @param [in]  ParentNode           If provided, set ParentNode as the parent
+                                    of the node created.
+  @param [out] NewObjectNode        If success, contains the created node.
+
+  @retval EFI_SUCCESS             Success.
+  @retval EFI_INVALID_PARAMETER   Invalid parameter.
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory.
+**/
+EFI_STATUS
+EFIAPI
+AmlCodeGenMethodRetBuffer (
+  IN  CONST CHAR8                   *MethodNameString,
+  IN  CONST UINT8                   *ReturnedBuffer,
+  IN        UINT32                  ReturnedBufferSize,
+  IN        UINT8                   NumArgs,
+  IN        BOOLEAN                 IsSerialized,
+  IN        UINT8                   SyncLevel,
+  IN        AML_NODE_HANDLE         ParentNode      OPTIONAL,
+  OUT       AML_OBJECT_NODE_HANDLE  *NewObjectNode  OPTIONAL
+  )
+{
+  EFI_STATUS              Status;
+  AML_OBJECT_NODE_HANDLE  MethodNode;
+  AML_OBJECT_NODE_HANDLE  BufferNode;
+
+  if ((MethodNameString == NULL)                         ||
+      ((ParentNode == NULL) && (NewObjectNode == NULL)) ||
+      ((ReturnedBuffer == NULL) != (ReturnedBufferSize == 0)))
+  {
+    ASSERT (0);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Create a Method named MethodNameString.
+  Status = AmlCodeGenMethod (
+             MethodNameString,
+             NumArgs,
+             IsSerialized,
+             SyncLevel,
+             NULL,
+             &MethodNode
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    return Status;
+  }
+
+  Status = AmlCodeGenBuffer (ReturnedBuffer, ReturnedBufferSize, &BufferNode);
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    goto error_handler;
+  }
+
+  // AmlCodeGenReturn() deletes BufferNode if an error occurs.
+  Status = AmlCodeGenReturn (
+             (AML_NODE_HEADER *)BufferNode,
+             (AML_NODE_HEADER *)MethodNode,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    goto error_handler;
+  }
+
+  Status = LinkNode (
+             MethodNode,
+             ParentNode,
+             NewObjectNode
+             );
+  if (EFI_ERROR (Status)) {
+    ASSERT (0);
+    goto error_handler;
+  }
+
+  return Status;
+
+error_handler:
+  if (MethodNode != NULL) {
+    AmlDeleteTree ((AML_NODE_HANDLE)MethodNode);
+  }
+
+  return Status;
+}
+
 /** Create a _LPI name.
 
   AmlCreateLpiNode ("_LPI", 0, 1, ParentNode, &LpiNode) is

--- a/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c
+++ b/DynamicTablesPkg/Library/Common/AmlLib/CodeGen/AmlResourceDataCodeGen.c
@@ -1266,7 +1266,8 @@ AmlCodeGenRdInterrupt (
   EFI_STATUS  Status;
 
   AML_DATA_NODE                           *RdNode;
-  EFI_ACPI_EXTENDED_INTERRUPT_DESCRIPTOR  RdInterrupt;
+  EFI_ACPI_EXTENDED_INTERRUPT_DESCRIPTOR  *RdInterrupt;
+  UINT16                                  RdInterruptSize;
   UINT32                                  *FirstInterrupt;
 
   if ((IrqList == NULL) ||
@@ -1277,32 +1278,40 @@ AmlCodeGenRdInterrupt (
     return EFI_INVALID_PARAMETER;
   }
 
+  // EFI_ACPI_EXTENDED_INTERRUPT_DESCRIPTOR already includes the first interrupt
+  RdInterruptSize = sizeof (EFI_ACPI_EXTENDED_INTERRUPT_DESCRIPTOR) + (IrqCount - 1) * sizeof (UINT32);
+  RdInterrupt     = (EFI_ACPI_EXTENDED_INTERRUPT_DESCRIPTOR *)AllocateZeroPool (RdInterruptSize);
+  if (RdInterrupt == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   // Header
-  RdInterrupt.Header.Header.Bits.Name =
+  RdInterrupt->Header.Header.Bits.Name =
     ACPI_LARGE_EXTENDED_IRQ_DESCRIPTOR_NAME;
-  RdInterrupt.Header.Header.Bits.Type = ACPI_LARGE_ITEM_FLAG;
-  RdInterrupt.Header.Length           = sizeof (EFI_ACPI_EXTENDED_INTERRUPT_DESCRIPTOR) -
-                                        sizeof (ACPI_LARGE_RESOURCE_HEADER);
+  RdInterrupt->Header.Header.Bits.Type = ACPI_LARGE_ITEM_FLAG;
+  RdInterrupt->Header.Length           = RdInterruptSize - sizeof (ACPI_LARGE_RESOURCE_HEADER);
 
   // Body
-  RdInterrupt.InterruptVectorFlags = (ResourceConsumer ? BIT0 : 0) |
-                                     (EdgeTriggered ? BIT1 : 0)    |
-                                     (ActiveLow ? BIT2 : 0)        |
-                                     (Shared ? BIT3 : 0);
-  RdInterrupt.InterruptTableLength = IrqCount;
+  RdInterrupt->InterruptVectorFlags = (ResourceConsumer ? BIT0 : 0) |
+                                      (EdgeTriggered ? BIT1 : 0)    |
+                                      (ActiveLow ? BIT2 : 0)        |
+                                      (Shared ? BIT3 : 0);
+  RdInterrupt->InterruptTableLength = IrqCount;
 
   // Get the address of the first interrupt field.
-  FirstInterrupt = RdInterrupt.InterruptNumber;
+  FirstInterrupt = RdInterrupt->InterruptNumber;
 
   // Copy the list of interrupts.
   CopyMem (FirstInterrupt, IrqList, (sizeof (UINT32) * IrqCount));
 
   Status = AmlCreateDataNode (
              EAmlNodeDataTypeResourceData,
-             (UINT8 *)&RdInterrupt,
-             sizeof (EFI_ACPI_EXTENDED_INTERRUPT_DESCRIPTOR),
+             (UINT8 *)RdInterrupt,
+             RdInterruptSize,
              &RdNode
              );
+  FreePool (RdInterrupt);
   if (EFI_ERROR (Status)) {
     ASSERT (0);
     return Status;


### PR DESCRIPTION
# Description

In order to support generating _SRS and _MAT methods, two new APIs were added: AmlCodeGenMethod and AmlCodeGenMethodRetBuffer.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Tested that _SRS and _MAT methods created correctly.

## Integration Instructions

N/A
