### PR TITLE
UefiPayloadPkg: Set bootmode from bootloader

### DIFF
--- a/UefiPayloadPkg/Include/Coreboot.h
+++ b/UefiPayloadPkg/Include/Coreboot.h
@@ -302,4 +302,31 @@ struct cb_range {
 
 typedef struct cb_memory CB_MEMORY;
 
+#define CB_TAG_BOOT_MODE  0x00cd
+
+enum cb_boot_mode {
+  /* Regular boot scenarios */
+  LB_BOOT_MODE_NORMAL,
+  /* Device is booting in low-batter w/o charger attached */
+  LB_BOOT_MODE_LOW_BATTERY,
+  /* Device is booting in low-batter w/ charger attached */
+  LB_BOOT_MODE_LOW_BATTERY_CHARGING,
+  /* Device is booting in due to charger insertion */
+  LB_BOOT_MODE_OFFMODE_CHARGING,
+  /* Device is booting in due to RTC alarm */
+  LB_BOOT_MODE_RTC_WAKE,
+  /* Device is booting in "no-battery" */
+  LB_BOOT_MODE_NO_BATTERY,
+  /* Device is booting with flash unlocked. */
+  LB_BOOT_MODE_FLASH_UPDATE,
+};
+
+/*
+ * Boot Mode: Passed the platform boot mode information to payload.
+ */
+struct lb_boot_mode {
+  UINT32            tag;
+  UINT32            size;
+  enum cb_boot_mode boot_mode;
+} __attribute__((packed));
 #endif // _COREBOOT_PEI_H_INCLUDED_

--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -81,6 +81,21 @@ ParseSmbiosTable (
   );
 
 /**
+  Parse the boot mode from the coreboot table in memory.
+
+  @param  Mode              Pointer to the boot mode variable
+
+  @retval RETURN_SUCCESS     Successfully find out the memory information.
+  @retval RETURN_NOT_FOUND   Failed to find the memory information.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseBootMode (
+  OUT EFI_BOOT_MODE  *Mode
+  );
+
+/**
   Acquire ACPI table from bootloader.
 
   @param  AcpiTableHob              Pointer to the ACPI table info.

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -409,6 +409,47 @@ ParseMemoryInfo (
 }
 
 /**
+  Parse the boot mode from the coreboot table in memory.
+
+  @param  Mode              Pointer to the boot mode variable
+
+  @retval RETURN_SUCCESS     Successfully find out the memory information.
+  @retval RETURN_NOT_FOUND   Failed to find the memory information.
+
+**/
+RETURN_STATUS
+EFIAPI
+ParseBootMode (
+  OUT EFI_BOOT_MODE  *Mode
+  )
+{
+  struct lb_boot_mode  *boot_mode;
+
+  //
+  // Get the coreboot memory table
+  //
+  boot_mode = (struct lb_boot_mode *)FindCbTag (CB_TAG_BOOT_MODE);
+  if (boot_mode == NULL) {
+    return RETURN_NOT_FOUND;
+  }
+
+  switch (boot_mode->boot_mode) {
+    case LB_BOOT_MODE_NORMAL:
+      *Mode = BOOT_WITH_FULL_CONFIGURATION;
+      break;
+
+    case LB_BOOT_MODE_FLASH_UPDATE:
+      *Mode = BOOT_ON_FLASH_UPDATE;
+      break;
+
+    default:
+      return RETURN_UNSUPPORTED;
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
   Acquire SMBIOS table from coreboot.
 
   @param  SmbiosTable               Pointer to the SMBIOS table info.

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -335,7 +335,7 @@ MemInfoCallback (
 **/
 EFI_STATUS
 BuildHobFromBl (
-  VOID
+  IN OUT EFI_HOB_HANDOFF_INFO_TABLE  *HobInfo
   )
 {
   EFI_STATUS                        Status;
@@ -350,6 +350,7 @@ BuildHobFromBl (
   EFI_PEI_GRAPHICS_DEVICE_INFO_HOB  *NewGfxDeviceInfo;
   UNIVERSAL_PAYLOAD_SMBIOS_TABLE    *SmBiosTableHob;
   UNIVERSAL_PAYLOAD_ACPI_TABLE      *AcpiTableHob;
+  EFI_BOOT_MODE                     BootMode;
 
   //
   // First find TOLUD
@@ -410,6 +411,15 @@ BuildHobFromBl (
     ASSERT (NewFirmwareInfo != NULL);
     CopyMem (NewFirmwareInfo, &FirmwareInfo, sizeof (FirmwareInfo));
     DEBUG ((DEBUG_INFO, "Created firmware info hob\n"));
+  }
+
+  //
+  // Get boot mode from bootloader and set it in HOB
+  //
+  Status = ParseBootMode (&BootMode);
+  if (!EFI_ERROR (Status)) {
+    HobInfo->BootMode = BootMode;
+    DEBUG ((DEBUG_INFO, "BootMode from payload: %x\n", BootMode));
   }
 
   //
@@ -590,7 +600,7 @@ _ModuleEntryPoint (
   DEBUG ((DEBUG_INFO, "HobMemBase    = 0x%llx\n", (UINT64)HobMemBase));
 
   // Build HOB based on information from Bootloader
-  Status = BuildHobFromBl ();
+  Status = BuildHobFromBl (HobInfo);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "BuildHobFromBl Status = %r\n", Status));
     return Status;


### PR DESCRIPTION
The coreboot bootloader always passes information about the boot mode since commit [1]. Use the new coreboot table when present to update the bootmode. When the table is not present or contains unknown values the bootmode is not updated.

This allows to support UEFI capsule updates that need the whole SPI flash to be unlocked. Since this is also a security concern the payload should never follow the regular boot flow, but reboot the system when done.

1: https://review.coreboot.org/c/coreboot/+/94094/

TEST=Can update the system using UEFI capsule on disk. coreboot detects the
     capsule and unlocks the SPI flash, sets the boot mode to
     LB_BOOT_MODE_FLASH_UPDATE and UefiPayload updates BootMode in the HOB
     handoff table allowing the capsule update code to run.

# Description
- [ ] Breaking change?
- [x] Impacts security?
  - Enforces flash update and reboot when SPI flash was left unlocked by bootloader.
- [ ] Includes tests?

## How This Was Tested

Can update the system using UEFI capsule on disk. coreboot detects the capsule and unlocks the SPI flash, sets the boot mode to LB_BOOT_MODE_FLASH_UPDATE and UefiPayload updates BootMode in the HOB handoff table allowing the capsule update code to run.

## Integration Instructions

N/A
