### PR TITLE
3945_arm_cca_v5_s7: Enable Arm Confidential Compute Architecture (CCA) support for the Kvmtool guest firmware.

### DIFF
--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -221,6 +221,7 @@
   #
   ArmVirtPkg/PrePi/ArmVirtPrePiUniCoreRelocatable.inf {
     <LibraryClasses>
+      DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
       ExtractGuidedSectionLib|EmbeddedPkg/Library/PrePiExtractGuidedSectionLib/PrePiExtractGuidedSectionLib.inf
       NULL|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
       PrePiLib|EmbeddedPkg/Library/PrePiLib/PrePiLib.inf

--- a/ArmVirtPkg/ArmVirtKvmTool.dsc
+++ b/ArmVirtPkg/ArmVirtKvmTool.dsc
@@ -73,6 +73,12 @@
 
   ArmCcaBootSyncCryptoLib|ArmVirtPkg/Library/ArmCcaBootSyncCryptoLib/ArmCcaBootSyncCryptoLib.inf
 
+  ArmCcaLib|ArmVirtPkg/Library/ArmCcaLib/ArmCcaLib.inf
+  ArmCcaRsiLib|ArmVirtPkg/Library/ArmCcaRsiLib/ArmCcaRsiLib.inf
+
+[LibraryClasses.common.SEC]
+  ArmCcaInitPeiLib|ArmVirtPkg/Library/ArmCcaInitPeiLib/ArmCcaInitPeiLib.inf
+
 [LibraryClasses.common.SEC, LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM]
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
   PlatformHookLib|ArmVirtPkg/Library/Fdt16550SerialPortHookLib/EarlyFdt16550SerialPortHookLib.inf

--- a/ArmVirtPkg/PrePi/ArmVirtPrePiUniCoreRelocatable.inf
+++ b/ArmVirtPkg/PrePi/ArmVirtPrePiUniCoreRelocatable.inf
@@ -1,6 +1,6 @@
 #/** @file
 #
-#  Copyright (c) 2011-2015, ARM Ltd. All rights reserved.<BR>
+#  Copyright (c) 2011-2023, Arm Limited. All rights reserved.<BR>
 #  Copyright (c) 2015, Linaro Ltd. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -32,6 +32,7 @@
   OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]
+  ArmCcaInitPeiLib
   BaseLib
   BaseMemoryLib
   DebugLib

--- a/ArmVirtPkg/PrePi/ModuleEntryPoint.S
+++ b/ArmVirtPkg/PrePi/ModuleEntryPoint.S
@@ -32,6 +32,11 @@ ASM_FUNC(_ModuleEntryPoint)
 
   bl    ASM_PFX(DiscoverDramFromDt)
 
+  // Use the temporary stack set up by DiscoverDramFromDt
+  // to determine whether we are in a Realm. If so,
+  // configure System Memory as Protected RAM.
+  bl    ASM_PFX(ArmCcaConfigureSystemMemory)
+
   // Get ID of this CPU in Multicore system
   bl    ASM_PFX(ArmReadMpidr)
   // Keep a copy of the MpId register value

--- a/ArmVirtPkg/PrePi/ModuleEntryPoint.S
+++ b/ArmVirtPkg/PrePi/ModuleEntryPoint.S
@@ -32,6 +32,10 @@ ASM_FUNC(_ModuleEntryPoint)
 
   bl    ASM_PFX(DiscoverDramFromDt)
 
+  // Check if we are in a Realm and configure
+  // the System Memory as Protected RAM.
+  bl    ASM_PFX(ArmCcaConfigureSystemMemory)
+
   // Get ID of this CPU in Multicore system
   bl    ASM_PFX(ArmReadMpidr)
   // Keep a copy of the MpId register value


### PR DESCRIPTION
# Description

Enable Arm Confidential Compute Architecture (CCA) support for the Kvmtool guest firmware.

When a Realm is created, only the memory containing the initial firmware image is configured as Protected RAM. The remaining system memory is initially in the Protected Empty state and must be transitioned to Protected RAM before the firmware can access it.

This change:

* Calls `ArmCcaConfigureSystemMemory()` during the early PrePi phase, after discovering the system memory from the device tree.

* Adds the `ArmCcaInitPeiLib`, `ArmCcaLib`, and `ArmCcaRsiLib` instances to the `ArmVirtKvmTool` firmware configuration.

* Uses the Null instance of `DebugLib` in PrePi. This prevents the serial-port constructor from accessing MMIO before the MMU is enabled and the Realm MMIO regions can be configured as unprotected.

* Uses Null library implementations where appropriate so that the changes do not affect non-CCA Kvmtool guests.

Note: This is a PR sub-series of the Arm CCA Support series at https://github.com/tianocore/edk2/pull/12224

* [ ] Breaking change?

  * **Breaking change** - Does this PR cause a break in build or boot behavior?
  * Examples: Does it add a new library class or move a module to a different repo.
  * If checked, follow the [[Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md)](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).

* [ ] Impacts security?

  * **Security** - Does this PR have a direct security impact?
  * Examples: Crypto algorithm change or buffer overflow fix.

* [ ] Includes tests?

  * **Tests** - Does this PR include any explicit test code?
  * Examples: Unit tests or integration tests.

## How This Was Tested

* Only build tested. Actual functionality can only be tested once the remaining PRs in https://github.com/tianocore/edk2/pull/12224 are merged.

## Integration Instructions

This PR depends on the preceding Arm CCA library patches that introduce `ArmCcaInitPeiLib`, `ArmCcaLib`, and `ArmCcaRsiLib`.

No additional integration steps are required.
