### PR TITLE
MdeModulePkg/BdsDxe: avoid polling console input

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -277,34 +277,6 @@ BdsWaitForSingleEvent (
 }
 
 /**
-  The function reads user inputs.
-
-**/
-VOID
-BdsReadKeys (
-  VOID
-  )
-{
-  EFI_STATUS     Status;
-  EFI_INPUT_KEY  Key;
-
-  if (PcdGetBool (PcdConInConnectOnDemand)) {
-    return;
-  }
-
-  while (gST->ConIn != NULL) {
-    Status = gST->ConIn->ReadKeyStroke (gST->ConIn, &Key);
-
-    if (EFI_ERROR (Status)) {
-      //
-      // No more keys.
-      //
-      break;
-    }
-  }
-}
-
-/**
   The function waits for the boot manager timeout expires or hotkey is pressed.
 
   It calls PlatformBootManagerWaitCallback each second.
@@ -325,9 +297,6 @@ BdsWait (
   while (TimeoutRemain != 0) {
     DEBUG ((DEBUG_INFO, "[Bds]BdsWait(%d)..Zzzz...\n", (UINTN)TimeoutRemain));
     PlatformBootManagerWaitCallback (TimeoutRemain);
-
-    BdsReadKeys (); // BUGBUG: Only reading can signal HotkeyTriggered
-                    //         Can be removed after all keyboard drivers invoke callback in timer callback.
 
     if (HotkeyTriggered != NULL) {
       Status = BdsWaitForSingleEvent (HotkeyTriggered, EFI_TIMER_PERIOD_SECONDS (1));
@@ -1063,11 +1032,6 @@ BdsEntry (
     PERF_INMODULE_BEGIN ("BdsWait");
     BdsWait (HotkeyTriggered);
     PERF_INMODULE_END ("BdsWait");
-    //
-    // BdsReadKeys() can be removed after all keyboard drivers invoke callback in timer callback.
-    //
-    BdsReadKeys ();
-
     EfiBootManagerHotkeyBoot ();
 
     if (BootNext != NULL) {

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -277,6 +277,27 @@ BdsWaitForSingleEvent (
 }
 
 /**
+  Drain queued console input.
+
+**/
+STATIC
+VOID
+BdsDrainConsoleInput (
+  VOID
+  )
+{
+  EFI_INPUT_KEY  Key;
+  EFI_STATUS     Status;
+
+  while (gST->ConIn != NULL) {
+    Status = gST->ConIn->ReadKeyStroke (gST->ConIn, &Key);
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+  }
+}
+
+/**
   The function waits for the boot manager timeout expires or hotkey is pressed.
 
   It calls PlatformBootManagerWaitCallback each second.
@@ -1009,6 +1030,12 @@ BdsEntry (
     if (PcdGetBool (PcdConInConnectOnDemand)) {
       BdsDxeOnConnectConInCallBack (NULL, NULL);
     }
+
+    //
+    // A hotkey notification can leave the same key queued for ReadKeyStroke().
+    // Consume it before Enter can immediately select Continue in Front Page.
+    //
+    BdsDrainConsoleInput ();
 
     //
     // Directly enter the setup page.


### PR DESCRIPTION
Reading ConIn during the boot timeout can trigger USB device discovery on every countdown tick.\n\nHotkey notifications arrive through the registered event, so remove the synchronous countdown input drain.\n\nKeep a one-time drain before an OS-requested firmware setup entry. A hotkey notification can leave the same Enter queued for ReadKeyStroke(), which would otherwise immediately activate Continue in Front Page.\n\n- [ ] Breaking change?\n- [ ] Impacts security?\n- [ ] Includes tests?\n\n## How This Was Tested\n\n- PatchCheck.py\n- MdeModulePkg NOOPT X64 Stuart build\n- MdeModulePkg X64 host unit tests\n\n## Integration Instructions\n\nN/A