### PR TITLE
RedfishPkg/RedfishHttpDxe: handle oversize HTTP content gracefully

### DIFF
--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
@@ -1,7 +1,7 @@
 /** @file
   RedfishHttpOperation handles HTTP operations.
 
-  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -372,7 +372,10 @@ BuildRequestMessage (
     }
 
     if (Request->ContentLength == 0) {
-      Request->ContentLength =  AsciiStrLen (Request->Content);
+      //
+      // Use AsciiStrnLenS to get the length of the content string safely. And it won't trigger assertion when the content is oversize.
+      //
+      Request->ContentLength =  AsciiStrnLenS (Request->Content, REDFISH_HTTP_CONTENT_LENGTH_MAXIMUM);
     }
 
     AsciiSPrint (

--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.h
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.h
@@ -1,7 +1,7 @@
 /** @file
   Definitions of RedfishHttpOperation
 
-  Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -19,6 +19,7 @@
 #define REDFISH_HTTP_HEADER_CONNECTION_STR       "Connection"
 #define REDFISH_HTTP_HEADER_CONNECTION_VALUE     "Keep-Alive"
 #define REDFISH_HTTP_CONTENT_ENCODING_NONE       "None"
+#define REDFISH_HTTP_CONTENT_LENGTH_MAXIMUM      0xA00000  // 10MB in bytes is 0xA00000 in hex
 #define ASCII_STR_DUPLICATE(a)  (AllocateCopyPool (AsciiStrSize ((a)), (a)))
 
 /**


### PR DESCRIPTION
# Description

AsciiStrLne throw assert when HTTP content length is more than PcdMaximumAsciiStringLength. Use AsciiStrnLenS to handle the oversize HTTP content gracefully, so Redfish driver can do error handling.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Tested on Arm base server system.

## Integration Instructions

N/A
