### PR TITLE
MdeModulePkg/ImagePropertiesRecordLib: Fix incorrect use of sizeof

### DIFF
--- a/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.c
+++ b/MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.c
@@ -864,7 +864,7 @@ GetFilename (
     }
   }
 
-  if (Index == sizeof (EfiFileName) - 4) {
+  if (Index == EfiFileNameSize - 4) {
     EfiFileName[Index] = 0;
   }
 }


### PR DESCRIPTION
# Description

In GetFilename(), the post-loop fallback termination used sizeof (EfiFileName), which is the size of the CHAR8 * pointer parameter (8 bytes on X64), not the buffer size. Use EfiFileNameSize - 4 to match the bound of the copy loop above so the string is terminated at the true end of the buffer.


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Tested on OvmfPkgIa32X64, DEBUG, GCC: DumpImageRecords() prints all runtime image names correctly and NUL-terminated, with no ASSERTs.

## Integration Instructions

N/A