### PR TITLE
3945_arm_cca_v5_s13: Add DMA sharing and image measurement for CCA for ArmVirtQemu

### DIFF
--- a/ArmVirtPkg/ArmVirtPkg.ci.yaml
+++ b/ArmVirtPkg/ArmVirtPkg.ci.yaml
@@ -44,6 +44,7 @@
     ## options defined .pytool/Plugin/DependencyCheck
     "DependencyCheck": {
         "AcceptableDependencies": [
+            "CryptoPkg/CryptoPkg.dec",
             "MdePkg/MdePkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
             "ArmVirtPkg/ArmVirtPkg.dec",

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -94,6 +94,7 @@
 !endif
 
   ArmPlatformLib|ArmVirtPkg/Library/ArmPlatformLibQemu/ArmPlatformLibQemu.inf
+  BlobVerifierLib|ArmVirtPkg/Library/BlobVerifierLibArmCca/BlobVerifierLibArmCca.inf
 
 [LibraryClasses.common.PEIM]
   ArmVirtMemInfoLib|ArmVirtPkg/Library/QemuVirtMemInfoLib/QemuVirtMemInfoPeiLib.inf
@@ -443,7 +444,7 @@
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
   OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf {
     <LibraryClasses>
-      NULL|OvmfPkg/Library/BlobVerifierLibNull/BlobVerifierLibNull.inf
+      NULL|ArmVirtPkg/Library/BlobVerifierLibArmCca/BlobVerifierLibArmCca.inf
   }
 
   #

--- a/ArmVirtPkg/ArmVirtQemu.dsc
+++ b/ArmVirtPkg/ArmVirtQemu.dsc
@@ -515,3 +515,13 @@
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   }
+
+  #
+  # Realm Aperture Management
+  #
+  ArmVirtPkg/RealmApertureManagementProtocolDxe/RealmApertureManagementProtocolDxe.inf
+
+  #
+  # IoMMU support for Arm CCA
+  #
+  ArmVirtPkg/ArmCcaIoMmuDxe/ArmCcaIoMmuDxe.inf

--- a/ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc
+++ b/ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc
@@ -154,6 +154,16 @@ READ_LOCK_STATUS   = TRUE
   INF OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 
   #
+  # Realm Aperture Management
+  #
+  INF ArmVirtPkg/RealmApertureManagementProtocolDxe/RealmApertureManagementProtocolDxe.inf
+
+  #
+  # IoMMU support for Arm CCA
+  #
+  INF ArmVirtPkg/ArmCcaIoMmuDxe/ArmCcaIoMmuDxe.inf
+
+  #
   # PCI support
   #
   INF UefiCpuPkg/CpuMmio2Dxe/CpuMmio2Dxe.inf

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -55,6 +55,7 @@
 !include ArmVirtPkg/ArmVirt.dsc.inc
 
 [LibraryClasses.common]
+  BlobVerifierLib|ArmVirtPkg/Library/BlobVerifierLibArmCca/BlobVerifierLibArmCca.inf
 
   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioDxeLib.inf
   QemuFwCfgS3Lib|OvmfPkg/Library/QemuFwCfgS3Lib/BaseQemuFwCfgS3LibNull.inf
@@ -329,7 +330,7 @@
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
   OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf {
     <LibraryClasses>
-      NULL|OvmfPkg/Library/BlobVerifierLibNull/BlobVerifierLibNull.inf
+      NULL|ArmVirtPkg/Library/BlobVerifierLibArmCca/BlobVerifierLibArmCca.inf
   }
 
   #

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -381,3 +381,13 @@
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf
   }
+
+  #
+  # Realm Aperture Management
+  #
+  ArmVirtPkg/RealmApertureManagementProtocolDxe/RealmApertureManagementProtocolDxe.inf
+
+  #
+  # IoMMU support for Arm CCA
+  #
+  ArmVirtPkg/ArmCcaIoMmuDxe/ArmCcaIoMmuDxe.inf

--- a/ArmVirtPkg/Library/BlobVerifierLibArmCca/BlobVerifierLibArmCca.c
+++ b/ArmVirtPkg/Library/BlobVerifierLibArmCca/BlobVerifierLibArmCca.c
@@ -1,0 +1,100 @@
+/** @file
+
+  Blob verifier library that uses Arm CCA measurements.
+
+  Copyright (C) 2023, Linaro Ltd
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/ArmCcaLib.h>
+#include <Library/ArmCcaRsiLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseCryptLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BlobVerifierLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+/**
+  Add Blob to the Extended Realm Measurement
+
+  @param[in] BlobName           The name of the blob
+  @param[in] Buf                The data of the blob
+  @param[in] BufSize            The size of the blob in bytes
+  @param[in] FetchStatus        The status of fetching this blob
+
+  @retval EFI_SUCCESS           The blob was verified successfully or was not
+                                found in the hash table.
+  @retval EFI_ACCESS_DENIED     Kernel hashes not supported but the boot can
+                                continue safely.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_INVALID_PARAMETER A parameter was invalid.
+**/
+EFI_STATUS
+EFIAPI
+VerifyBlob (
+  IN  CONST CHAR16  *BlobName,
+  IN  CONST VOID    *Buf,
+  IN  UINT32        BufSize,
+  IN  EFI_STATUS    FetchStatus
+  )
+{
+  EFI_STATUS            Status;
+  UINT8                 Hash[SHA512_DIGEST_SIZE];
+  RETURN_STATUS         RetStatus;
+  ARM_CCA_REALM_CONFIG  *Config;
+  UINTN                 HashLen;
+
+  /* If fetch failed, then the REM will be wrong */
+  if (EFI_ERROR (FetchStatus)) {
+    return FetchStatus;
+  }
+
+  if ((BufSize == 0) || !ArmCcaIsRealm ()) {
+    return EFI_SUCCESS;
+  }
+
+  Config = (ARM_CCA_REALM_CONFIG *)AllocateAlignedPages (
+                                     EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_REALM_CONFIG)),
+                                     ARM_CCA_REALM_GRANULE_SIZE
+                                     );
+  if (Config == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (Config, sizeof (ARM_CCA_REALM_CONFIG));
+
+  RetStatus = ArmCcaRsiGetRealmConfig (Config);
+  if (RETURN_ERROR (RetStatus)) {
+    ASSERT (0);
+    Status = (EFI_STATUS)RetStatus;
+    goto ErrorHandler;
+  }
+
+  DEBUG ((
+    DEBUG_VERBOSE,
+    "%a: adding measurement of '%s' (%d)\n",
+    __func__,
+    BlobName,
+    BufSize
+    ));
+
+  if (Config->HashAlgorithm == ARM_CCA_RSI_HASH_SHA_256) {
+    Sha256HashAll (Buf, BufSize, Hash);
+    HashLen = SHA256_DIGEST_SIZE;
+  } else if (Config->HashAlgorithm == ARM_CCA_RSI_HASH_SHA_512) {
+    Sha512HashAll (Buf, BufSize, Hash);
+    HashLen = SHA512_DIGEST_SIZE;
+  } else {
+    Status = EFI_INVALID_PARAMETER;
+    goto ErrorHandler;
+  }
+
+  Status = ArmCcaRsiExtendMeasurement (1, Hash, HashLen);
+  ASSERT_EFI_ERROR (Status);
+
+ErrorHandler:
+  FreeAlignedPages (Config, EFI_SIZE_TO_PAGES (sizeof (ARM_CCA_REALM_CONFIG)));
+  return Status;
+}

--- a/ArmVirtPkg/Library/BlobVerifierLibArmCca/BlobVerifierLibArmCca.inf
+++ b/ArmVirtPkg/Library/BlobVerifierLibArmCca/BlobVerifierLibArmCca.inf
@@ -1,0 +1,33 @@
+## @file
+#  Blob verifier library that uses Arm CCA measurements.
+#
+#  Copyright (C) 2023, Linaro Ltd
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = BlobVerifierLibArmCca
+  FILE_GUID                      = 98e08845-885a-4f22-8b46-c85d98ac6dc2
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BlobVerifierLib
+
+[Sources]
+  BlobVerifierLibArmCca.c
+
+[Packages]
+  ArmVirtPkg/ArmVirtPkg.dec
+  CryptoPkg/CryptoPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses]
+  ArmCcaLib
+  ArmCcaRsiLib
+  BaseCryptLib
+  DebugLib
+

--- a/OvmfPkg/IoMmuAbsentDxe/IoMmuAbsentDxe.c
+++ b/OvmfPkg/IoMmuAbsentDxe/IoMmuAbsentDxe.c
@@ -1,0 +1,41 @@
+/** @file
+
+  IoMmuDxe driver that installs gIoMmuAbsentProtocolGuid for
+  guest VMs for which confidential computing support has not
+  yet been enabled.
+
+  Copyright (c) 2017, AMD Inc. All rights reserved.<BR>
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+EFI_STATUS
+EFIAPI
+IoMmuAbsentDxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  EFI_HANDLE  Handle;
+
+  Handle = NULL;
+
+  //
+  // For Guest VMs for which CC is not yet enabled
+  // install the gIoMmuAbsentProtocolGuid for dependent
+  // modules to continue to load.
+  //
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &Handle,
+                  &gIoMmuAbsentProtocolGuid,
+                  NULL,
+                  NULL
+                  );
+  return Status;
+}

--- a/OvmfPkg/IoMmuAbsentDxe/IoMmuAbsentDxe.inf
+++ b/OvmfPkg/IoMmuAbsentDxe/IoMmuAbsentDxe.inf
@@ -1,0 +1,41 @@
+#/** @file
+#
+#  Driver provides the IOMMU Absent protcol support
+#  for PciHostBridgeIo and others drivers for
+#  guest VMs for which confidential computing support
+#  has not yet been enabled.
+#
+#  Copyright (c) 2017, AMD Inc. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 1.25
+  BASE_NAME                      = IoMmuAbsentDxe
+  FILE_GUID                      = 00b68c72-1ae5-49ee-ae28-47a307367b93
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = IoMmuAbsentDxeEntryPoint
+
+[Sources.RISCV64, Sources.LOONGARCH64]
+  IoMmuAbsentDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  OvmfPkg/OvmfPkg.dec
+
+[LibraryClasses.common]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+
+[Protocols]
+  gIoMmuAbsentProtocolGuid                    ## SOMETIME_PRODUCES
+
+[Depex]
+  TRUE

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibMmio.c
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibMmio.c
@@ -23,6 +23,7 @@
 #include <Library/UefiBootServicesTableLib.h>
 
 #include <Protocol/FdtClient.h>
+#include <Protocol/IoMmu.h>
 
 #include "QemuFwCfgLibMmioInternal.h"
 
@@ -32,6 +33,19 @@
 READ_BYTES_FUNCTION   *InternalQemuFwCfgReadBytes  = MmioReadBytes;
 WRITE_BYTES_FUNCTION  *InternalQemuFwCfgWriteBytes = MmioWriteBytes;
 SKIP_BYTES_FUNCTION   *InternalQemuFwCfgSkipBytes  = MmioSkipBytes;
+
+STATIC EDKII_IOMMU_PROTOCOL  *mIoMmuProtocol;
+
+/**
+  Initialize the IOMMU protocol
+**/
+RETURN_STATUS
+InternalInitIoMmu (
+  VOID
+  )
+{
+  return gBS->LocateProtocol (&gEdkiiIoMmuProtocolGuid, NULL, (VOID **)&mIoMmuProtocol);
+}
 
 /**
   Build firmware configure resource HOB.
@@ -191,8 +205,16 @@ DmaTransferBytes (
   IN     UINT32  Control
   )
 {
-  volatile FW_CFG_DMA_ACCESS  Access;
+  FW_CFG_DMA_ACCESS           LocalAccess;
+  UINTN                       AccessSize;
+  UINTN                       BufferSize;
+  volatile FW_CFG_DMA_ACCESS  *Access;
   UINT32                      Status;
+  EFI_PHYSICAL_ADDRESS        BufferDeviceAddress;
+  EFI_PHYSICAL_ADDRESS        AccessDeviceAddress = 0;
+  VOID                        *AccessMapping;
+  VOID                        *BufferMapping;
+  EFI_STATUS                  RetStatus;
 
   ASSERT (
     Control == FW_CFG_DMA_CTL_WRITE || Control == FW_CFG_DMA_CTL_READ ||
@@ -205,9 +227,85 @@ DmaTransferBytes (
 
   ASSERT (Size <= MAX_UINT32);
 
-  Access.Control = SwapBytes32 (Control);
-  Access.Length  = SwapBytes32 ((UINT32)Size);
-  Access.Address = SwapBytes64 ((UINT64)(UINTN)Buffer);
+  if (mIoMmuProtocol) {
+    RetStatus = mIoMmuProtocol->AllocateBuffer (
+                                  mIoMmuProtocol,
+                                  AllocateAnyPages,
+                                  EfiBootServicesData,
+                                  1,
+                                  (VOID **)&Access,
+                                  EDKII_IOMMU_ATTRIBUTE_MEMORY_CACHED
+                                  );
+    if (EFI_ERROR (RetStatus)) {
+      ASSERT_EFI_ERROR (RetStatus);
+      return;
+    }
+
+    AccessSize = sizeof (FW_CFG_DMA_ACCESS);
+    RetStatus  = mIoMmuProtocol->Map (
+                                   mIoMmuProtocol,
+                                   EdkiiIoMmuOperationBusMasterCommonBuffer64,
+                                   (VOID *)Access,
+                                   &AccessSize,
+                                   &AccessDeviceAddress,
+                                   &AccessMapping
+                                   );
+    DEBUG ((
+      DEBUG_VERBOSE,
+      "Map access %r %p 0x%llx 0x%llx\n",
+      RetStatus,
+      Access,
+      AccessSize,
+      AccessDeviceAddress
+      ));
+    if (EFI_ERROR (RetStatus)) {
+      ASSERT_EFI_ERROR (RetStatus);
+      mIoMmuProtocol->FreeBuffer (mIoMmuProtocol, 1, (VOID *)Access);
+      return;
+    }
+
+    if (Control & (FW_CFG_DMA_CTL_READ | FW_CFG_DMA_CTL_WRITE)) {
+      BufferSize = Size;
+      RetStatus  = mIoMmuProtocol->Map (
+                                     mIoMmuProtocol,
+                                     Control & FW_CFG_DMA_CTL_WRITE ?
+                                     /* CTL_WRITE is device read */
+                                     EdkiiIoMmuOperationBusMasterRead64 :
+                                     EdkiiIoMmuOperationBusMasterWrite64,
+                                     Buffer,
+                                     &BufferSize,
+                                     &BufferDeviceAddress,
+                                     &BufferMapping
+                                     );
+      DEBUG ((
+        DEBUG_VERBOSE,
+        "Map buffer %r %p 0x%llx 0x%llx\n",
+        RetStatus,
+        Buffer,
+        BufferSize,
+        BufferDeviceAddress
+        ));
+      if (EFI_ERROR (RetStatus)) {
+        ASSERT_EFI_ERROR (RetStatus);
+        mIoMmuProtocol->Unmap (mIoMmuProtocol, AccessMapping);
+        mIoMmuProtocol->FreeBuffer (mIoMmuProtocol, 1, (VOID *)Access);
+        return;
+      }
+    } else {
+      // If the Control is FW_CFG_DMA_CTL_SKIP, we do not expect any read/write
+      // operation. So pass NULL here.
+      BufferDeviceAddress = 0;
+      BufferMapping       = NULL;
+    }
+  } else {
+    Access              = &LocalAccess;
+    AccessDeviceAddress = (EFI_PHYSICAL_ADDRESS)&LocalAccess;
+    BufferDeviceAddress = (EFI_PHYSICAL_ADDRESS)Buffer;
+  }
+
+  Access->Control = SwapBytes32 (Control);
+  Access->Length  = SwapBytes32 ((UINT32)Size);
+  Access->Address = SwapBytes64 ((UINT64)BufferDeviceAddress);
 
   //
   // We shouldn't start the transfer before setting up Access.
@@ -218,9 +316,9 @@ DmaTransferBytes (
   // This will fire off the transfer.
   //
  #if defined (MDE_CPU_AARCH64) || defined (MDE_CPU_RISCV64) || defined (MDE_CPU_LOONGARCH64)
-  MmioWrite64 (QemuGetFwCfgDmaAddress (), SwapBytes64 ((UINT64)&Access));
+  MmioWrite64 (QemuGetFwCfgDmaAddress (), SwapBytes64 ((UINT64)AccessDeviceAddress));
  #else
-  MmioWrite32 ((UINT32)(QemuGetFwCfgDmaAddress () + 4), SwapBytes32 ((UINT32)&Access));
+  MmioWrite32 ((UINT32)(QemuGetFwCfgDmaAddress () + 4), SwapBytes32 ((UINT32)AccessDeviceAddress));
  #endif
 
   //
@@ -229,7 +327,7 @@ DmaTransferBytes (
   MemoryFence ();
 
   do {
-    Status = SwapBytes32 (Access.Control);
+    Status = SwapBytes32 (Access->Control);
     ASSERT ((Status & FW_CFG_DMA_CTL_ERROR) == 0);
   } while (Status != 0);
 
@@ -237,6 +335,15 @@ DmaTransferBytes (
   // The caller will want to access the transferred data.
   //
   MemoryFence ();
+
+  if (mIoMmuProtocol) {
+    if (BufferMapping != NULL) {
+      mIoMmuProtocol->Unmap (mIoMmuProtocol, BufferMapping);
+    }
+
+    mIoMmuProtocol->Unmap (mIoMmuProtocol, AccessMapping);
+    mIoMmuProtocol->FreeBuffer (mIoMmuProtocol, 1, (VOID *)Access);
+  }
 }
 
 /**

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibMmioInternal.h
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgLibMmioInternal.h
@@ -17,6 +17,11 @@ typedef struct {
   UINTN    FwCfgDmaAddress;
 } QEMU_FW_CFG_RESOURCE;
 
+RETURN_STATUS
+InternalInitIoMmu (
+  VOID
+  );
+
 /**
   Reads firmware configuration bytes into a buffer
 

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioDxe.c
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioDxe.c
@@ -203,6 +203,8 @@ QemuFwCfgInitialize (
           InternalQemuFwCfgWriteBytes = DmaWriteBytes;
           InternalQemuFwCfgSkipBytes  = DmaSkipBytes;
         }
+
+        InternalInitIoMmu ();
       }
     } else {
       mFwCfgSelectorAddress = 0;

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioDxeLib.inf
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioDxeLib.inf
@@ -26,6 +26,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   OvmfPkg/OvmfPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
 
@@ -36,12 +37,14 @@
   HobLib
   IoLib
   UefiBootServicesTableLib
+  UefiLib
 
 [Protocols]
   gFdtClientProtocolGuid                                ## CONSUMES
+  gEdkiiIoMmuProtocolGuid                               ## SOMETIMES_CONSUMES
 
 [Guids]
   gQemuFirmwareResourceHobGuid
 
 [Depex]
-  gFdtClientProtocolGuid
+  gFdtClientProtocolGuid AND ( gEdkiiIoMmuProtocolGuid OR gIoMmuAbsentProtocolGuid )

--- a/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioPeiLib.inf
+++ b/OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgMmioPeiLib.inf
@@ -27,6 +27,7 @@
 [Packages]
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
   OvmfPkg/OvmfPkg.dec
 
 [LibraryClasses]

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -645,6 +645,7 @@
   #
   # Platform Driver
   #
+  OvmfPkg/IoMmuAbsentDxe/IoMmuAbsentDxe.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
   OvmfPkg/VirtioRngDxe/VirtioRng.inf

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
@@ -112,6 +112,7 @@ INF  OvmfPkg/Virtio10Dxe/Virtio10.inf
 #
 # Platform Driver
 #
+INF  OvmfPkg/IoMmuAbsentDxe/IoMmuAbsentDxe.inf
 INF  OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
 INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -451,6 +451,7 @@
       DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   }
   OvmfPkg/Fdt/HighMemDxe/HighMemDxe.inf
+  OvmfPkg/IoMmuAbsentDxe/IoMmuAbsentDxe.inf
   OvmfPkg/VirtioBlkDxe/VirtioBlk.inf
   OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
   OvmfPkg/VirtioNetDxe/VirtioNet.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
@@ -72,6 +72,7 @@ INF  MdeModulePkg/Universal/DevicePathDxe/DevicePathDxe.inf
 INF  OvmfPkg/Fdt/VirtioFdtDxe/VirtioFdtDxe.inf
 INF  EmbeddedPkg/Drivers/FdtClientDxe/FdtClientDxe.inf
 INF  OvmfPkg/Fdt/HighMemDxe/HighMemDxe.inf
+INF  OvmfPkg/IoMmuAbsentDxe/IoMmuAbsentDxe.inf
 
 #
 # PI DXE Drivers producing Architectural Protocols (EFI Services)


### PR DESCRIPTION
# Add DMA sharing and image measurement for CCA for ArmVirtQemu

Enable DMA buffer sharing and firmware-loaded image measurement for Arm CCA Realm guests running on the ArmVirtQemu platform.

Add the Realm Aperture Management Protocol and Arm CCA IOMMU driver to ArmVirtQemu. Update `QemuFwCfgLibMmio` to use the IOMMU protocol when performing DMA operations so that buffers are explicitly shared with the host when firmware is executing in a Realm.

Since `QemuFwCfgLibMmio` now depends on either the IOMMU protocol or the IOMMU-absent protocol, add `IoMmuAbsentDxe` for platforms that do not support confidential computing. Include this driver in the RiscVVirtQemu and LoongArchVirtQemu firmware builds so that drivers using the FwCfg library can be dispatched correctly.

Add `BlobVerifierLibArmCca` to measure kernel and initrd images loaded through QEMU FwCfg. The library selects the Realm-configured SHA-256 or SHA-512 algorithm, hashes each image, and extends the resulting digest into Realm Extended Measurement register 1. ArmVirtQemu and ArmVirtQemuKernel are updated to use this library in place of the null blob verifier.

Note: This is a PR sub-series of the Arm CCA Support series at https://github.com/tianocore/edk2/pull/12224

* [ ] Breaking change?

  * **Breaking change** - Does this PR cause a break in build or boot behavior?
  * Examples: Does it add a new library class or move a module to a different repo.
  * If checked, follow the [[Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md)](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
* [ ] Impacts security?

  * **Security** - Does this PR have a direct security impact?
  * Examples: Crypto algorithm change or buffer overflow fix.
* [ ] Includes tests?

  * **Tests** - Does this PR include any explicit test code?
  * Examples: Unit tests or integration tests.

# How This Was Tested

* Built the ArmVirtQemu and ArmVirtQemuKernel firmware configurations.
* Build-tested the RiscVVirtQemu and LoongArchVirtQemu firmware configurations with `IoMmuAbsentDxe`.

### Note: The edk2 CI will not pass until PR https://github.com/tianocore/edk2/pull/12893 and https://github.com/tianocore/edk2/pull/12895 is merged. 

# Integration Instructions

N/A