### PR TITLE
VirtioInputDxe: implement key notifications

### DIFF
--- a/OvmfPkg/VirtioInputDxe/VirtioInput.h
+++ b/OvmfPkg/VirtioInputDxe/VirtioInput.h
@@ -115,7 +115,8 @@ typedef struct {
           CR (a, VIRTIO_INPUT_DEV, AbsolutePointer, VIRTIO_INPUT_SIG)
 
 // Bellow candidates to be included as Linux header
-#define KEY_PRESSED  1
+#define KEY_RELEASED  0
+#define KEY_PRESSED   1
 
 //
 // VirtioInput.c

--- a/OvmfPkg/VirtioInputDxe/VirtioInput.h
+++ b/OvmfPkg/VirtioInputDxe/VirtioInput.h
@@ -18,6 +18,9 @@
 #include <Protocol/SimpleTextInEx.h>
 
 #include <IndustryStandard/Virtio.h>
+#include <IndustryStandard/VirtioInput.h>
+
+#include <Library/VirtioLib.h>
 
 #include "VirtioKeyCodes.h"
 

--- a/OvmfPkg/VirtioInputDxe/VirtioInput.h
+++ b/OvmfPkg/VirtioInputDxe/VirtioInput.h
@@ -95,6 +95,9 @@ typedef struct {
   BOOLEAN                              KeyActive[MAX_KEYBOARD_CODE + 1]; // Key modifiers
   EFI_KEY_QUEUE                        KeyQueue;
 
+  BOOLEAN                              CapsLock;
+  BOOLEAN                              NumLock;
+  BOOLEAN                              ScrollLock;
   BOOLEAN                              SupportPartialKeys;
 
   // Mouse implementation

--- a/OvmfPkg/VirtioInputDxe/VirtioInput.h
+++ b/OvmfPkg/VirtioInputDxe/VirtioInput.h
@@ -17,7 +17,10 @@
 #include <Protocol/SimpleTextIn.h>
 #include <Protocol/SimpleTextInEx.h>
 
+#include <Library/VirtioLib.h>
+
 #include <IndustryStandard/Virtio.h>
+#include <IndustryStandard/VirtioInput.h>
 
 #include "VirtioKeyCodes.h"
 

--- a/OvmfPkg/VirtioInputDxe/VirtioInput.h
+++ b/OvmfPkg/VirtioInputDxe/VirtioInput.h
@@ -84,10 +84,12 @@ typedef struct {
   BOOLEAN                              HasKeyboard;
   EFI_SIMPLE_TEXT_INPUT_PROTOCOL       Txt;
   EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL    TxtEx;
-  EFI_INPUT_KEY                        LastKey;
+  EFI_KEY_DATA                         LastKeyData;
   LIST_ENTRY                           KeyNotifyList;
   BOOLEAN                              KeyActive[MAX_KEYBOARD_CODE + 1]; // Key modifiers
   BOOLEAN                              KeyReady;
+
+  BOOLEAN                              SupportPartialKeys;
 
   // Mouse implementation
   BOOLEAN                              HasMouse;

--- a/OvmfPkg/VirtioInputDxe/VirtioInput.h
+++ b/OvmfPkg/VirtioInputDxe/VirtioInput.h
@@ -38,6 +38,13 @@
 // Key code 0x100 ~ 0x15f range is for all kinds of button events.
 #define IS_BUTTON_CODE(Code)  (((Code) >= BTN_MISC) && ((Code) < KEY_OK))
 
+#define KEYBOARD_EFI_KEY_MAX_COUNT  256
+typedef struct {
+  EFI_KEY_DATA    Buffer[KEYBOARD_EFI_KEY_MAX_COUNT];
+  UINTN           Head;
+  UINTN           Tail;
+} EFI_KEY_QUEUE;
+
 typedef struct {
   UINTN                      Signature;
   EFI_KEY_DATA               KeyData;
@@ -84,10 +91,9 @@ typedef struct {
   BOOLEAN                              HasKeyboard;
   EFI_SIMPLE_TEXT_INPUT_PROTOCOL       Txt;
   EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL    TxtEx;
-  EFI_KEY_DATA                         LastKeyData;
   LIST_ENTRY                           KeyNotifyList;
   BOOLEAN                              KeyActive[MAX_KEYBOARD_CODE + 1]; // Key modifiers
-  BOOLEAN                              KeyReady;
+  EFI_KEY_QUEUE                        KeyQueue;
 
   BOOLEAN                              SupportPartialKeys;
 

--- a/OvmfPkg/VirtioInputDxe/VirtioInput.h
+++ b/OvmfPkg/VirtioInputDxe/VirtioInput.h
@@ -92,8 +92,10 @@ typedef struct {
   EFI_SIMPLE_TEXT_INPUT_PROTOCOL       Txt;
   EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL    TxtEx;
   LIST_ENTRY                           KeyNotifyList;
+  EFI_EVENT                            KeyNotifyProcessEvent;
   BOOLEAN                              KeyActive[MAX_KEYBOARD_CODE + 1]; // Key modifiers
   EFI_KEY_QUEUE                        KeyQueue;
+  EFI_KEY_QUEUE                        KeyQueueForNotify;
 
   BOOLEAN                              CapsLock;
   BOOLEAN                              NumLock;
@@ -169,6 +171,13 @@ VirtioKeyboardInit (
 VOID
 VirtioKeyboardUninit (
   IN OUT VIRTIO_INPUT_DEV  *Dev
+  );
+
+VOID
+EFIAPI
+VirtioKeyboardNotifyHandler (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
   );
 
 //

--- a/OvmfPkg/VirtioInputDxe/VirtioInput.inf
+++ b/OvmfPkg/VirtioInputDxe/VirtioInput.inf
@@ -32,6 +32,7 @@
   DebugLib
   MemoryAllocationLib
   UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
   UefiDriverEntryPoint
   UefiLib
   VirtioLib

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -447,8 +447,22 @@ VirtioKeyboardReadKeyStroke (
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
-  Status = PopEfikeyBufHead (&Dev->KeyQueue, &KeyData);
-  *Key   = KeyData.Key;
+  //
+  // ReadKeyStroke of SIMPLE_TEXT_INPUT must omit partial keystrokes
+  //
+  while (TRUE) {
+    Status = PopEfikeyBufHead (&Dev->KeyQueue, &KeyData);
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    if ((KeyData.Key.ScanCode == SCAN_NULL) && (KeyData.Key.UnicodeChar == CHAR_NULL)) {
+      continue;
+    }
+
+    *Key = KeyData.Key;
+    break;
+  }
 
   gBS->RestoreTPL (OldTpl);
 
@@ -467,6 +481,8 @@ VirtioKeyboardWaitForKey (
 {
   VIRTIO_INPUT_DEV  *Dev = (VIRTIO_INPUT_DEV *)Context;
   EFI_TPL           OldTpl;
+  EFI_KEY_DATA      KeyData;
+  EFI_STATUS        Status;
 
   //
   // Stall 1ms to give a chance to let other driver interrupt this routine
@@ -485,9 +501,23 @@ VirtioKeyboardWaitForKey (
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
+  //
   // If there is a new key ready - send signal
-  if (!IsEfikeyBufEmpty (&Dev->KeyQueue)) {
+  // WaitForKey(Ex) must omit partial keystrokes
+  //
+  while (TRUE) {
+    Status = PeekEfikeyBufHead (&Dev->KeyQueue, &KeyData);
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    if ((KeyData.Key.ScanCode == SCAN_NULL) && (KeyData.Key.UnicodeChar == CHAR_NULL)) {
+      (void)PopEfikeyBufHead (&Dev->KeyQueue, NULL);
+      continue;
+    }
+
     gBS->SignalEvent (Event);
+    break;
   }
 
   gBS->RestoreTPL (OldTpl);

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -315,11 +315,6 @@ VirtioKeyboardConvertKeyCode (
         KeyData->KeyState.KeyShiftState &= ~(EFI_LEFT_SHIFT_PRESSED | EFI_RIGHT_SHIFT_PRESSED);
       }
 
-      if (Dev->KeyActive[KEY_LEFTCTRL] || Dev->KeyActive[KEY_RIGHTCTRL]) {
-        // Convert Ctrl+[a-z] and Ctrl+[A-Z] into [1-26] ASCII table entries
-        Key->UnicodeChar &= 0x1F;
-      }
-
       break;
   }
 }
@@ -475,6 +470,22 @@ VirtioKeyboardReadKeyStroke (
 
     if ((KeyData.Key.ScanCode == SCAN_NULL) && (KeyData.Key.UnicodeChar == CHAR_NULL)) {
       continue;
+    }
+
+    // Since ReadKeyStroke does not allow to convey modifier state, we have to
+    // fold Ctrl into the printable character to produce a C0 control code
+    // (i.e. apply the caret notation).
+    // NB1: this is not actually in the SIMPLE_TEXT_INPUT(_EX) spec; we do it
+    //     for compatibility with other keyboard drivers and TerminalDxe.
+    // NB2: We only apply a subset of caret notation limited to alphabetic
+    //      characters, as these are idempotent wrt. Shift and CapsLock
+    //      (which are already applied at this point).
+    if (KeyData.KeyState.KeyShiftState & (EFI_LEFT_CONTROL_PRESSED | EFI_RIGHT_CONTROL_PRESSED)) {
+      if (((KeyData.Key.UnicodeChar >= 'A') && (KeyData.Key.UnicodeChar <= 'Z')) ||
+          ((KeyData.Key.UnicodeChar >= 'a') && (KeyData.Key.UnicodeChar <= 'z')))
+      {
+        KeyData.Key.UnicodeChar &= 0x1F;
+      }
     }
 
     *Key = KeyData.Key;

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -194,7 +194,7 @@ VirtioKeyboardHandleEvent (
   IN VIRTIO_INPUT_EVENT    *Event
   )
 {
-  if (Event->Value == KEY_PRESSED) {
+  if (Event->Value != KEY_RELEASED) {
     // Key pressed event received
     Dev->KeyActive[(UINT8)Event->Code] = TRUE;
 

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -312,6 +312,17 @@ VirtioKeyboardConvertKeyCode (
         KeyData->KeyState.KeyShiftState &= ~(EFI_LEFT_SHIFT_PRESSED | EFI_RIGHT_SHIFT_PRESSED);
       }
 
+      if (Dev->CapsLock) {
+        // On CapsLock, invert capitalization of alphabetic characters
+        // NB1: this must run in series with Shift handling (CapsLock XORs with Shift)
+        // NB2: this must run after Ctrl handling (CapsLock must not affect control codes)
+        if (((Key->UnicodeChar >= 'a') && (Key->UnicodeChar <= 'z')) ||
+            ((Key->UnicodeChar >= 'A') && (Key->UnicodeChar <= 'Z')))
+        {
+          Key->UnicodeChar ^= 0x20;
+        }
+      }
+
       break;
   }
 }
@@ -340,6 +351,9 @@ VirtioKeyboardInitializeKeyState (
                              );
 
   KeyState->KeyToggleState = (
+                              (Dev->NumLock ? EFI_NUM_LOCK_ACTIVE : 0) |
+                              (Dev->CapsLock ? EFI_CAPS_LOCK_ACTIVE : 0) |
+                              (Dev->ScrollLock ? EFI_SCROLL_LOCK_ACTIVE : 0) |
                               (Dev->SupportPartialKeys ? EFI_KEY_STATE_EXPOSED : 0) |
                               EFI_TOGGLE_STATE_VALID
                               );
@@ -393,6 +407,26 @@ VirtioKeyboardHandleEvent (
     // Key pressed event received
     Dev->KeyActive[(UINT8)Event->Code] = TRUE;
 
+    //
+    // Update toggle state
+    // This must happen before EFI_KEY_DATA is populated, since the toggle state
+    // is used both to initialize ->KeyState and to modify key code behavior.
+    // NB: only explicitly handle KEY_PRESSED to ignore autorepeat events
+    //
+    if (Event->Value == KEY_PRESSED) {
+      switch (Event->Code) {
+        case KEY_NUMLOCK:
+          Dev->NumLock = (BOOLEAN) !Dev->NumLock;
+          break;
+        case KEY_CAPSLOCK:
+          Dev->CapsLock = (BOOLEAN) !Dev->CapsLock;
+          break;
+        case KEY_SCROLLLOCK:
+          Dev->ScrollLock = (BOOLEAN) !Dev->ScrollLock;
+          break;
+      }
+    }
+
     // Evaluate key
     Status = VirtioKeyboardProcessEvent (Dev, Event->Code, &KeyData);
     if (EFI_ERROR (Status)) {
@@ -427,6 +461,9 @@ VirtioKeyboardReset (
   ZeroMem (Dev->KeyActive, sizeof (Dev->KeyActive));
   ClearEfikeyBuf (&Dev->KeyQueue);
 
+  Dev->NumLock            = FALSE;
+  Dev->CapsLock           = FALSE;
+  Dev->ScrollLock         = FALSE;
   Dev->SupportPartialKeys = FALSE;
 
   gBS->RestoreTPL (OldTpl);
@@ -631,6 +668,14 @@ VirtioKeyboardSetStateEx (
     return EFI_UNSUPPORTED;
   }
 
+  //
+  // Update effective toggle states
+  // TODO: updating (virtio) hardware LEDs is not implemented
+  //       (needs EV_LED write on status virtqueue; this driver does not initialize it)
+  //
+  Dev->NumLock            = (BOOLEAN)((*KeyToggleState & EFI_NUM_LOCK_ACTIVE) != 0);
+  Dev->CapsLock           = (BOOLEAN)((*KeyToggleState & EFI_CAPS_LOCK_ACTIVE) != 0);
+  Dev->ScrollLock         = (BOOLEAN)((*KeyToggleState & EFI_SCROLL_LOCK_ACTIVE) != 0);
   Dev->SupportPartialKeys = (BOOLEAN)((*KeyToggleState & EFI_KEY_STATE_EXPOSED) != 0);
 
   return EFI_SUCCESS;

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -13,6 +13,7 @@
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/UefiLib.h>
 
 #include "VirtioInput.h"
@@ -440,6 +441,16 @@ VirtioKeyboardHandleEvent (
   if (Event->Value != KEY_RELEASED) {
     // Key pressed event received
     Dev->KeyActive[(UINT8)Event->Code] = TRUE;
+
+    // Handle Ctrl-Alt-Del (in any order)
+    if (
+        (Dev->KeyActive[KEY_LEFTCTRL] || Dev->KeyActive[KEY_RIGHTCTRL]) &&
+        (Dev->KeyActive[KEY_LEFTALT] || Dev->KeyActive[KEY_RIGHTALT]) &&
+        Dev->KeyActive[KEY_DELETE]
+        )
+    {
+      gRT->ResetSystem (EfiResetWarm, EFI_SUCCESS, 0, NULL);
+    }
 
     //
     // Update toggle state

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -315,6 +315,17 @@ VirtioKeyboardConvertKeyCode (
         KeyData->KeyState.KeyShiftState &= ~(EFI_LEFT_SHIFT_PRESSED | EFI_RIGHT_SHIFT_PRESSED);
       }
 
+      if (Dev->CapsLock) {
+        // On CapsLock, invert capitalization of alphabetic characters
+        // NB1: this must run in series with Shift handling (CapsLock XORs with Shift)
+        // NB2: this must run after Ctrl handling (CapsLock must not affect control codes)
+        if (((Key->UnicodeChar >= 'a') && (Key->UnicodeChar <= 'z')) ||
+            ((Key->UnicodeChar >= 'A') && (Key->UnicodeChar <= 'Z')))
+        {
+          Key->UnicodeChar ^= 0x20;
+        }
+      }
+
       break;
   }
 }
@@ -343,6 +354,9 @@ VirtioKeyboardInitializeKeyState (
                              );
 
   KeyState->KeyToggleState = (
+                              (Dev->NumLock ? EFI_NUM_LOCK_ACTIVE : 0) |
+                              (Dev->CapsLock ? EFI_CAPS_LOCK_ACTIVE : 0) |
+                              (Dev->ScrollLock ? EFI_SCROLL_LOCK_ACTIVE : 0) |
                               (Dev->SupportPartialKeys ? EFI_KEY_STATE_EXPOSED : 0) |
                               EFI_TOGGLE_STATE_VALID
                               );
@@ -396,6 +410,26 @@ VirtioKeyboardHandleEvent (
     // Key pressed event received
     Dev->KeyActive[(UINT8)Event->Code] = TRUE;
 
+    //
+    // Update toggle state
+    // This must happen before EFI_KEY_DATA is populated, since the toggle state
+    // is used both to initialize ->KeyState and to modify key code behavior.
+    // NB: only explicitly handle KEY_PRESSED to ignore autorepeat events
+    //
+    if (Event->Value == KEY_PRESSED) {
+      switch (Event->Code) {
+        case KEY_NUMLOCK:
+          Dev->NumLock = (BOOLEAN) !Dev->NumLock;
+          break;
+        case KEY_CAPSLOCK:
+          Dev->CapsLock = (BOOLEAN) !Dev->CapsLock;
+          break;
+        case KEY_SCROLLLOCK:
+          Dev->ScrollLock = (BOOLEAN) !Dev->ScrollLock;
+          break;
+      }
+    }
+
     // Evaluate key
     Status = VirtioKeyboardProcessEvent (Dev, Event->Code, &KeyData);
     if (EFI_ERROR (Status)) {
@@ -430,6 +464,9 @@ VirtioKeyboardReset (
   ZeroMem (Dev->KeyActive, sizeof (Dev->KeyActive));
   ClearEfikeyBuf (&Dev->KeyQueue);
 
+  Dev->NumLock            = FALSE;
+  Dev->CapsLock           = FALSE;
+  Dev->ScrollLock         = FALSE;
   Dev->SupportPartialKeys = FALSE;
 
   gBS->RestoreTPL (OldTpl);
@@ -634,6 +671,14 @@ VirtioKeyboardSetStateEx (
     return EFI_UNSUPPORTED;
   }
 
+  //
+  // Update effective toggle states
+  // TODO: updating (virtio) hardware LEDs is not implemented
+  //       (needs EV_LED write on status virtqueue; this driver does not initialize it)
+  //
+  Dev->NumLock            = (BOOLEAN)((*KeyToggleState & EFI_NUM_LOCK_ACTIVE) != 0);
+  Dev->CapsLock           = (BOOLEAN)((*KeyToggleState & EFI_CAPS_LOCK_ACTIVE) != 0);
+  Dev->ScrollLock         = (BOOLEAN)((*KeyToggleState & EFI_SCROLL_LOCK_ACTIVE) != 0);
   Dev->SupportPartialKeys = (BOOLEAN)((*KeyToggleState & EFI_KEY_STATE_EXPOSED) != 0);
 
   return EFI_SUCCESS;

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -182,6 +182,67 @@ VirtioKeyboardConvertKeyCode (
 }
 
 // -----------------------------------------------------------------------------
+// Function populating modifier and toggle state of an UEFI key event
+STATIC
+VOID
+VirtioKeyboardInitializeKeyState (
+  IN  VIRTIO_INPUT_DEV  *Dev,
+  OUT EFI_KEY_STATE     *KeyState
+  )
+{
+  KeyState->KeyShiftState = (
+                             (Dev->KeyActive[KEY_RIGHTSHIFT] ? EFI_RIGHT_SHIFT_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_LEFTSHIFT] ? EFI_LEFT_SHIFT_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_RIGHTCTRL] ? EFI_RIGHT_CONTROL_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_LEFTCTRL] ? EFI_LEFT_CONTROL_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_RIGHTALT] ? EFI_RIGHT_ALT_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_LEFTALT] ? EFI_LEFT_ALT_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_RIGHTMETA] ? EFI_RIGHT_LOGO_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_LEFTMETA] ? EFI_LEFT_LOGO_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_COMPOSE] ? EFI_MENU_KEY_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_SYSRQ] ? EFI_SYS_REQ_PRESSED : 0) |
+                             EFI_SHIFT_STATE_VALID
+                             );
+
+  KeyState->KeyToggleState = (
+                              (Dev->SupportPartialKeys ? EFI_KEY_STATE_EXPOSED : 0) |
+                              EFI_TOGGLE_STATE_VALID
+                              );
+}
+
+// -----------------------------------------------------------------------------
+// Function processing a single VirtIO keyboard event into a complete UEFI event
+STATIC
+EFI_STATUS
+VirtioKeyboardProcessEvent (
+  IN  VIRTIO_INPUT_DEV  *Dev,
+  IN  UINT16            KeyCode,
+  OUT EFI_KEY_DATA      *KeyData
+  )
+{
+  //
+  // Translate the virtio scancode into EFI scancode and Unicode char
+  //
+  VirtioKeyboardConvertKeyCode (Dev, KeyCode, &KeyData->Key);
+
+  //
+  // Keys with no Unicode representation and no EFI scancode are not valid,
+  // unless we were requested to process partial keys
+  //
+  if ((KeyData->Key.UnicodeChar == CHAR_NULL) && (KeyData->Key.ScanCode == SCAN_NULL)) {
+    if (!Dev->SupportPartialKeys) {
+      return EFI_NOT_READY;
+    }
+  }
+
+  //
+  // Complete the key data structure with current keyboard state (active modifiers)
+  //
+  VirtioKeyboardInitializeKeyState (Dev, &KeyData->KeyState);
+  return EFI_SUCCESS;
+}
+
+// -----------------------------------------------------------------------------
 // Function handling VirtIO keyboard events
 VOID
 VirtioKeyboardHandleEvent (
@@ -189,15 +250,23 @@ VirtioKeyboardHandleEvent (
   IN VIRTIO_INPUT_EVENT    *Event
   )
 {
+  EFI_STATUS    Status;
+  EFI_KEY_DATA  KeyData;
+
   if (Event->Value != KEY_RELEASED) {
     // Key pressed event received
     Dev->KeyActive[(UINT8)Event->Code] = TRUE;
 
     // Evaluate key
-    VirtioKeyboardConvertKeyCode (Dev, Event->Code, &Dev->LastKey);
+    Status = VirtioKeyboardProcessEvent (Dev, Event->Code, &KeyData);
+    if (EFI_ERROR (Status)) {
+      return;
+    }
 
     // Flag that printable character is ready to be send
-    Dev->KeyReady = TRUE;
+    // TODO: turn this into a queue
+    Dev->LastKeyData = KeyData;
+    Dev->KeyReady    = TRUE;
   } else {
     // Key released event received
     Dev->KeyActive[(UINT8)Event->Code] = FALSE;
@@ -221,10 +290,11 @@ VirtioKeyboardReset (
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
-  Dev->KeyReady            = FALSE;
-  Dev->LastKey.ScanCode    = SCAN_NULL;
-  Dev->LastKey.UnicodeChar = CHAR_NULL;
+  Dev->KeyReady = FALSE;
+  ZeroMem (&Dev->LastKeyData, sizeof (Dev->LastKeyData));
   ZeroMem (Dev->KeyActive, sizeof (Dev->KeyActive));
+
+  Dev->SupportPartialKeys = FALSE;
 
   gBS->RestoreTPL (OldTpl);
   return EFI_SUCCESS;
@@ -252,7 +322,7 @@ VirtioKeyboardReadKeyStroke (
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
   if (Dev->KeyReady) {
     // Get last key from the buffer
-    *Key = Dev->LastKey;
+    *Key = Dev->LastKeyData.Key;
 
     // Mark key as consumed
     Dev->KeyReady = FALSE;
@@ -337,9 +407,7 @@ VirtioKeyboardReadKeyStrokeEx (
   )
 {
   VIRTIO_INPUT_DEV  *Dev;
-  EFI_STATUS        Status;
-  EFI_INPUT_KEY     Key;
-  EFI_KEY_STATE     KeyState;
+  EFI_TPL           OldTpl;
 
   if (KeyData == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -347,48 +415,20 @@ VirtioKeyboardReadKeyStrokeEx (
 
   Dev = VIRTIO_INPUT_EX_FROM_THIS (This);
 
-  // Get the last pressed key
-  Status = Dev->Txt.ReadKeyStroke (&Dev->Txt, &Key);
-  if (EFI_ERROR (Status)) {
-    return EFI_DEVICE_ERROR;
+  OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+  if (Dev->KeyReady) {
+    // Get last key from the buffer
+    *KeyData = Dev->LastKeyData;
+
+    // Mark key as consumed
+    Dev->KeyReady = FALSE;
+
+    gBS->RestoreTPL (OldTpl);
+    return EFI_SUCCESS;
   }
 
-  // Add key state informations
-  KeyState.KeyShiftState  = EFI_SHIFT_STATE_VALID;
-  KeyState.KeyToggleState = EFI_TOGGLE_STATE_VALID;
-
-  // Shift key modifier
-  if (Dev->KeyActive[KEY_LEFTSHIFT]) {
-    KeyState.KeyShiftState |= EFI_LEFT_SHIFT_PRESSED;
-  }
-
-  if (Dev->KeyActive[KEY_RIGHTSHIFT]) {
-    KeyState.KeyShiftState |= EFI_RIGHT_SHIFT_PRESSED;
-  }
-
-  // Ctrl key modifier
-  if (Dev->KeyActive[KEY_LEFTCTRL]) {
-    KeyState.KeyShiftState |= EFI_LEFT_CONTROL_PRESSED;
-  }
-
-  if (Dev->KeyActive[KEY_RIGHTCTRL]) {
-    KeyState.KeyShiftState |= EFI_RIGHT_CONTROL_PRESSED;
-  }
-
-  // ALt key modifier
-  if (Dev->KeyActive[KEY_LEFTALT]) {
-    KeyState.KeyShiftState |= EFI_LEFT_ALT_PRESSED;
-  }
-
-  if (Dev->KeyActive[KEY_RIGHTALT]) {
-    KeyState.KeyShiftState |= EFI_RIGHT_ALT_PRESSED;
-  }
-
-  // Return value only when there is no failure
-  KeyData->Key      = Key;
-  KeyData->KeyState = KeyState;
-
-  return EFI_SUCCESS;
+  gBS->RestoreTPL (OldTpl);
+  return EFI_NOT_READY;
 }
 
 // -----------------------------------------------------------------------------
@@ -401,9 +441,19 @@ VirtioKeyboardSetStateEx (
   IN EFI_KEY_TOGGLE_STATE               *KeyToggleState
   )
 {
+  VIRTIO_INPUT_DEV  *Dev;
+
   if (KeyToggleState == NULL) {
     return EFI_INVALID_PARAMETER;
   }
+
+  Dev = VIRTIO_INPUT_EX_FROM_THIS (This);
+
+  if (!(*KeyToggleState & EFI_TOGGLE_STATE_VALID)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Dev->SupportPartialKeys = (BOOLEAN)((*KeyToggleState & EFI_KEY_STATE_EXPOSED) != 0);
 
   return EFI_SUCCESS;
 }

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -444,8 +444,22 @@ VirtioKeyboardReadKeyStroke (
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
-  Status = PopEfikeyBufHead (&Dev->KeyQueue, &KeyData);
-  *Key   = KeyData.Key;
+  //
+  // ReadKeyStroke of SIMPLE_TEXT_INPUT must omit partial keystrokes
+  //
+  while (TRUE) {
+    Status = PopEfikeyBufHead (&Dev->KeyQueue, &KeyData);
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    if ((KeyData.Key.ScanCode == SCAN_NULL) && (KeyData.Key.UnicodeChar == CHAR_NULL)) {
+      continue;
+    }
+
+    *Key = KeyData.Key;
+    break;
+  }
 
   gBS->RestoreTPL (OldTpl);
 
@@ -464,6 +478,8 @@ VirtioKeyboardWaitForKey (
 {
   VIRTIO_INPUT_DEV  *Dev = (VIRTIO_INPUT_DEV *)Context;
   EFI_TPL           OldTpl;
+  EFI_KEY_DATA      KeyData;
+  EFI_STATUS        Status;
 
   //
   // Stall 1ms to give a chance to let other driver interrupt this routine
@@ -482,9 +498,23 @@ VirtioKeyboardWaitForKey (
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
+  //
   // If there is a new key ready - send signal
-  if (!IsEfikeyBufEmpty (&Dev->KeyQueue)) {
+  // WaitForKey(Ex) must omit partial keystrokes
+  //
+  while (TRUE) {
+    Status = PeekEfikeyBufHead (&Dev->KeyQueue, &KeyData);
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    if ((KeyData.Key.ScanCode == SCAN_NULL) && (KeyData.Key.UnicodeChar == CHAR_NULL)) {
+      (void)PopEfikeyBufHead (&Dev->KeyQueue, NULL);
+      continue;
+    }
+
     gBS->SignalEvent (Event);
+    break;
   }
 
   gBS->RestoreTPL (OldTpl);

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -183,7 +183,7 @@ VOID
 VirtioKeyboardConvertKeyCode (
   IN OUT VIRTIO_INPUT_DEV  *Dev,
   IN UINT16                Code,
-  OUT EFI_INPUT_KEY        *Key
+  OUT EFI_KEY_DATA         *KeyData
   )
 {
   // Key mapping in between Linux and UEFI
@@ -218,6 +218,8 @@ VirtioKeyboardConvertKeyCode (
     [KEY_SPACE]         = ' ',
     [MAX_KEYBOARD_CODE] = 0x00
   };
+
+  EFI_INPUT_KEY  *Key = &KeyData->Key;
 
   // Set default readings
   Key->ScanCode    = SCAN_NULL;
@@ -299,6 +301,20 @@ VirtioKeyboardConvertKeyCode (
         Key->UnicodeChar = Map[Code];
       }
 
+      // If this key cannot be mapped to either a scancode or a printable character, return
+      if (Key->UnicodeChar == CHAR_NULL) {
+        return;
+      }
+
+      // If we are processing a shiftable character, clear the explicit shift state (if any)
+      // because it is now reflected in the character representation itself.
+      // "if a class of printable characters that are normally adjusted by shift modifiers
+      // (e.g. Shift Key + “f” key) would be presented solely as a KeyData.Key.UnicodeChar
+      // without the associated shift state."
+      if (MapShift[Code] != Map[Code]) {
+        KeyData->KeyState.KeyShiftState &= ~(EFI_LEFT_SHIFT_PRESSED | EFI_RIGHT_SHIFT_PRESSED);
+      }
+
       if (Dev->KeyActive[KEY_LEFTCTRL] || Dev->KeyActive[KEY_RIGHTCTRL]) {
         // Convert Ctrl+[a-z] and Ctrl+[A-Z] into [1-26] ASCII table entries
         Key->UnicodeChar &= 0x1F;
@@ -348,9 +364,14 @@ VirtioKeyboardProcessEvent (
   )
 {
   //
+  // Initialize the key data structure with current keyboard and toggle state
+  //
+  VirtioKeyboardInitializeKeyState (Dev, &KeyData->KeyState);
+
+  //
   // Translate the virtio scancode into EFI scancode and Unicode char
   //
-  VirtioKeyboardConvertKeyCode (Dev, KeyCode, &KeyData->Key);
+  VirtioKeyboardConvertKeyCode (Dev, KeyCode, KeyData);
 
   //
   // Keys with no Unicode representation and no EFI scancode are not valid,
@@ -362,10 +383,6 @@ VirtioKeyboardProcessEvent (
     }
   }
 
-  //
-  // Complete the key data structure with current keyboard state (active modifiers)
-  //
-  VirtioKeyboardInitializeKeyState (Dev, &KeyData->KeyState);
   return EFI_SUCCESS;
 }
 

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -141,6 +141,13 @@ ClearEfikeyBuf (
   ZeroMem (Queue->Buffer, sizeof (Queue->Buffer));
 }
 
+STATIC
+BOOLEAN
+IsKeyRegistered (
+  IN EFI_KEY_DATA  *RegisteredData,
+  IN EFI_KEY_DATA  *InputData
+  );
+
 // -----------------------------------------------------------------------------
 // End utility functions
 // -----------------------------------------------------------------------------
@@ -372,6 +379,10 @@ VirtioKeyboardProcessEvent (
   OUT EFI_KEY_DATA      *KeyData
   )
 {
+  LIST_ENTRY                 *Link;
+  LIST_ENTRY                 *NotifyList;
+  VIRTIO_INPUT_IN_EX_NOTIFY  *CurrentNotify;
+
   //
   // Initialize the key data structure with current keyboard and toggle state
   //
@@ -389,6 +400,29 @@ VirtioKeyboardProcessEvent (
   if ((KeyData->Key.UnicodeChar == CHAR_NULL) && (KeyData->Key.ScanCode == SCAN_NULL)) {
     if (!Dev->SupportPartialKeys) {
       return EFI_NOT_READY;
+    }
+  }
+
+  //
+  // Signal KeyNotify process event if this key pressed matches any key registered.
+  //
+  NotifyList = &Dev->KeyNotifyList;
+  for (Link = GetFirstNode (NotifyList); !IsNull (NotifyList, Link); Link = GetNextNode (NotifyList, Link)) {
+    CurrentNotify = CR (
+                      Link,
+                      VIRTIO_INPUT_IN_EX_NOTIFY,
+                      NotifyEntry,
+                      VIRTIO_INPUT_SIG
+                      );
+    if (IsKeyRegistered (&CurrentNotify->KeyData, KeyData)) {
+      //
+      // The key notification function needs to run at TPL_CALLBACK
+      // while current TPL is TPL_NOTIFY. It will be invoked in
+      // KeyNotifyProcessHandler() which runs at TPL_CALLBACK.
+      //
+      PushEfikeyBufTail (&Dev->KeyQueueForNotify, KeyData);
+      gBS->SignalEvent (Dev->KeyNotifyProcessEvent);
+      break;
     }
   }
 
@@ -445,6 +479,52 @@ VirtioKeyboardHandleEvent (
 }
 
 // -----------------------------------------------------------------------------
+// Function handling key notifications
+VOID
+EFIAPI
+VirtioKeyboardNotifyHandler (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS                 Status;
+  VIRTIO_INPUT_DEV           *Dev;
+  EFI_KEY_DATA               KeyData;
+  LIST_ENTRY                 *Link;
+  LIST_ENTRY                 *NotifyList;
+  VIRTIO_INPUT_IN_EX_NOTIFY  *CurrentNotify;
+  EFI_TPL                    OldTpl;
+
+  Dev        = (VIRTIO_INPUT_DEV *)Context;
+  NotifyList = &Dev->KeyNotifyList;
+
+  while (TRUE) {
+    //
+    // Critical section
+    //
+    OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+    Status = PopEfikeyBufHead (&Dev->KeyQueueForNotify, &KeyData);
+    gBS->RestoreTPL (OldTpl);
+
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    for (Link = GetFirstNode (NotifyList); !IsNull (NotifyList, Link); Link = GetNextNode (NotifyList, Link)) {
+      CurrentNotify = CR (
+                        Link,
+                        VIRTIO_INPUT_IN_EX_NOTIFY,
+                        NotifyEntry,
+                        VIRTIO_INPUT_SIG
+                        );
+      if (IsKeyRegistered (&CurrentNotify->KeyData, &KeyData)) {
+        CurrentNotify->KeyNotificationFn (&KeyData);
+      }
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
 // EFI_SIMPLE_TEXT_INPUT_PROTOCOL API
 STATIC
 EFI_STATUS
@@ -463,6 +543,7 @@ VirtioKeyboardReset (
 
   ZeroMem (Dev->KeyActive, sizeof (Dev->KeyActive));
   ClearEfikeyBuf (&Dev->KeyQueue);
+  ClearEfikeyBuf (&Dev->KeyQueueForNotify);
 
   Dev->NumLock            = FALSE;
   Dev->CapsLock           = FALSE;
@@ -890,6 +971,46 @@ VirtioKeyboardInit (
     return Status;
   }
 
+  //
+  // Setup the key notification processing callback event
+  //
+  Status = gBS->CreateEvent (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  &VirtioKeyboardNotifyHandler,
+                  Dev,
+                  &Dev->KeyNotifyProcessEvent
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+VirtioFreeNotifyList (
+  IN OUT LIST_ENTRY  *ListHead
+  )
+{
+  VIRTIO_INPUT_IN_EX_NOTIFY  *NotifyNode;
+
+  if (ListHead == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  while (!IsListEmpty (ListHead)) {
+    NotifyNode = CR (
+                   ListHead->ForwardLink,
+                   VIRTIO_INPUT_IN_EX_NOTIFY,
+                   NotifyEntry,
+                   VIRTIO_INPUT_SIG
+                   );
+    RemoveEntryList (ListHead->ForwardLink);
+    gBS->FreePool (NotifyNode);
+  }
+
   return EFI_SUCCESS;
 }
 
@@ -900,4 +1021,6 @@ VirtioKeyboardUninit (
 {
   gBS->CloseEvent (Dev->Txt.WaitForKey);
   gBS->CloseEvent (Dev->TxtEx.WaitForKeyEx);
+  gBS->CloseEvent (Dev->KeyNotifyProcessEvent);
+  VirtioFreeNotifyList (&Dev->KeyNotifyList);
 }

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -191,7 +191,7 @@ VirtioKeyboardHandleEvent (
   IN VIRTIO_INPUT_EVENT    *Event
   )
 {
-  if (Event->Value == KEY_PRESSED) {
+  if (Event->Value != KEY_RELEASED) {
     // Key pressed event received
     Dev->KeyActive[(UINT8)Event->Code] = TRUE;
 

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -13,6 +13,7 @@
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Library/VirtioLib.h>
 
@@ -443,6 +444,16 @@ VirtioKeyboardHandleEvent (
   if (Event->Value != KEY_RELEASED) {
     // Key pressed event received
     Dev->KeyActive[(UINT8)Event->Code] = TRUE;
+
+    // Handle Ctrl-Alt-Del (in any order)
+    if (
+        (Dev->KeyActive[KEY_LEFTCTRL] || Dev->KeyActive[KEY_RIGHTCTRL]) &&
+        (Dev->KeyActive[KEY_LEFTALT] || Dev->KeyActive[KEY_RIGHTALT]) &&
+        Dev->KeyActive[KEY_DELETE]
+        )
+    {
+      gRT->ResetSystem (EfiResetWarm, EFI_SUCCESS, 0, NULL);
+    }
 
     //
     // Update toggle state

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -18,6 +18,130 @@
 #include "VirtioInput.h"
 #include "VirtioKeyCodes.h"
 
+// -----------------------------------------------------------------------------
+// Utility functions
+// -----------------------------------------------------------------------------
+
+/**
+  Check whether the EFI key buffer is empty.
+
+  @param Queue     Pointer to instance of EFI_KEY_QUEUE.
+
+  @retval TRUE    The EFI key buffer is empty.
+  @retval FALSE   The EFI key buffer isn't empty.
+**/
+STATIC
+BOOLEAN
+IsEfikeyBufEmpty (
+  IN  EFI_KEY_QUEUE  *Queue
+  )
+{
+  return (BOOLEAN)(Queue->Head == Queue->Tail);
+}
+
+/**
+  Read (but do not remove) one key data entry from the EFI key buffer.
+
+  @param Queue     Pointer to instance of EFI_KEY_QUEUE.
+  @param KeyData   Receive the key data.
+
+  @retval EFI_SUCCESS   The key data is popped successfully.
+  @retval EFI_NOT_READY There is no key data available.
+**/
+STATIC
+EFI_STATUS
+PeekEfikeyBufHead (
+  IN  EFI_KEY_QUEUE  *Queue,
+  OUT EFI_KEY_DATA   *KeyData OPTIONAL
+  )
+{
+  if (IsEfikeyBufEmpty (Queue)) {
+    return EFI_NOT_READY;
+  }
+
+  if (KeyData != NULL) {
+    CopyMem (KeyData, &Queue->Buffer[Queue->Head], sizeof (EFI_KEY_DATA));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Read & remove one key data from the EFI key buffer.
+
+  @param Queue     Pointer to instance of EFI_KEY_QUEUE.
+  @param KeyData   Receive the key data.
+
+  @retval EFI_SUCCESS   The key data is popped successfully.
+  @retval EFI_NOT_READY There is no key data available.
+**/
+STATIC
+EFI_STATUS
+PopEfikeyBufHead (
+  IN  EFI_KEY_QUEUE  *Queue,
+  OUT EFI_KEY_DATA   *KeyData OPTIONAL
+  )
+{
+  if (IsEfikeyBufEmpty (Queue)) {
+    return EFI_NOT_READY;
+  }
+
+  //
+  // Retrieve and remove the values
+  //
+  if (KeyData != NULL) {
+    CopyMem (KeyData, &Queue->Buffer[Queue->Head], sizeof (EFI_KEY_DATA));
+  }
+
+  ZeroMem (&Queue->Buffer[Queue->Head], sizeof (EFI_KEY_DATA));
+  Queue->Head = (Queue->Head + 1) % KEYBOARD_EFI_KEY_MAX_COUNT;
+  return EFI_SUCCESS;
+}
+
+/**
+  Push one key data to the EFI key buffer.
+
+  @param Queue     Pointer to instance of EFI_KEY_QUEUE.
+  @param KeyData   The key data to push.
+**/
+STATIC
+VOID
+PushEfikeyBufTail (
+  IN  EFI_KEY_QUEUE  *Queue,
+  IN  EFI_KEY_DATA   *KeyData
+  )
+{
+  if ((Queue->Tail + 1) % KEYBOARD_EFI_KEY_MAX_COUNT == Queue->Head) {
+    //
+    // If Queue is full, pop the one from head.
+    //
+    PopEfikeyBufHead (Queue, NULL);
+  }
+
+  CopyMem (&Queue->Buffer[Queue->Tail], KeyData, sizeof (EFI_KEY_DATA));
+  Queue->Tail = (Queue->Tail + 1) % KEYBOARD_EFI_KEY_MAX_COUNT;
+}
+
+/**
+  Clear the EFI key queue.
+
+  @param Queue   Pointer to instance of EFI_KEY_QUEUE.
+ */
+STATIC
+VOID
+ClearEfikeyBuf (
+  IN  EFI_KEY_QUEUE  *Queue
+  )
+{
+  Queue->Head = 0;
+  Queue->Tail = 0;
+  ZeroMem (Queue->Buffer, sizeof (Queue->Buffer));
+}
+
+// -----------------------------------------------------------------------------
+// End utility functions
+// -----------------------------------------------------------------------------
+
 BOOLEAN
 VirtioKeyboardProbe (
   IN VIRTIO_INPUT_DEV  *Dev
@@ -263,10 +387,8 @@ VirtioKeyboardHandleEvent (
       return;
     }
 
-    // Flag that printable character is ready to be send
-    // TODO: turn this into a queue
-    Dev->LastKeyData = KeyData;
-    Dev->KeyReady    = TRUE;
+    // Submit this key
+    PushEfikeyBufTail (&Dev->KeyQueue, &KeyData);
   } else {
     // Key released event received
     Dev->KeyActive[(UINT8)Event->Code] = FALSE;
@@ -290,9 +412,8 @@ VirtioKeyboardReset (
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
-  Dev->KeyReady = FALSE;
-  ZeroMem (&Dev->LastKeyData, sizeof (Dev->LastKeyData));
   ZeroMem (Dev->KeyActive, sizeof (Dev->KeyActive));
+  ClearEfikeyBuf (&Dev->KeyQueue);
 
   Dev->SupportPartialKeys = FALSE;
 
@@ -312,6 +433,8 @@ VirtioKeyboardReadKeyStroke (
 {
   VIRTIO_INPUT_DEV  *Dev;
   EFI_TPL           OldTpl;
+  EFI_KEY_DATA      KeyData;
+  EFI_STATUS        Status;
 
   if (Key == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -320,20 +443,13 @@ VirtioKeyboardReadKeyStroke (
   Dev = VIRTIO_INPUT_FROM_THIS (This);
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
-  if (Dev->KeyReady) {
-    // Get last key from the buffer
-    *Key = Dev->LastKeyData.Key;
 
-    // Mark key as consumed
-    Dev->KeyReady = FALSE;
-
-    gBS->RestoreTPL (OldTpl);
-    return EFI_SUCCESS;
-  }
+  Status = PopEfikeyBufHead (&Dev->KeyQueue, &KeyData);
+  *Key   = KeyData.Key;
 
   gBS->RestoreTPL (OldTpl);
 
-  return EFI_NOT_READY;
+  return Status;
 }
 
 // -----------------------------------------------------------------------------
@@ -347,6 +463,7 @@ VirtioKeyboardWaitForKey (
   )
 {
   VIRTIO_INPUT_DEV  *Dev = (VIRTIO_INPUT_DEV *)Context;
+  EFI_TPL           OldTpl;
 
   //
   // Stall 1ms to give a chance to let other driver interrupt this routine
@@ -363,10 +480,14 @@ VirtioKeyboardWaitForKey (
   // Use TimerEvent callback function to check whether there's any key pressed
   VirtioInputTimer (NULL, Dev);
 
+  OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+
   // If there is a new key ready - send signal
-  if (Dev->KeyReady) {
+  if (!IsEfikeyBufEmpty (&Dev->KeyQueue)) {
     gBS->SignalEvent (Event);
   }
+
+  gBS->RestoreTPL (OldTpl);
 }
 
 /// -----------------------------------------------------------------------------
@@ -408,6 +529,7 @@ VirtioKeyboardReadKeyStrokeEx (
 {
   VIRTIO_INPUT_DEV  *Dev;
   EFI_TPL           OldTpl;
+  EFI_STATUS        Status;
 
   if (KeyData == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -416,19 +538,12 @@ VirtioKeyboardReadKeyStrokeEx (
   Dev = VIRTIO_INPUT_EX_FROM_THIS (This);
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
-  if (Dev->KeyReady) {
-    // Get last key from the buffer
-    *KeyData = Dev->LastKeyData;
 
-    // Mark key as consumed
-    Dev->KeyReady = FALSE;
-
-    gBS->RestoreTPL (OldTpl);
-    return EFI_SUCCESS;
-  }
+  Status = PopEfikeyBufHead (&Dev->KeyQueue, KeyData);
 
   gBS->RestoreTPL (OldTpl);
-  return EFI_NOT_READY;
+
+  return Status;
 }
 
 // -----------------------------------------------------------------------------

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -570,6 +570,11 @@ VirtioKeyboardReadKeyStrokeEx (
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
   Status = PopEfikeyBufHead (&Dev->KeyQueue, KeyData);
+  // "There was no keystroke data available. Current KeyData.KeyState values are exposed."
+  if (Status == EFI_NOT_READY) {
+    ZeroMem (&KeyData->Key, sizeof (KeyData->Key));
+    VirtioKeyboardInitializeKeyState (Dev, &KeyData->KeyState);
+  }
 
   gBS->RestoreTPL (OldTpl);
 

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -14,9 +14,6 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
-#include <Library/VirtioLib.h>
-
-#include <IndustryStandard/VirtioInput.h>
 
 #include "VirtioInput.h"
 #include "VirtioKeyCodes.h"

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -573,6 +573,11 @@ VirtioKeyboardReadKeyStrokeEx (
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
   Status = PopEfikeyBufHead (&Dev->KeyQueue, KeyData);
+  // "There was no keystroke data available. Current KeyData.KeyState values are exposed."
+  if (Status == EFI_NOT_READY) {
+    ZeroMem (&KeyData->Key, sizeof (KeyData->Key));
+    VirtioKeyboardInitializeKeyState (Dev, &KeyData->KeyState);
+  }
 
   gBS->RestoreTPL (OldTpl);
 

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -167,10 +167,8 @@ VirtioKeyboardConvertKeyCode (
 
     default:
       if (Dev->KeyActive[KEY_LEFTSHIFT] || Dev->KeyActive[KEY_RIGHTSHIFT]) {
-        Key->ScanCode    = MapShift[Code];
         Key->UnicodeChar = MapShift[Code];
       } else {
-        Key->ScanCode    = Map[Code];
         Key->UnicodeChar = Map[Code];
       }
 

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -312,11 +312,6 @@ VirtioKeyboardConvertKeyCode (
         KeyData->KeyState.KeyShiftState &= ~(EFI_LEFT_SHIFT_PRESSED | EFI_RIGHT_SHIFT_PRESSED);
       }
 
-      if (Dev->KeyActive[KEY_LEFTCTRL] || Dev->KeyActive[KEY_RIGHTCTRL]) {
-        // Convert Ctrl+[a-z] and Ctrl+[A-Z] into [1-26] ASCII table entries
-        Key->UnicodeChar &= 0x1F;
-      }
-
       break;
   }
 }
@@ -472,6 +467,22 @@ VirtioKeyboardReadKeyStroke (
 
     if ((KeyData.Key.ScanCode == SCAN_NULL) && (KeyData.Key.UnicodeChar == CHAR_NULL)) {
       continue;
+    }
+
+    // Since ReadKeyStroke does not allow to convey modifier state, we have to
+    // fold Ctrl into the printable character to produce a C0 control code
+    // (i.e. apply the caret notation).
+    // NB1: this is not actually in the SIMPLE_TEXT_INPUT(_EX) spec; we do it
+    //     for compatibility with other keyboard drivers and TerminalDxe.
+    // NB2: We only apply a subset of caret notation limited to alphabetic
+    //      characters, as these are idempotent wrt. Shift and CapsLock
+    //      (which are already applied at this point).
+    if (KeyData.KeyState.KeyShiftState & (EFI_LEFT_CONTROL_PRESSED | EFI_RIGHT_CONTROL_PRESSED)) {
+      if (((KeyData.Key.UnicodeChar >= 'A') && (KeyData.Key.UnicodeChar <= 'Z')) ||
+          ((KeyData.Key.UnicodeChar >= 'a') && (KeyData.Key.UnicodeChar <= 'z')))
+      {
+        KeyData.Key.UnicodeChar &= 0x1F;
+      }
     }
 
     *Key = KeyData.Key;

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -138,6 +138,13 @@ ClearEfikeyBuf (
   ZeroMem (Queue->Buffer, sizeof (Queue->Buffer));
 }
 
+STATIC
+BOOLEAN
+IsKeyRegistered (
+  IN EFI_KEY_DATA  *RegisteredData,
+  IN EFI_KEY_DATA  *InputData
+  );
+
 // -----------------------------------------------------------------------------
 // End utility functions
 // -----------------------------------------------------------------------------
@@ -369,6 +376,10 @@ VirtioKeyboardProcessEvent (
   OUT EFI_KEY_DATA      *KeyData
   )
 {
+  LIST_ENTRY                 *Link;
+  LIST_ENTRY                 *NotifyList;
+  VIRTIO_INPUT_IN_EX_NOTIFY  *CurrentNotify;
+
   //
   // Initialize the key data structure with current keyboard and toggle state
   //
@@ -386,6 +397,29 @@ VirtioKeyboardProcessEvent (
   if ((KeyData->Key.UnicodeChar == CHAR_NULL) && (KeyData->Key.ScanCode == SCAN_NULL)) {
     if (!Dev->SupportPartialKeys) {
       return EFI_NOT_READY;
+    }
+  }
+
+  //
+  // Signal KeyNotify process event if this key pressed matches any key registered.
+  //
+  NotifyList = &Dev->KeyNotifyList;
+  for (Link = GetFirstNode (NotifyList); !IsNull (NotifyList, Link); Link = GetNextNode (NotifyList, Link)) {
+    CurrentNotify = CR (
+                      Link,
+                      VIRTIO_INPUT_IN_EX_NOTIFY,
+                      NotifyEntry,
+                      VIRTIO_INPUT_SIG
+                      );
+    if (IsKeyRegistered (&CurrentNotify->KeyData, KeyData)) {
+      //
+      // The key notification function needs to run at TPL_CALLBACK
+      // while current TPL is TPL_NOTIFY. It will be invoked in
+      // KeyNotifyProcessHandler() which runs at TPL_CALLBACK.
+      //
+      PushEfikeyBufTail (&Dev->KeyQueueForNotify, KeyData);
+      gBS->SignalEvent (Dev->KeyNotifyProcessEvent);
+      break;
     }
   }
 
@@ -442,6 +476,52 @@ VirtioKeyboardHandleEvent (
 }
 
 // -----------------------------------------------------------------------------
+// Function handling key notifications
+VOID
+EFIAPI
+VirtioKeyboardNotifyHandler (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS                 Status;
+  VIRTIO_INPUT_DEV           *Dev;
+  EFI_KEY_DATA               KeyData;
+  LIST_ENTRY                 *Link;
+  LIST_ENTRY                 *NotifyList;
+  VIRTIO_INPUT_IN_EX_NOTIFY  *CurrentNotify;
+  EFI_TPL                    OldTpl;
+
+  Dev        = (VIRTIO_INPUT_DEV *)Context;
+  NotifyList = &Dev->KeyNotifyList;
+
+  while (TRUE) {
+    //
+    // Critical section
+    //
+    OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+    Status = PopEfikeyBufHead (&Dev->KeyQueueForNotify, &KeyData);
+    gBS->RestoreTPL (OldTpl);
+
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    for (Link = GetFirstNode (NotifyList); !IsNull (NotifyList, Link); Link = GetNextNode (NotifyList, Link)) {
+      CurrentNotify = CR (
+                        Link,
+                        VIRTIO_INPUT_IN_EX_NOTIFY,
+                        NotifyEntry,
+                        VIRTIO_INPUT_SIG
+                        );
+      if (IsKeyRegistered (&CurrentNotify->KeyData, &KeyData)) {
+        CurrentNotify->KeyNotificationFn (&KeyData);
+      }
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
 // EFI_SIMPLE_TEXT_INPUT_PROTOCOL API
 STATIC
 EFI_STATUS
@@ -460,6 +540,7 @@ VirtioKeyboardReset (
 
   ZeroMem (Dev->KeyActive, sizeof (Dev->KeyActive));
   ClearEfikeyBuf (&Dev->KeyQueue);
+  ClearEfikeyBuf (&Dev->KeyQueueForNotify);
 
   Dev->NumLock            = FALSE;
   Dev->CapsLock           = FALSE;
@@ -887,6 +968,46 @@ VirtioKeyboardInit (
     return Status;
   }
 
+  //
+  // Setup the key notification processing callback event
+  //
+  Status = gBS->CreateEvent (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  &VirtioKeyboardNotifyHandler,
+                  Dev,
+                  &Dev->KeyNotifyProcessEvent
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+VirtioFreeNotifyList (
+  IN OUT LIST_ENTRY  *ListHead
+  )
+{
+  VIRTIO_INPUT_IN_EX_NOTIFY  *NotifyNode;
+
+  if (ListHead == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  while (!IsListEmpty (ListHead)) {
+    NotifyNode = CR (
+                   ListHead->ForwardLink,
+                   VIRTIO_INPUT_IN_EX_NOTIFY,
+                   NotifyEntry,
+                   VIRTIO_INPUT_SIG
+                   );
+    RemoveEntryList (ListHead->ForwardLink);
+    gBS->FreePool (NotifyNode);
+  }
+
   return EFI_SUCCESS;
 }
 
@@ -897,4 +1018,6 @@ VirtioKeyboardUninit (
 {
   gBS->CloseEvent (Dev->Txt.WaitForKey);
   gBS->CloseEvent (Dev->TxtEx.WaitForKeyEx);
+  gBS->CloseEvent (Dev->KeyNotifyProcessEvent);
+  VirtioFreeNotifyList (&Dev->KeyNotifyList);
 }

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -21,6 +21,130 @@
 #include "VirtioInput.h"
 #include "VirtioKeyCodes.h"
 
+// -----------------------------------------------------------------------------
+// Utility functions
+// -----------------------------------------------------------------------------
+
+/**
+  Check whether the EFI key buffer is empty.
+
+  @param Queue     Pointer to instance of EFI_KEY_QUEUE.
+
+  @retval TRUE    The EFI key buffer is empty.
+  @retval FALSE   The EFI key buffer isn't empty.
+**/
+STATIC
+BOOLEAN
+IsEfikeyBufEmpty (
+  IN  EFI_KEY_QUEUE  *Queue
+  )
+{
+  return (BOOLEAN)(Queue->Head == Queue->Tail);
+}
+
+/**
+  Read (but do not remove) one key data entry from the EFI key buffer.
+
+  @param Queue     Pointer to instance of EFI_KEY_QUEUE.
+  @param KeyData   Receive the key data.
+
+  @retval EFI_SUCCESS   The key data is popped successfully.
+  @retval EFI_NOT_READY There is no key data available.
+**/
+STATIC
+EFI_STATUS
+PeekEfikeyBufHead (
+  IN  EFI_KEY_QUEUE  *Queue,
+  OUT EFI_KEY_DATA   *KeyData OPTIONAL
+  )
+{
+  if (IsEfikeyBufEmpty (Queue)) {
+    return EFI_NOT_READY;
+  }
+
+  if (KeyData != NULL) {
+    CopyMem (KeyData, &Queue->Buffer[Queue->Head], sizeof (EFI_KEY_DATA));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Read & remove one key data from the EFI key buffer.
+
+  @param Queue     Pointer to instance of EFI_KEY_QUEUE.
+  @param KeyData   Receive the key data.
+
+  @retval EFI_SUCCESS   The key data is popped successfully.
+  @retval EFI_NOT_READY There is no key data available.
+**/
+STATIC
+EFI_STATUS
+PopEfikeyBufHead (
+  IN  EFI_KEY_QUEUE  *Queue,
+  OUT EFI_KEY_DATA   *KeyData OPTIONAL
+  )
+{
+  if (IsEfikeyBufEmpty (Queue)) {
+    return EFI_NOT_READY;
+  }
+
+  //
+  // Retrieve and remove the values
+  //
+  if (KeyData != NULL) {
+    CopyMem (KeyData, &Queue->Buffer[Queue->Head], sizeof (EFI_KEY_DATA));
+  }
+
+  ZeroMem (&Queue->Buffer[Queue->Head], sizeof (EFI_KEY_DATA));
+  Queue->Head = (Queue->Head + 1) % KEYBOARD_EFI_KEY_MAX_COUNT;
+  return EFI_SUCCESS;
+}
+
+/**
+  Push one key data to the EFI key buffer.
+
+  @param Queue     Pointer to instance of EFI_KEY_QUEUE.
+  @param KeyData   The key data to push.
+**/
+STATIC
+VOID
+PushEfikeyBufTail (
+  IN  EFI_KEY_QUEUE  *Queue,
+  IN  EFI_KEY_DATA   *KeyData
+  )
+{
+  if ((Queue->Tail + 1) % KEYBOARD_EFI_KEY_MAX_COUNT == Queue->Head) {
+    //
+    // If Queue is full, pop the one from head.
+    //
+    PopEfikeyBufHead (Queue, NULL);
+  }
+
+  CopyMem (&Queue->Buffer[Queue->Tail], KeyData, sizeof (EFI_KEY_DATA));
+  Queue->Tail = (Queue->Tail + 1) % KEYBOARD_EFI_KEY_MAX_COUNT;
+}
+
+/**
+  Clear the EFI key queue.
+
+  @param Queue   Pointer to instance of EFI_KEY_QUEUE.
+ */
+STATIC
+VOID
+ClearEfikeyBuf (
+  IN  EFI_KEY_QUEUE  *Queue
+  )
+{
+  Queue->Head = 0;
+  Queue->Tail = 0;
+  ZeroMem (Queue->Buffer, sizeof (Queue->Buffer));
+}
+
+// -----------------------------------------------------------------------------
+// End utility functions
+// -----------------------------------------------------------------------------
+
 BOOLEAN
 VirtioKeyboardProbe (
   IN VIRTIO_INPUT_DEV  *Dev
@@ -266,10 +390,8 @@ VirtioKeyboardHandleEvent (
       return;
     }
 
-    // Flag that printable character is ready to be send
-    // TODO: turn this into a queue
-    Dev->LastKeyData = KeyData;
-    Dev->KeyReady    = TRUE;
+    // Submit this key
+    PushEfikeyBufTail (&Dev->KeyQueue, &KeyData);
   } else {
     // Key released event received
     Dev->KeyActive[(UINT8)Event->Code] = FALSE;
@@ -293,9 +415,8 @@ VirtioKeyboardReset (
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
-  Dev->KeyReady = FALSE;
-  ZeroMem (&Dev->LastKeyData, sizeof (Dev->LastKeyData));
   ZeroMem (Dev->KeyActive, sizeof (Dev->KeyActive));
+  ClearEfikeyBuf (&Dev->KeyQueue);
 
   Dev->SupportPartialKeys = FALSE;
 
@@ -315,6 +436,8 @@ VirtioKeyboardReadKeyStroke (
 {
   VIRTIO_INPUT_DEV  *Dev;
   EFI_TPL           OldTpl;
+  EFI_KEY_DATA      KeyData;
+  EFI_STATUS        Status;
 
   if (Key == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -323,20 +446,13 @@ VirtioKeyboardReadKeyStroke (
   Dev = VIRTIO_INPUT_FROM_THIS (This);
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
-  if (Dev->KeyReady) {
-    // Get last key from the buffer
-    *Key = Dev->LastKeyData.Key;
 
-    // Mark key as consumed
-    Dev->KeyReady = FALSE;
-
-    gBS->RestoreTPL (OldTpl);
-    return EFI_SUCCESS;
-  }
+  Status = PopEfikeyBufHead (&Dev->KeyQueue, &KeyData);
+  *Key   = KeyData.Key;
 
   gBS->RestoreTPL (OldTpl);
 
-  return EFI_NOT_READY;
+  return Status;
 }
 
 // -----------------------------------------------------------------------------
@@ -350,6 +466,7 @@ VirtioKeyboardWaitForKey (
   )
 {
   VIRTIO_INPUT_DEV  *Dev = (VIRTIO_INPUT_DEV *)Context;
+  EFI_TPL           OldTpl;
 
   //
   // Stall 1ms to give a chance to let other driver interrupt this routine
@@ -366,10 +483,14 @@ VirtioKeyboardWaitForKey (
   // Use TimerEvent callback function to check whether there's any key pressed
   VirtioInputTimer (NULL, Dev);
 
+  OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+
   // If there is a new key ready - send signal
-  if (Dev->KeyReady) {
+  if (!IsEfikeyBufEmpty (&Dev->KeyQueue)) {
     gBS->SignalEvent (Event);
   }
+
+  gBS->RestoreTPL (OldTpl);
 }
 
 /// -----------------------------------------------------------------------------
@@ -411,6 +532,7 @@ VirtioKeyboardReadKeyStrokeEx (
 {
   VIRTIO_INPUT_DEV  *Dev;
   EFI_TPL           OldTpl;
+  EFI_STATUS        Status;
 
   if (KeyData == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -419,19 +541,12 @@ VirtioKeyboardReadKeyStrokeEx (
   Dev = VIRTIO_INPUT_EX_FROM_THIS (This);
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
-  if (Dev->KeyReady) {
-    // Get last key from the buffer
-    *KeyData = Dev->LastKeyData;
 
-    // Mark key as consumed
-    Dev->KeyReady = FALSE;
-
-    gBS->RestoreTPL (OldTpl);
-    return EFI_SUCCESS;
-  }
+  Status = PopEfikeyBufHead (&Dev->KeyQueue, KeyData);
 
   gBS->RestoreTPL (OldTpl);
-  return EFI_NOT_READY;
+
+  return Status;
 }
 
 // -----------------------------------------------------------------------------

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -185,6 +185,67 @@ VirtioKeyboardConvertKeyCode (
 }
 
 // -----------------------------------------------------------------------------
+// Function populating modifier and toggle state of an UEFI key event
+STATIC
+VOID
+VirtioKeyboardInitializeKeyState (
+  IN  VIRTIO_INPUT_DEV  *Dev,
+  OUT EFI_KEY_STATE     *KeyState
+  )
+{
+  KeyState->KeyShiftState = (
+                             (Dev->KeyActive[KEY_RIGHTSHIFT] ? EFI_RIGHT_SHIFT_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_LEFTSHIFT] ? EFI_LEFT_SHIFT_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_RIGHTCTRL] ? EFI_RIGHT_CONTROL_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_LEFTCTRL] ? EFI_LEFT_CONTROL_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_RIGHTALT] ? EFI_RIGHT_ALT_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_LEFTALT] ? EFI_LEFT_ALT_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_RIGHTMETA] ? EFI_RIGHT_LOGO_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_LEFTMETA] ? EFI_LEFT_LOGO_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_COMPOSE] ? EFI_MENU_KEY_PRESSED : 0) |
+                             (Dev->KeyActive[KEY_SYSRQ] ? EFI_SYS_REQ_PRESSED : 0) |
+                             EFI_SHIFT_STATE_VALID
+                             );
+
+  KeyState->KeyToggleState = (
+                              (Dev->SupportPartialKeys ? EFI_KEY_STATE_EXPOSED : 0) |
+                              EFI_TOGGLE_STATE_VALID
+                              );
+}
+
+// -----------------------------------------------------------------------------
+// Function processing a single VirtIO keyboard event into a complete UEFI event
+STATIC
+EFI_STATUS
+VirtioKeyboardProcessEvent (
+  IN  VIRTIO_INPUT_DEV  *Dev,
+  IN  UINT16            KeyCode,
+  OUT EFI_KEY_DATA      *KeyData
+  )
+{
+  //
+  // Translate the virtio scancode into EFI scancode and Unicode char
+  //
+  VirtioKeyboardConvertKeyCode (Dev, KeyCode, &KeyData->Key);
+
+  //
+  // Keys with no Unicode representation and no EFI scancode are not valid,
+  // unless we were requested to process partial keys
+  //
+  if ((KeyData->Key.UnicodeChar == CHAR_NULL) && (KeyData->Key.ScanCode == SCAN_NULL)) {
+    if (!Dev->SupportPartialKeys) {
+      return EFI_NOT_READY;
+    }
+  }
+
+  //
+  // Complete the key data structure with current keyboard state (active modifiers)
+  //
+  VirtioKeyboardInitializeKeyState (Dev, &KeyData->KeyState);
+  return EFI_SUCCESS;
+}
+
+// -----------------------------------------------------------------------------
 // Function handling VirtIO keyboard events
 VOID
 VirtioKeyboardHandleEvent (
@@ -192,15 +253,23 @@ VirtioKeyboardHandleEvent (
   IN VIRTIO_INPUT_EVENT    *Event
   )
 {
+  EFI_STATUS    Status;
+  EFI_KEY_DATA  KeyData;
+
   if (Event->Value != KEY_RELEASED) {
     // Key pressed event received
     Dev->KeyActive[(UINT8)Event->Code] = TRUE;
 
     // Evaluate key
-    VirtioKeyboardConvertKeyCode (Dev, Event->Code, &Dev->LastKey);
+    Status = VirtioKeyboardProcessEvent (Dev, Event->Code, &KeyData);
+    if (EFI_ERROR (Status)) {
+      return;
+    }
 
     // Flag that printable character is ready to be send
-    Dev->KeyReady = TRUE;
+    // TODO: turn this into a queue
+    Dev->LastKeyData = KeyData;
+    Dev->KeyReady    = TRUE;
   } else {
     // Key released event received
     Dev->KeyActive[(UINT8)Event->Code] = FALSE;
@@ -224,10 +293,11 @@ VirtioKeyboardReset (
 
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
 
-  Dev->KeyReady            = FALSE;
-  Dev->LastKey.ScanCode    = SCAN_NULL;
-  Dev->LastKey.UnicodeChar = CHAR_NULL;
+  Dev->KeyReady = FALSE;
+  ZeroMem (&Dev->LastKeyData, sizeof (Dev->LastKeyData));
   ZeroMem (Dev->KeyActive, sizeof (Dev->KeyActive));
+
+  Dev->SupportPartialKeys = FALSE;
 
   gBS->RestoreTPL (OldTpl);
   return EFI_SUCCESS;
@@ -255,7 +325,7 @@ VirtioKeyboardReadKeyStroke (
   OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
   if (Dev->KeyReady) {
     // Get last key from the buffer
-    *Key = Dev->LastKey;
+    *Key = Dev->LastKeyData.Key;
 
     // Mark key as consumed
     Dev->KeyReady = FALSE;
@@ -340,9 +410,7 @@ VirtioKeyboardReadKeyStrokeEx (
   )
 {
   VIRTIO_INPUT_DEV  *Dev;
-  EFI_STATUS        Status;
-  EFI_INPUT_KEY     Key;
-  EFI_KEY_STATE     KeyState;
+  EFI_TPL           OldTpl;
 
   if (KeyData == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -350,48 +418,20 @@ VirtioKeyboardReadKeyStrokeEx (
 
   Dev = VIRTIO_INPUT_EX_FROM_THIS (This);
 
-  // Get the last pressed key
-  Status = Dev->Txt.ReadKeyStroke (&Dev->Txt, &Key);
-  if (EFI_ERROR (Status)) {
-    return EFI_DEVICE_ERROR;
+  OldTpl = gBS->RaiseTPL (TPL_NOTIFY);
+  if (Dev->KeyReady) {
+    // Get last key from the buffer
+    *KeyData = Dev->LastKeyData;
+
+    // Mark key as consumed
+    Dev->KeyReady = FALSE;
+
+    gBS->RestoreTPL (OldTpl);
+    return EFI_SUCCESS;
   }
 
-  // Add key state informations
-  KeyState.KeyShiftState  = EFI_SHIFT_STATE_VALID;
-  KeyState.KeyToggleState = EFI_TOGGLE_STATE_VALID;
-
-  // Shift key modifier
-  if (Dev->KeyActive[KEY_LEFTSHIFT]) {
-    KeyState.KeyShiftState |= EFI_LEFT_SHIFT_PRESSED;
-  }
-
-  if (Dev->KeyActive[KEY_RIGHTSHIFT]) {
-    KeyState.KeyShiftState |= EFI_RIGHT_SHIFT_PRESSED;
-  }
-
-  // Ctrl key modifier
-  if (Dev->KeyActive[KEY_LEFTCTRL]) {
-    KeyState.KeyShiftState |= EFI_LEFT_CONTROL_PRESSED;
-  }
-
-  if (Dev->KeyActive[KEY_RIGHTCTRL]) {
-    KeyState.KeyShiftState |= EFI_RIGHT_CONTROL_PRESSED;
-  }
-
-  // ALt key modifier
-  if (Dev->KeyActive[KEY_LEFTALT]) {
-    KeyState.KeyShiftState |= EFI_LEFT_ALT_PRESSED;
-  }
-
-  if (Dev->KeyActive[KEY_RIGHTALT]) {
-    KeyState.KeyShiftState |= EFI_RIGHT_ALT_PRESSED;
-  }
-
-  // Return value only when there is no failure
-  KeyData->Key      = Key;
-  KeyData->KeyState = KeyState;
-
-  return EFI_SUCCESS;
+  gBS->RestoreTPL (OldTpl);
+  return EFI_NOT_READY;
 }
 
 // -----------------------------------------------------------------------------
@@ -404,9 +444,19 @@ VirtioKeyboardSetStateEx (
   IN EFI_KEY_TOGGLE_STATE               *KeyToggleState
   )
 {
+  VIRTIO_INPUT_DEV  *Dev;
+
   if (KeyToggleState == NULL) {
     return EFI_INVALID_PARAMETER;
   }
+
+  Dev = VIRTIO_INPUT_EX_FROM_THIS (This);
+
+  if (!(*KeyToggleState & EFI_TOGGLE_STATE_VALID)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Dev->SupportPartialKeys = (BOOLEAN)((*KeyToggleState & EFI_KEY_STATE_EXPOSED) != 0);
 
   return EFI_SUCCESS;
 }

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -180,7 +180,7 @@ VOID
 VirtioKeyboardConvertKeyCode (
   IN OUT VIRTIO_INPUT_DEV  *Dev,
   IN UINT16                Code,
-  OUT EFI_INPUT_KEY        *Key
+  OUT EFI_KEY_DATA         *KeyData
   )
 {
   // Key mapping in between Linux and UEFI
@@ -215,6 +215,8 @@ VirtioKeyboardConvertKeyCode (
     [KEY_SPACE]         = ' ',
     [MAX_KEYBOARD_CODE] = 0x00
   };
+
+  EFI_INPUT_KEY  *Key = &KeyData->Key;
 
   // Set default readings
   Key->ScanCode    = SCAN_NULL;
@@ -296,6 +298,20 @@ VirtioKeyboardConvertKeyCode (
         Key->UnicodeChar = Map[Code];
       }
 
+      // If this key cannot be mapped to either a scancode or a printable character, return
+      if (Key->UnicodeChar == CHAR_NULL) {
+        return;
+      }
+
+      // If we are processing a shiftable character, clear the explicit shift state (if any)
+      // because it is now reflected in the character representation itself.
+      // "if a class of printable characters that are normally adjusted by shift modifiers
+      // (e.g. Shift Key + “f” key) would be presented solely as a KeyData.Key.UnicodeChar
+      // without the associated shift state."
+      if (MapShift[Code] != Map[Code]) {
+        KeyData->KeyState.KeyShiftState &= ~(EFI_LEFT_SHIFT_PRESSED | EFI_RIGHT_SHIFT_PRESSED);
+      }
+
       if (Dev->KeyActive[KEY_LEFTCTRL] || Dev->KeyActive[KEY_RIGHTCTRL]) {
         // Convert Ctrl+[a-z] and Ctrl+[A-Z] into [1-26] ASCII table entries
         Key->UnicodeChar &= 0x1F;
@@ -345,9 +361,14 @@ VirtioKeyboardProcessEvent (
   )
 {
   //
+  // Initialize the key data structure with current keyboard and toggle state
+  //
+  VirtioKeyboardInitializeKeyState (Dev, &KeyData->KeyState);
+
+  //
   // Translate the virtio scancode into EFI scancode and Unicode char
   //
-  VirtioKeyboardConvertKeyCode (Dev, KeyCode, &KeyData->Key);
+  VirtioKeyboardConvertKeyCode (Dev, KeyCode, KeyData);
 
   //
   // Keys with no Unicode representation and no EFI scancode are not valid,
@@ -359,10 +380,6 @@ VirtioKeyboardProcessEvent (
     }
   }
 
-  //
-  // Complete the key data structure with current keyboard state (active modifiers)
-  //
-  VirtioKeyboardInitializeKeyState (Dev, &KeyData->KeyState);
   return EFI_SUCCESS;
 }
 

--- a/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioKeyboard.c
@@ -170,10 +170,8 @@ VirtioKeyboardConvertKeyCode (
 
     default:
       if (Dev->KeyActive[KEY_LEFTSHIFT] || Dev->KeyActive[KEY_RIGHTSHIFT]) {
-        Key->ScanCode    = MapShift[Code];
         Key->UnicodeChar = MapShift[Code];
       } else {
-        Key->ScanCode    = Map[Code];
         Key->UnicodeChar = Map[Code];
       }
 

--- a/OvmfPkg/VirtioInputDxe/VirtioMouse.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioMouse.c
@@ -11,9 +11,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/UefiBootServicesTableLib.h>
-#include <Library/VirtioLib.h>
-
-#include <IndustryStandard/VirtioInput.h>
 
 #include "VirtioInput.h"
 #include "VirtioKeyCodes.h"

--- a/OvmfPkg/VirtioInputDxe/VirtioTablet.c
+++ b/OvmfPkg/VirtioInputDxe/VirtioTablet.c
@@ -11,9 +11,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/UefiBootServicesTableLib.h>
-#include <Library/VirtioLib.h>
-
-#include <IndustryStandard/VirtioInput.h>
 
 #include "VirtioInput.h"
 #include "VirtioKeyCodes.h"


### PR DESCRIPTION
# Description

Presently, VirtioInputDxe accepts key notifications (RegisterKeyNotifyEx) but does not act upon them. Despite ConSplitter correctly registering notifications via all input devices (including PS/2 etc. devices that implement key notifications correctly), emulators such as QEMU stop sending input to non-virtio keyboards as soon as the virtio device is claimed.

As a result, preboot hotkeys are non-functional when virtio is used.

Fixes: #12887.

---

Additionally, a number of spec compliance issues were fixed in keyboard part of VirtioInputDxe:
- `->ScanCode` field is handled correctly
- key modifiers, key state and partial keystrokes are handled correctly, along with `EFI_KEY_STATE_EXPOSED`
- toggle state (*Lock keys) is now honored and handled
- Ctrl key handling (caret notation) is now applied only in ReadKeyStroke, mimicking other keyboard drivers
  (it is not in the `SIMPLE_TEXT_INPUT` spec, so I treated it as a compatibility thing)
- Ctrl-Alt-Del handling was added, while at it

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Manually tested in x86\_64 QEMU.

## Integration Instructions

N/A
