### PR TITLE
MdeModulePkg/PciHostBridgeDxe: Support minimum secondary bus number

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -1325,6 +1325,7 @@ StartBusEnumeration (
   PCI_ROOT_BRIDGE_INSTANCE           *RootBridge;
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR  *Descriptor;
   EFI_ACPI_END_TAG_DESCRIPTOR        *End;
+  UINTN                              DescriptorCount;
 
   if (Configuration == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -1338,7 +1339,21 @@ StartBusEnumeration (
   {
     RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
     if (RootBridgeHandle == RootBridge->Handle) {
-      *Configuration = AllocatePool (sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) + sizeof (EFI_ACPI_END_TAG_DESCRIPTOR));
+      //
+      // Keep the root bus as the enumeration entry in the first descriptor.
+      // The optional second descriptor only raises the lower bound for
+      // downstream bus number allocation. Skipped bus numbers remain within
+      // the root bridge configuration space aperture.
+      //
+      DescriptorCount = 1;
+      if (RootBridge->MinSecondaryBusNumber > RootBridge->Bus.Base + 1) {
+        DescriptorCount = 2;
+      }
+
+      *Configuration = AllocateZeroPool (
+                         DescriptorCount * sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) +
+                         sizeof (EFI_ACPI_END_TAG_DESCRIPTOR)
+                         );
       if (*Configuration == NULL) {
         return EFI_OUT_OF_RESOURCES;
       }
@@ -1354,6 +1369,21 @@ StartBusEnumeration (
       Descriptor->AddrRangeMax          = 0;
       Descriptor->AddrTranslationOffset = 0;
       Descriptor->AddrLen               = RootBridge->Bus.Limit - RootBridge->Bus.Base + 1;
+
+      if (DescriptorCount == 2) {
+        Descriptor->AddrLen = 1;
+        Descriptor++;
+        Descriptor->Desc                  = ACPI_ADDRESS_SPACE_DESCRIPTOR;
+        Descriptor->Len                   = sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) - 3;
+        Descriptor->ResType               = ACPI_ADDRESS_SPACE_TYPE_BUS;
+        Descriptor->GenFlag               = 0;
+        Descriptor->SpecificFlag          = 0;
+        Descriptor->AddrSpaceGranularity  = 0;
+        Descriptor->AddrRangeMin          = RootBridge->MinSecondaryBusNumber;
+        Descriptor->AddrRangeMax          = 0;
+        Descriptor->AddrTranslationOffset = 0;
+        Descriptor->AddrLen               = RootBridge->Bus.Limit - RootBridge->MinSecondaryBusNumber + 1;
+      }
 
       End           = (EFI_ACPI_END_TAG_DESCRIPTOR *)(Descriptor + 1);
       End->Desc     = ACPI_END_TAG_DESCRIPTOR;
@@ -1391,23 +1421,12 @@ SetBusNumbers (
   PCI_HOST_BRIDGE_INSTANCE           *HostBridge;
   PCI_ROOT_BRIDGE_INSTANCE           *RootBridge;
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR  *Descriptor;
+  EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR  *NextDescriptor;
   EFI_ACPI_END_TAG_DESCRIPTOR        *End;
+  UINT64                             AllocatedBusBase;
+  UINT64                             LastBusNumber;
 
   if (Configuration == NULL) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)Configuration;
-  End        = (EFI_ACPI_END_TAG_DESCRIPTOR *)(Descriptor + 1);
-
-  //
-  // Check the Configuration is valid
-  //
-  if ((Descriptor->Desc != ACPI_ADDRESS_SPACE_DESCRIPTOR) ||
-      (Descriptor->ResType != ACPI_ADDRESS_SPACE_TYPE_BUS) ||
-      (End->Desc != ACPI_END_TAG_DESCRIPTOR)
-      )
-  {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -1419,22 +1438,58 @@ SetBusNumbers (
   {
     RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
     if (RootBridgeHandle == RootBridge->Handle) {
-      if (Descriptor->AddrLen == 0) {
-        return EFI_INVALID_PARAMETER;
-      }
-
-      if ((Descriptor->AddrRangeMin < RootBridge->Bus.Base) ||
-          (Descriptor->AddrRangeMin + Descriptor->AddrLen - 1 > RootBridge->Bus.Limit)
-          )
+      Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)Configuration;
+      if ((Descriptor->Desc != ACPI_ADDRESS_SPACE_DESCRIPTOR) ||
+          (Descriptor->ResType != ACPI_ADDRESS_SPACE_TYPE_BUS) ||
+          (Descriptor->AddrLen == 0) ||
+          (Descriptor->AddrRangeMin < RootBridge->Bus.Base) ||
+          (Descriptor->AddrRangeMin > RootBridge->Bus.Limit) ||
+          (Descriptor->AddrLen > RootBridge->Bus.Limit - Descriptor->AddrRangeMin + 1))
       {
         return EFI_INVALID_PARAMETER;
       }
 
+      AllocatedBusBase = Descriptor->AddrRangeMin;
+      LastBusNumber    = Descriptor->AddrRangeMin + Descriptor->AddrLen - 1;
+      NextDescriptor   = Descriptor + 1;
+      if (NextDescriptor->Desc == ACPI_ADDRESS_SPACE_DESCRIPTOR) {
+        if ((RootBridge->MinSecondaryBusNumber <= RootBridge->Bus.Base + 1) ||
+            (Descriptor->AddrRangeMin != RootBridge->Bus.Base) ||
+            (Descriptor->AddrLen != 1) ||
+            (NextDescriptor->ResType != ACPI_ADDRESS_SPACE_TYPE_BUS) ||
+            (NextDescriptor->AddrRangeMin != RootBridge->MinSecondaryBusNumber) ||
+            (NextDescriptor->AddrLen == 0) ||
+            (NextDescriptor->AddrLen > RootBridge->Bus.Limit - NextDescriptor->AddrRangeMin + 1))
+        {
+          return EFI_INVALID_PARAMETER;
+        }
+
+        AllocatedBusBase = RootBridge->Bus.Base;
+        LastBusNumber    = NextDescriptor->AddrRangeMin + NextDescriptor->AddrLen - 1;
+        End              = (EFI_ACPI_END_TAG_DESCRIPTOR *)(NextDescriptor + 1);
+      } else {
+        End = (EFI_ACPI_END_TAG_DESCRIPTOR *)NextDescriptor;
+        if ((RootBridge->MinSecondaryBusNumber > RootBridge->Bus.Base + 1) &&
+            ((Descriptor->AddrRangeMin != RootBridge->Bus.Base) || (Descriptor->AddrLen != 1)))
+        {
+          return EFI_INVALID_PARAMETER;
+        }
+
+        if (RootBridge->MinSecondaryBusNumber > RootBridge->Bus.Base + 1) {
+          AllocatedBusBase = RootBridge->Bus.Base;
+        }
+      }
+
+      if (End->Desc != ACPI_END_TAG_DESCRIPTOR) {
+        return EFI_INVALID_PARAMETER;
+      }
+
       //
-      // Update the Bus Range
+      // The skipped bus numbers remain part of the root bridge decode aperture,
+      // but are not assigned to PCI bridges.
       //
-      RootBridge->ResAllocNode[TypeBus].Base   = Descriptor->AddrRangeMin;
-      RootBridge->ResAllocNode[TypeBus].Length = Descriptor->AddrLen;
+      RootBridge->ResAllocNode[TypeBus].Base   = AllocatedBusBase;
+      RootBridge->ResAllocNode[TypeBus].Length = LastBusNumber - AllocatedBusBase + 1;
       RootBridge->ResAllocNode[TypeBus].Status = ResAllocated;
       return EFI_SUCCESS;
     }

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridge.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridge.h
@@ -59,6 +59,7 @@ typedef struct {
   UINT64                             Supports;
   PCI_RES_NODE                       ResAllocNode[TypeMax];
   PCI_ROOT_BRIDGE_APERTURE           Bus;
+  UINT8                              MinSecondaryBusNumber;
   PCI_ROOT_BRIDGE_APERTURE           Io;
   PCI_ROOT_BRIDGE_APERTURE           Mem;
   PCI_ROOT_BRIDGE_APERTURE           PMem;

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -90,11 +90,20 @@ CreateRootBridge (
     Bridge->Bus.Limit,
     Bridge->Bus.Translation
     ));
+  DEBUG ((DEBUG_INFO, "      MinSecBus: %x\n", Bridge->MinSecondaryBusNumber));
   //
   // Translation for bus is not supported.
   //
   ASSERT (Bridge->Bus.Translation == 0);
   if (Bridge->Bus.Translation != 0) {
+    return NULL;
+  }
+
+  //
+  // The minimum secondary bus number must not exceed the bus aperture.
+  // Values at or below Bus.Base + 1 keep the default allocation behavior.
+  //
+  if (Bridge->MinSecondaryBusNumber > Bridge->Bus.Limit) {
     return NULL;
   }
 
@@ -204,6 +213,7 @@ CreateRootBridge (
   RootBridge->DmaAbove4G            = Bridge->DmaAbove4G;
   RootBridge->NoExtendedConfigSpace = Bridge->NoExtendedConfigSpace;
   RootBridge->AllocationAttributes  = Bridge->AllocationAttributes;
+  RootBridge->MinSecondaryBusNumber = Bridge->MinSecondaryBusNumber;
   RootBridge->DevicePath            = DuplicateDevicePath (Bridge->DevicePath);
   RootBridge->DevicePathStr         = DevicePathStr;
   RootBridge->ConfigBuffer          = AllocatePool (

--- a/MdeModulePkg/Include/Library/PciHostBridgeLib.h
+++ b/MdeModulePkg/Include/Library/PciHostBridgeLib.h
@@ -63,6 +63,12 @@ typedef struct {
   PCI_ROOT_BRIDGE_APERTURE    PMem;                  ///< Prefetchable MMIO aperture below 4GB which can be used by the root bridge.
   PCI_ROOT_BRIDGE_APERTURE    PMemAbove4G;           ///< Prefetchable MMIO aperture above 4GB which can be used by the root bridge.
   EFI_DEVICE_PATH_PROTOCOL    *DevicePath;           ///< Device path.
+  //
+  // Minimum bus number that may be assigned to a PCI bridge below the root
+  // bus. Values less than or equal to Bus.Base + 1 preserve the default
+  // consecutive bus number allocation.
+  //
+  UINT8                       MinSecondaryBusNumber;
 } PCI_ROOT_BRIDGE;
 
 /**


### PR DESCRIPTION
# Description

Some multi-root systems attach one PCIe switch hierarchy to each PCI
segment and interconnect the switches as a shared fabric. Firmware models
each host-facing interface as a separate root bridge whose root bus is 00:

```text
  RC0 / RB0     RC1 / RB1     RC2 / RB2     RC3 / RB3
  Seg 0:00      Seg 1:00      Seg 2:00      Seg 3:00
      |             |             |             |
   +--+--+       +--+--+       +--+--+       +--+--+
   | SW0 |=======| SW1 |=======| SW2 |=======| SW3 |
   +--+--+       +--+--+       +--+--+       +--+--+
      |             |             |             |
   01-3F         40-7F         80-BF         C0-FF
```

Here RC means the hardware Root Complex, and RB means the firmware Root
Bridge. The shared fabric can route peer-to-peer traffic between downstream
devices without traversing a Root Complex data path. PCIe Requester IDs
contain the bus, device, and function numbers, but not the software segment
number. Downstream bus ranges in the shared fabric must therefore not
overlap.

`Bus.Limit` already provides the upper bound of each root bridge bus aperture.
PciHostBridgeDxe, however, always starts secondary bus allocation at
`Bus.Base + 1`. It cannot keep every root bus at 00 while selecting the lower
bound of each downstream range.

Add `MinSecondaryBusNumber` to `PCI_ROOT_BRIDGE`. The first secondary bus is
allocated from the greater of `Bus.Base + 1` and `MinSecondaryBusNumber`, so
zero-initialized platforms keep the existing behavior.

When a higher lower bound is requested, keep the root bus in the first bus
resource descriptor and use a second descriptor for the downstream
allocation window. All sibling and nested bridges under the root bridge
continue to share the normal increasing bus number allocator. Bus numbers
between the root bus and the lower bound are skipped during allocation, but
remain within the root bridge configuration space aperture.

This change does not configure the switch fabric or implement peer-to-peer
routing. It only lets platform firmware allocate the non-overlapping
downstream bus ranges required by such a topology.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Configured `MinSecondaryBusNumber` for each PCI root bridge and verified
  with the UEFI Shell `pci` command that the enumerated bus topology was
  consistent with the expected layout.

## Integration Instructions

Platforms that require a non-default downstream bus number window should set
`MinSecondaryBusNumber` for each `PCI_ROOT_BRIDGE` and use `Bus.Limit` as the
upper bound of that root bridge's allocation window. A zero value, or any
value at or below `Bus.Base + 1`, preserves the existing allocation behavior.
