### PR TITLE
MdeModulePkg: harden capsule-on-disk discovery

### DIFF
--- a/MdeModulePkg/Include/Library/CapsuleLib.h
+++ b/MdeModulePkg/Include/Library/CapsuleLib.h
@@ -9,10 +9,24 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #pragma once
 
+#include <Guid/FileInfo.h>
+
 //
 // BOOLEAN Variable to indicate whether system is in the capsule on disk state.
 //
 #define COD_RELOCATION_INFO_VAR_NAME  L"CodRelocationInfo"
+
+typedef struct {
+  //
+  // image address.
+  //
+  VOID             *ImageAddress;
+  //
+  // The file info of the image comes from.
+  // if FileInfo == NULL, image does not come from file.
+  //
+  EFI_FILE_INFO    *FileInfo;
+} IMAGE_INFO;
 
 /**
   The firmware checks whether the capsule image is supported
@@ -97,6 +111,61 @@ BOOLEAN
 EFIAPI
 CoDCheckCapsuleOnDiskFlag (
   VOID
+  );
+
+/**
+  Check if any on-disk capsules are present.
+
+  @param[in]  MaxRetry  Max Connection Retry. Stall 100ms between each
+                        connection try to ensure devices like USB can get
+                        enumerated.
+
+  @retval TRUE   At least one potential on-disk capsule was found on a boot
+                 drive.
+  @retval FALSE  No capsule candidates were discovered on a boot drive.
+**/
+BOOLEAN
+EFIAPI
+CoDPresent (
+  IN UINTN  MaxRetry
+  );
+
+/**
+  This routine is called to get all capsules from file. The capsule file image is
+  copied to BS memory. Caller is responsible to free them.
+
+  @param[in]    MaxRetry             Max Connection Retry. Stall 100ms between each connection try to ensure
+                                     devices like USB can get enumerated.
+  @param[out]   CapsulePtr           Copied Capsule file Image Info buffer
+  @param[out]   CapsuleNum           CapsuleNumber
+  @param[out]   FsHandle             File system handle
+  @param[out]   LoadOptionNumber     OptionNumber of boot option
+
+  @retval EFI_SUCCESS  Succeed to get all capsules.
+
+**/
+EFI_STATUS
+EFIAPI
+CoDGetAll (
+  IN  UINTN       MaxRetry,
+  OUT IMAGE_INFO  **CapsulePtr,
+  OUT UINTN       *CapsuleNum,
+  OUT EFI_HANDLE  *FsHandle,
+  OUT UINT16      *LoadOptionNumber
+  );
+
+/**
+  Free resources allocated by CoDGetAll.
+
+  @param[in]  ImageInfo  An array of data and information of files
+  @param[in]  Count      Length of the array.
+
+**/
+VOID
+EFIAPI
+CoDFreeImages (
+  IN IMAGE_INFO  *ImageInfo,
+  IN UINTN       Count
   );
 
 /**

--- a/MdeModulePkg/Include/Library/CapsuleLib.h
+++ b/MdeModulePkg/Include/Library/CapsuleLib.h
@@ -116,9 +116,18 @@ CoDCheckCapsuleOnDiskFlag (
 /**
   Check if any on-disk capsules are present.
 
-  @param[in]  MaxRetry  Max Connection Retry. Stall 100ms between each
-                        connection try to ensure devices like USB can get
-                        enumerated.
+  Connecting the boot device can discover option ROMs. The caller must provide
+  a suitable image-dispatch policy before setting ConnectBootDevice to TRUE.
+
+  @param[in]  MaxRetry          Max Connection Retry. Stall 100ms between each
+                                connection try to ensure devices like USB can
+                                get enumerated.
+  @param[in]  ConnectBootDevice Connect the active boot device before expanding
+                                its media path.
+  @param[out] BootDeviceReady   Set to TRUE when the active boot option's
+                                filesystem is available. Optional.
+  @param[out] ConnectAllNeeded  Set to TRUE when an active media-only boot path
+                                needs global device connection. Optional.
 
   @retval TRUE   At least one potential on-disk capsule was found on a boot
                  drive.
@@ -127,7 +136,10 @@ CoDCheckCapsuleOnDiskFlag (
 BOOLEAN
 EFIAPI
 CoDPresent (
-  IN UINTN  MaxRetry
+  IN  UINTN    MaxRetry,
+  IN  BOOLEAN  ConnectBootDevice,
+  OUT BOOLEAN  *BootDeviceReady OPTIONAL,
+  OUT BOOLEAN  *ConnectAllNeeded OPTIONAL
   );
 
 /**

--- a/MdeModulePkg/Include/Library/CapsuleLib.h
+++ b/MdeModulePkg/Include/Library/CapsuleLib.h
@@ -141,7 +141,8 @@ CoDPresent (
   @param[out]   FsHandle             File system handle
   @param[out]   LoadOptionNumber     OptionNumber of boot option
 
-  @retval EFI_SUCCESS  Succeed to get all capsules.
+  @retval EFI_SUCCESS              Succeed to get all capsules.
+  @retval EFI_WARN_DELETE_FAILURE  Valid capsules were loaded, but at least one source file could not be removed.
 
 **/
 EFI_STATUS

--- a/MdeModulePkg/Include/Library/UefiBootManagerLib.h
+++ b/MdeModulePkg/Include/Library/UefiBootManagerLib.h
@@ -460,6 +460,27 @@ EfiBootManagerGetNextLoadOptionDevicePath (
   );
 
 /**
+  Get the next possible full path pointing to the load option.
+
+  Unlike EfiBootManagerGetNextLoadOptionDevicePath(), short-form expansion does
+  not call EfiBootManagerConnectAll().
+
+  @param FilePath  The device path pointing to a load option.
+                   It could be a short-form device path.
+  @param FullPath  The full path returned by the routine in last call.
+                   Set to NULL in first call.
+
+  @return The next possible full path pointing to the load option.
+          Caller is responsible to free the memory.
+**/
+EFI_DEVICE_PATH_PROTOCOL *
+EFIAPI
+EfiBootManagerGetNextLoadOptionDevicePathNoConnectAll (
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath
+  );
+
+/**
   Get the load option by its device path.
 
   @param FilePath  The device path pointing to a load option.

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/CapsuleOnDisk.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/CapsuleOnDisk.c
@@ -1121,7 +1121,99 @@ EXIT:
 }
 
 /**
-  This routine is called to get all caspules from file. The capsule file image is
+  Check if any on-disk capsules are present.
+
+  @param[in]  MaxRetry  Max Connection Retry. Stall 100ms between each
+                        connection try to ensure devices like USB can get
+                        enumerated.
+
+  @retval TRUE   At least one potential on-disk capsule was found on a boot
+                 drive.
+  @retval FALSE  No capsule candidates were discovered on a boot drive.
+**/
+BOOLEAN
+EFIAPI
+CoDPresent (
+  IN UINTN  MaxRetry
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_HANDLE                       FsHandle;
+  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL  *Fs;
+  EFI_FILE_HANDLE                  RootDir;
+  EFI_FILE_HANDLE                  FileDir;
+  UINT16                           *TempOptionNumber;
+  UINTN                            FileCount;
+  LIST_ENTRY                       FileInfoList;
+  LIST_ENTRY                       *Link;
+  FILE_INFO_ENTRY                  *FileInfoEntry;
+
+  if (!PcdGetBool (PcdCapsuleOnDiskSupport)) {
+    return FALSE;
+  }
+
+  TempOptionNumber = NULL;
+  Status = GetEfiSysPartitionFromActiveBootOption (MaxRetry, &TempOptionNumber, &FsHandle);
+  if (EFI_ERROR (Status)) {
+    return FALSE;
+  }
+
+  Status = gBS->HandleProtocol (FsHandle, &gEfiSimpleFileSystemProtocolGuid, (VOID **)&Fs);
+  if (EFI_ERROR (Status)) {
+    return FALSE;
+  }
+
+  Status = Fs->OpenVolume (Fs, &RootDir);
+  if (EFI_ERROR (Status)) {
+    return FALSE;
+  }
+
+  Status = RootDir->Open (
+                      RootDir,
+                      &FileDir,
+                      EFI_CAPSULE_FILE_DIRECTORY,
+                      EFI_FILE_MODE_READ,
+                      0
+                      );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "CoDPresent failed to open %s: %r\n", EFI_CAPSULE_FILE_DIRECTORY, Status));
+    RootDir->Close (RootDir);
+    return FALSE;
+  }
+
+  RootDir->Close (RootDir);
+
+  FileCount = 0;
+  Status = GetFileInfoListInAlphabetFromDir (
+             FileDir,
+             EFI_FILE_SYSTEM | EFI_FILE_ARCHIVE,
+             &FileInfoList,
+             &FileCount
+             );
+  FileDir->Close (FileDir);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "GetFileInfoListInAlphabetFromDir failed: %r\n", Status));
+    return FALSE;
+  }
+
+  while (!IsListEmpty (&FileInfoList)) {
+    Link = FileInfoList.ForwardLink;
+    RemoveEntryList (Link);
+
+    FileInfoEntry = CR (Link, FILE_INFO_ENTRY, Link, FILE_INFO_SIGNATURE);
+
+    FreePool (FileInfoEntry->FileInfo);
+    FreePool (FileInfoEntry->FileNameFirstPart);
+    FreePool (FileInfoEntry->FileNameSecondPart);
+    FreePool (FileInfoEntry);
+  }
+
+  DEBUG ((DEBUG_INFO, "%a(): found %u potential on-disk capsule(s)\n", __func__, FileCount));
+  return FileCount > 0;
+}
+
+/**
+  This routine is called to get all capsules from file. The capsule file image is
   copied to BS memory. Caller is responsible to free them.
 
   @param[in]    MaxRetry             Max Connection Retry. Stall 100ms between each connection try to ensure
@@ -1135,7 +1227,8 @@ EXIT:
 
 **/
 EFI_STATUS
-GetAllCapsuleOnDisk (
+EFIAPI
+CoDGetAll (
   IN  UINTN       MaxRetry,
   OUT IMAGE_INFO  **CapsulePtr,
   OUT UINTN       *CapsuleNum,
@@ -1207,6 +1300,34 @@ GetAllCapsuleOnDisk (
   }
 
   return Status;
+}
+
+/**
+  Free resources allocated by CoDGetAll.
+
+  @param[in]  ImageInfo  An array of data and information of files
+  @param[in]  Count      Length of the array.
+
+**/
+VOID
+EFIAPI
+CoDFreeImages (
+  IN IMAGE_INFO  *ImageInfo,
+  IN UINTN       Count
+  )
+{
+  UINTN  Index;
+
+  if (ImageInfo == NULL) {
+    return;
+  }
+
+  for (Index = 0; Index < Count; Index++) {
+    FreePool (ImageInfo[Index].ImageAddress);
+    FreePool (ImageInfo[Index].FileInfo);
+  }
+
+  FreePool (ImageInfo);
 }
 
 /**
@@ -1465,9 +1586,9 @@ RelocateCapsuleToDisk (
   //
   // 1. Load all Capsule On Disks in to memory
   //
-  Status = GetAllCapsuleOnDisk (MaxRetry, &CapsuleOnDiskBuf, &CapsuleOnDiskNum, &Handle, &LoadOptionNumber);
+  Status = CoDGetAll (MaxRetry, &CapsuleOnDiskBuf, &CapsuleOnDiskNum, &Handle, &LoadOptionNumber);
   if (EFI_ERROR (Status) || (CapsuleOnDiskNum == 0) || (CapsuleOnDiskBuf == NULL)) {
-    DEBUG ((DEBUG_INFO, "RelocateCapsule: GetAllCapsuleOnDisk Status - 0x%x\n", Status));
+    DEBUG ((DEBUG_INFO, "RelocateCapsule: CoDGetAll Status - 0x%x\n", Status));
     return EFI_NOT_FOUND;
   }
 
@@ -1772,9 +1893,9 @@ RelocateCapsuleToRam (
   //
   // 1. Load all Capsule On Disks into memory
   //
-  Status = GetAllCapsuleOnDisk (MaxRetry, &CapsuleOnDiskBuf, &CapsuleOnDiskNum, &Handle, NULL);
+  Status = CoDGetAll (MaxRetry, &CapsuleOnDiskBuf, &CapsuleOnDiskNum, &Handle, NULL);
   if (EFI_ERROR (Status) || (CapsuleOnDiskNum == 0) || (CapsuleOnDiskBuf == NULL)) {
-    DEBUG ((DEBUG_ERROR, "GetAllCapsuleOnDisk Status - 0x%x\n", Status));
+    DEBUG ((DEBUG_ERROR, "CoDGetAll Status - 0x%x\n", Status));
     return EFI_NOT_FOUND;
   }
 

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/CapsuleOnDisk.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/CapsuleOnDisk.c
@@ -534,6 +534,96 @@ GetEfiSysPartitionFromDevPath (
   return EFI_NOT_FOUND;
 }
 
+STATIC
+BOOLEAN
+IsNetworkBootDevicePath (
+  IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  )
+{
+  BOOLEAN  NetworkPath;
+  BOOLEAN  StoragePath;
+  UINT8    SubType;
+
+  NetworkPath = FALSE;
+  StoragePath = FALSE;
+  while (!IsDevicePathEnd (DevicePath)) {
+    SubType = DevicePathSubType (DevicePath);
+    if ((DevicePathType (DevicePath) == MEDIA_DEVICE_PATH) &&
+        ((SubType == MEDIA_HARDDRIVE_DP) || (SubType == MEDIA_CDROM_DP)))
+    {
+      StoragePath = TRUE;
+    } else if (DevicePathType (DevicePath) == MESSAGING_DEVICE_PATH) {
+      switch (SubType) {
+        case MSG_INFINIBAND_DP:
+          if (DevicePathNodeLength (DevicePath) < sizeof (INFINIBAND_DEVICE_PATH)) {
+            NetworkPath = TRUE;
+            break;
+          }
+
+          if ((((INFINIBAND_DEVICE_PATH *)DevicePath)->ResourceFlags &
+               INFINIBAND_RESOURCE_FLAG_STORAGE_PROTOCOL) != 0)
+          {
+            StoragePath = TRUE;
+          }
+
+          if ((((INFINIBAND_DEVICE_PATH *)DevicePath)->ResourceFlags &
+               INFINIBAND_RESOURCE_FLAG_NETWORK_PROTOCOL) != 0)
+          {
+            NetworkPath = TRUE;
+          }
+
+          break;
+        case MSG_MAC_ADDR_DP:
+        case MSG_IPv4_DP:
+        case MSG_IPv6_DP:
+        case MSG_VLAN_DP:
+        case MSG_URI_DP:
+        case MSG_DNS_DP:
+        case MSG_WIFI_DP:
+          NetworkPath = TRUE;
+          break;
+        case MSG_ATAPI_DP:
+        case MSG_SCSI_DP:
+        case MSG_FIBRECHANNEL_DP:
+        case MSG_FIBRECHANNELEX_DP:
+        case MSG_ISCSI_DP:
+        case MSG_I2O_DP:
+        case MSG_DEVICE_LOGICAL_UNIT_DP:
+        case MSG_SATA_DP:
+        case MSG_SASEX_DP:
+        case MSG_NVME_NAMESPACE_DP:
+        case MSG_NVME_OF_NAMESPACE_DP:
+        case MSG_UFS_DP:
+        case MSG_SD_DP:
+        case MSG_EMMC_DP:
+          StoragePath = TRUE;
+          break;
+        default:
+          break;
+      }
+    }
+
+    DevicePath = NextDevicePathNode (DevicePath);
+  }
+
+  //
+  // Controller-only paths may not identify their transport until connected.
+  // Reject only paths that are positively network boot and are not SAN-backed.
+  //
+  return NetworkPath && !StoragePath;
+}
+
+STATIC
+BOOLEAN
+IsMediaShortFormDevicePath (
+  IN EFI_DEVICE_PATH_PROTOCOL  *DevicePath
+  )
+{
+  return (DevicePathType (DevicePath) == MEDIA_DEVICE_PATH) &&
+         ((DevicePathSubType (DevicePath) == MEDIA_HARDDRIVE_DP) ||
+          (DevicePathSubType (DevicePath) == MEDIA_FILEPATH_DP));
+}
+
 /**
   This routine is called to get Simple File System protocol on the first EFI system partition found in
   active boot option. The boot option list is detemined in order by
@@ -546,6 +636,10 @@ GetEfiSysPartitionFromDevPath (
                                       On output, return the OptionNumber of the boot option where EFI
                                       system partition is got from.
   @param[out]      FsFsHandle         Simple File System Protocol found on first active EFI system partition
+  @param[in]       ConnectBootDevice  Connect the boot device before expanding
+                                      its media path.
+  @param[out]      ConnectAllNeeded   Set when an active media-only boot path
+                                      needs global device connection. Optional.
 
   @retval EFI_SUCCESS     Simple File System protocol found for EFI system partition
   @retval EFI_NOT_FOUND   No Simple File System protocol found for EFI system partition
@@ -555,16 +649,26 @@ EFI_STATUS
 GetEfiSysPartitionFromActiveBootOption (
   IN UINTN        MaxRetry,
   IN OUT UINT16   **LoadOptionNumber,
-  OUT EFI_HANDLE  *FsHandle
+  OUT EFI_HANDLE  *FsHandle,
+  IN BOOLEAN      ConnectBootDevice,
+  OUT BOOLEAN     *ConnectAllNeeded OPTIONAL
   )
 {
   EFI_STATUS                    Status;
   EFI_BOOT_MANAGER_LOAD_OPTION  *BootOptionBuf;
   UINTN                         BootOptionNum;
   UINTN                         Index;
+  UINTN                         RetryCount;
+  UINTN                         DevicePathSize;
+  EFI_HANDLE                    DeviceHandle;
   EFI_DEVICE_PATH_PROTOCOL      *DevicePath;
+  EFI_DEVICE_PATH_PROTOCOL      *RemainingDevicePath;
   EFI_DEVICE_PATH_PROTOCOL      *CurFullPath;
   EFI_DEVICE_PATH_PROTOCOL      *PreFullPath;
+
+  if (ConnectAllNeeded != NULL) {
+    *ConnectAllNeeded = FALSE;
+  }
 
   *FsHandle   = NULL;
   CurFullPath = NULL;
@@ -592,17 +696,53 @@ GetEfiSysPartitionFromActiveBootOption (
   //
   for (Index = 0; Index < BootOptionNum; Index++) {
     //
-    // Get the boot option from the link list
+    // Skip inactive boot options.
     //
-    DevicePath = BootOptionBuf[Index].FilePath;
+    if ((BootOptionBuf[Index].Attributes & LOAD_OPTION_ACTIVE) == 0) {
+      continue;
+    }
+
+    RetryCount          = MaxRetry;
+    Status              = EFI_NOT_FOUND;
+    RemainingDevicePath = BootOptionBuf[Index].FilePath;
+    DevicePath          = GetNextDevicePathInstance (&RemainingDevicePath, &DevicePathSize);
+    if (DevicePath == NULL) {
+      continue;
+    }
 
     //
-    // Skip inactive or legacy boot options
+    // Only FilePathList[0] identifies the boot image. Later path instances are
+    // OSV-specific metadata and must not be connected as boot targets.
     //
-    if (((BootOptionBuf[Index].Attributes & LOAD_OPTION_ACTIVE) == 0) ||
-        (DevicePathType (DevicePath) == BBS_DEVICE_PATH))
+    if ((DevicePathType (DevicePath) == BBS_DEVICE_PATH) ||
+        (ConnectBootDevice && IsNetworkBootDevicePath (DevicePath)))
     {
+      FreePool (DevicePath);
       continue;
+    }
+
+    //
+    // A file-path-only option does not identify a filesystem. Targeted and
+    // capsule-in-RAM lookups must not expand it to an unrelated ESP. The no-RAM
+    // legacy path retains global resolution for relocation compatibility.
+    //
+    if ((ConnectBootDevice || PcdGetBool (PcdCapsuleInRamSupport)) &&
+        (DevicePathType (DevicePath) == MEDIA_DEVICE_PATH) &&
+        (DevicePathSubType (DevicePath) == MEDIA_FILEPATH_DP))
+    {
+      if (ConnectBootDevice && (ConnectAllNeeded != NULL)) {
+        *ConnectAllNeeded = TRUE;
+      }
+
+      FreePool (DevicePath);
+      break;
+    }
+
+    if (ConnectBootDevice &&
+        IsMediaShortFormDevicePath (DevicePath) &&
+        (ConnectAllNeeded != NULL))
+    {
+      *ConnectAllNeeded = TRUE;
     }
 
     DEBUG_CODE_BEGIN ();
@@ -618,19 +758,57 @@ GetEfiSysPartitionFromActiveBootOption (
 
     DEBUG_CODE_END ();
 
+    if (ConnectBootDevice) {
+      //
+      // A disk-only boot option does not name the partition or filesystem,
+      // so expansion cannot find the ESP until the storage controller has
+      // produced those child handles.
+      //
+      DeviceHandle = NULL;
+      Status       = EfiBootManagerConnectDevicePath (DevicePath, &DeviceHandle);
+      if (!EFI_ERROR (Status) && (DeviceHandle != NULL)) {
+        gBS->ConnectController (DeviceHandle, NULL, NULL, TRUE);
+      }
+    }
+
     CurFullPath = NULL;
     //
     // Try every full device Path generated from bootoption
     //
     do {
       PreFullPath = CurFullPath;
-      CurFullPath = EfiBootManagerGetNextLoadOptionDevicePath (DevicePath, CurFullPath);
+      if (ConnectBootDevice) {
+        CurFullPath = EfiBootManagerGetNextLoadOptionDevicePathNoConnectAll (
+                        DevicePath,
+                        CurFullPath
+                        );
+      } else {
+        CurFullPath = EfiBootManagerGetNextLoadOptionDevicePath (DevicePath, CurFullPath);
+      }
 
       if (PreFullPath != NULL) {
         FreePool (PreFullPath);
       }
 
       if (CurFullPath == NULL) {
+        if (ConnectBootDevice && (RetryCount > 0))
+        {
+          //
+          // A slow device may not expose a path on the first connection.
+          // Retry the targeted connection before expanding the path again.
+          //
+          gBS->Stall (100000);
+          RetryCount--;
+          DeviceHandle = NULL;
+          Status       = EfiBootManagerConnectDevicePath (DevicePath, &DeviceHandle);
+          if (!EFI_ERROR (Status) && (DeviceHandle != NULL)) {
+            gBS->ConnectController (DeviceHandle, NULL, NULL, TRUE);
+          }
+
+          Status = EFI_NOT_READY;
+          continue;
+        }
+
         //
         // No Active EFI system partition is found in BootOption device path
         //
@@ -651,8 +829,8 @@ GetEfiSysPartitionFromActiveBootOption (
 
       //
       // Make sure the boot option device path connected.
-      // Only handle first device in boot option. Other optional device paths are described as OSV specific
-      // FullDevice could contain extra directory & file info. So don't check connection status here.
+      // FullDevice could contain extra directory and file information, so
+      // do not check connection status here.
       //
       EfiBootManagerConnectDevicePath (CurFullPath, NULL);
       Status = GetEfiSysPartitionFromDevPath (CurFullPath, FsHandle);
@@ -660,11 +838,12 @@ GetEfiSysPartitionFromActiveBootOption (
       //
       // Some relocation device like USB need more time to get enumerated
       //
-      while (EFI_ERROR (Status) && MaxRetry > 0) {
+      while (EFI_ERROR (Status) && RetryCount > 0) {
         EfiBootManagerConnectDevicePath (CurFullPath, NULL);
 
         //
-        // Search for EFI system partition protocol on full device path in Boot Option
+        // Search for EFI system partition protocol on full device path in
+        // Boot Option.
         //
         Status = GetEfiSysPartitionFromDevPath (CurFullPath, FsHandle);
         if (!EFI_ERROR (Status)) {
@@ -676,9 +855,11 @@ GetEfiSysPartitionFromActiveBootOption (
         // Stall 100ms if connection failed to ensure USB stack is ready
         //
         gBS->Stall (100000);
-        MaxRetry--;
+        RetryCount--;
       }
     } while (EFI_ERROR (Status));
+
+    FreePool (DevicePath);
 
     //
     // Find a qualified Simple File System
@@ -1237,7 +1418,9 @@ CoDSelectCapsuleFs (
     Status               = GetEfiSysPartitionFromActiveBootOption (
                              0,
                              &ResolvedOptionNumber,
-                             &ResolvedFsHandle
+                             &ResolvedFsHandle,
+                             FALSE,
+                             NULL
                              );
     if (!EFI_ERROR (Status)) {
       PreferredFsHandle = ResolvedFsHandle;
@@ -1589,9 +1772,15 @@ EXIT:
 /**
   Check if any on-disk capsules are present.
 
-  @param[in]  MaxRetry  Max Connection Retry. Stall 100ms between each
-                        connection try to ensure devices like USB can get
-                        enumerated.
+  @param[in]  MaxRetry          Max Connection Retry. Stall 100ms between each
+                                connection try to ensure devices like USB can
+                                get enumerated.
+  @param[in]  ConnectBootDevice Connect the active boot device before expanding
+                                its media path.
+  @param[out] BootDeviceReady   Set to TRUE when the active boot option's
+                                filesystem is available. Optional.
+  @param[out] ConnectAllNeeded  Set to TRUE when an active media-only boot path
+                                needs global device connection. Optional.
 
   @retval TRUE   At least one potential on-disk capsule was found on a boot
                  drive.
@@ -1600,7 +1789,10 @@ EXIT:
 BOOLEAN
 EFIAPI
 CoDPresent (
-  IN UINTN  MaxRetry
+  IN  UINTN    MaxRetry,
+  IN  BOOLEAN  ConnectBootDevice,
+  OUT BOOLEAN  *BootDeviceReady OPTIONAL,
+  OUT BOOLEAN  *ConnectAllNeeded OPTIONAL
   )
 {
   EFI_STATUS  Status;
@@ -1608,6 +1800,14 @@ CoDPresent (
   EFI_HANDLE  CapsuleFsHandle;
   UINT16      *TempOptionNumber;
   UINTN       FileCount;
+
+  if (BootDeviceReady != NULL) {
+    *BootDeviceReady = FALSE;
+  }
+
+  if (ConnectAllNeeded != NULL) {
+    *ConnectAllNeeded = FALSE;
+  }
 
   if (!PcdGetBool (PcdCapsuleOnDiskSupport)) {
     return FALSE;
@@ -1618,7 +1818,17 @@ CoDPresent (
   CapsuleFsHandle  = NULL;
   FileCount        = 0;
 
-  Status = GetEfiSysPartitionFromActiveBootOption (MaxRetry, &TempOptionNumber, &ActiveFsHandle);
+  Status = GetEfiSysPartitionFromActiveBootOption (
+             MaxRetry,
+             &TempOptionNumber,
+             &ActiveFsHandle,
+             ConnectBootDevice,
+             ConnectAllNeeded
+             );
+  if (!EFI_ERROR (Status) && (BootDeviceReady != NULL)) {
+    *BootDeviceReady = TRUE;
+  }
+
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "%a(): active boot option lookup failed: %r\n", __func__, Status));
   }
@@ -1691,7 +1901,15 @@ CoDGetAll (
   *CapsuleNum            = 0;
   *FsHandle              = NULL;
 
-  Status = GetEfiSysPartitionFromActiveBootOption (MaxRetry, &TempOptionNumber, &ActiveFsHandle);
+  Status = GetEfiSysPartitionFromActiveBootOption (
+             MaxRetry,
+             &TempOptionNumber,
+             &ActiveFsHandle,
+             (BOOLEAN)(PcdGetBool (PcdCapsuleInRamSupport) &&
+                       FeaturePcdGet (PcdCapsuleOnDiskConnectBootDevice) &&
+                       !mDxeCapsuleLibEndOfDxe),
+             NULL
+             );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "%a(): active boot option lookup failed: %r\n", __func__, Status));
   }
@@ -1972,7 +2190,9 @@ CoDClearCapsuleOnDiskFlag (
                          sizeof (UINT64),
                          &OsIndication
                          );
-  ASSERT (!EFI_ERROR (Status));
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   //
   // Delete BootNext variable. Capsule Process may reset system, so can't rely on Bds to clear this variable
@@ -1984,9 +2204,7 @@ CoDClearCapsuleOnDiskFlag (
                   0,
                   NULL
                   );
-  ASSERT (Status == EFI_SUCCESS || Status == EFI_NOT_FOUND);
-
-  return EFI_SUCCESS;
+  return (Status == EFI_NOT_FOUND) ? EFI_SUCCESS : Status;
 }
 
 /**
@@ -2562,7 +2780,13 @@ CoDRemoveTempFile (
   //
   // Get the EFI file system from the boot option where the capsules are relocated
   //
-  Status = GetEfiSysPartitionFromActiveBootOption (MaxRetry, &LoadOptionNumber, &FsHandle);
+  Status = GetEfiSysPartitionFromActiveBootOption (
+             MaxRetry,
+             &LoadOptionNumber,
+             &FsHandle,
+             FALSE,
+             NULL
+             );
   if (EFI_ERROR (Status)) {
     goto EXIT;
   }

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/CapsuleOnDisk.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/CapsuleOnDisk.c
@@ -8,6 +8,10 @@
 
 #include "CapsuleOnDisk.h"
 
+#include <Library/HobLib.h>
+
+extern BOOLEAN  mDxeCapsuleLibEndOfDxe;
+
 /**
   Return if this capsule is a capsule name capsule, based upon CapsuleHeader.
 
@@ -20,6 +24,110 @@ BOOLEAN
 IsCapsuleNameCapsule (
   IN EFI_CAPSULE_HEADER  *CapsuleHeader
   );
+
+BOOLEAN
+IsValidCapsuleHeader (
+  IN EFI_CAPSULE_HEADER  *CapsuleHeader,
+  IN UINT64              CapsuleSize
+  );
+
+STATIC
+BOOLEAN
+CoDFileAttributeMatches (
+  IN UINT64  FileAttribute,
+  IN UINT64  FileAttr
+  )
+{
+  if ((FileAttribute & EFI_FILE_DIRECTORY) != 0) {
+    return FALSE;
+  }
+
+  if ((FileAttribute & FileAttr) != 0) {
+    return TRUE;
+  }
+
+  //
+  // Some FAT implementations report regular files without EFI_FILE_ARCHIVE.
+  // The caller has already opened the trusted capsule directory, so accept an
+  // attribute-less regular entry when looking for archive or system files.
+  //
+  return (FileAttribute == 0) &&
+         ((FileAttr & (EFI_FILE_ARCHIVE | EFI_FILE_SYSTEM)) != 0);
+}
+
+STATIC
+BOOLEAN
+CoDIsValidCapsuleImage (
+  IN VOID    *ImageAddress,
+  IN UINT64  ImageSize
+  )
+{
+  EFI_CAPSULE_HEADER  *CapsuleHeader;
+
+  if ((ImageAddress == NULL) ||
+      (ImageSize < sizeof (EFI_CAPSULE_HEADER)) ||
+      (ImageSize > MAX_UINTN))
+  {
+    return FALSE;
+  }
+
+  CapsuleHeader = ImageAddress;
+  if (CapsuleHeader->HeaderSize < sizeof (*CapsuleHeader)) {
+    return FALSE;
+  }
+
+  return IsValidCapsuleHeader (CapsuleHeader, ImageSize);
+}
+
+STATIC
+EFI_STATUS
+CoDFilterInvalidCapsuleImages (
+  IN OUT IMAGE_INFO  *CapsuleImages,
+  IN OUT UINTN       *CapsuleCount
+  )
+{
+  UINTN  Index;
+  UINTN  ValidCount;
+
+  if ((CapsuleImages == NULL) || (CapsuleCount == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ValidCount = 0;
+  for (Index = 0; Index < *CapsuleCount; Index++) {
+    if ((CapsuleImages[Index].FileInfo == NULL) ||
+        !CoDIsValidCapsuleImage (
+           CapsuleImages[Index].ImageAddress,
+           CapsuleImages[Index].FileInfo->FileSize
+           ))
+    {
+      if (CapsuleImages[Index].FileInfo != NULL) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a(): ignoring invalid capsule file %s\n",
+          __func__,
+          CapsuleImages[Index].FileInfo->FileName
+          ));
+        FreePool (CapsuleImages[Index].FileInfo);
+      }
+
+      if (CapsuleImages[Index].ImageAddress != NULL) {
+        FreePool (CapsuleImages[Index].ImageAddress);
+      }
+
+      continue;
+    }
+
+    if (ValidCount != Index) {
+      CapsuleImages[ValidCount] = CapsuleImages[Index];
+    }
+
+    ValidCount++;
+  }
+
+  *CapsuleCount = ValidCount;
+  return (ValidCount == 0) ? EFI_NOT_FOUND : EFI_SUCCESS;
+}
 
 /**
   Check the integrity of the capsule name capsule.
@@ -581,20 +689,21 @@ GetEfiSysPartitionFromActiveBootOption (
   }
 
   //
-  // Return the OptionNumber of the boot option where EFI system partition is got from
-  //
-  if (*LoadOptionNumber == NULL) {
-    *LoadOptionNumber = AllocateCopyPool (sizeof (UINT16), (UINT16 *)&BootOptionBuf[Index].OptionNumber);
-    if (*LoadOptionNumber == NULL) {
-      Status = EFI_OUT_OF_RESOURCES;
-    }
-  }
-
-  //
   // No qualified EFI system partition found
   //
   if (*FsHandle == NULL) {
     Status = EFI_NOT_FOUND;
+  }
+
+  //
+  // Return the option number only after finding its EFI system partition.
+  // Index equals BootOptionNum when every boot option lookup failed.
+  //
+  if ((*LoadOptionNumber == NULL) && !EFI_ERROR (Status)) {
+    *LoadOptionNumber = AllocateCopyPool (sizeof (UINT16), (UINT16 *)&BootOptionBuf[Index].OptionNumber);
+    if (*LoadOptionNumber == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+    }
   }
 
   DEBUG_CODE_BEGIN ();
@@ -710,7 +819,7 @@ GetFileInfoListInAlphabetFromDir (
     //
     // Skip file with mismatching File attribute
     //
-    if ((FileInfo->Attribute & (FileAttr)) == 0) {
+    if (!CoDFileAttributeMatches (FileInfo->Attribute, FileAttr)) {
       continue;
     }
 
@@ -879,6 +988,348 @@ EXIT:
   return Status;
 }
 
+STATIC
+VOID
+CoDFreeFileInfoList (
+  IN OUT LIST_ENTRY  *FileInfoList
+  )
+{
+  LIST_ENTRY       *Link;
+  FILE_INFO_ENTRY  *FileInfoEntry;
+
+  while (!IsListEmpty (FileInfoList)) {
+    Link = FileInfoList->ForwardLink;
+    RemoveEntryList (Link);
+
+    FileInfoEntry = CR (Link, FILE_INFO_ENTRY, Link, FILE_INFO_SIGNATURE);
+    FreePool (FileInfoEntry->FileInfo);
+    FreePool (FileInfoEntry->FileNameFirstPart);
+    FreePool (FileInfoEntry->FileNameSecondPart);
+    FreePool (FileInfoEntry);
+  }
+}
+
+STATIC
+EFI_STATUS
+CoDOpenCapsuleDirectoryOnFs (
+  IN  EFI_HANDLE       FsHandle,
+  OUT EFI_FILE_HANDLE  *FileDir
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL  *Fs;
+  EFI_FILE_HANDLE                  RootDir;
+
+  *FileDir = NULL;
+  RootDir  = NULL;
+
+  Status = gBS->HandleProtocol (FsHandle, &gEfiSimpleFileSystemProtocolGuid, (VOID **)&Fs);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = Fs->OpenVolume (Fs, &RootDir);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = RootDir->Open (
+                      RootDir,
+                      FileDir,
+                      EFI_CAPSULE_FILE_DIRECTORY,
+                      EFI_FILE_MODE_READ,
+                      0
+                      );
+  RootDir->Close (RootDir);
+
+  return Status;
+}
+
+STATIC
+EFI_STATUS
+CoDCountCapsulesOnFs (
+  IN  EFI_HANDLE  FsHandle,
+  OUT UINTN       *ValidFileCount,
+  OUT UINTN       *CandidateFileCount
+  )
+{
+  EFI_STATUS          Status;
+  EFI_STATUS          FileStatus;
+  EFI_FILE_HANDLE     FileDir;
+  EFI_FILE_HANDLE     FileHandle;
+  LIST_ENTRY          FileInfoList;
+  LIST_ENTRY          *Link;
+  FILE_INFO_ENTRY     *FileInfoEntry;
+  EFI_FILE_INFO       *FileInfo;
+  EFI_CAPSULE_HEADER  CapsuleHeader;
+  UINTN               HeaderSize;
+
+  *ValidFileCount     = 0;
+  *CandidateFileCount = 0;
+  FileHandle          = NULL;
+
+  Status = CoDOpenCapsuleDirectoryOnFs (FsHandle, &FileDir);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = GetFileInfoListInAlphabetFromDir (
+             FileDir,
+             EFI_FILE_SYSTEM | EFI_FILE_ARCHIVE,
+             &FileInfoList,
+             CandidateFileCount
+             );
+  if (EFI_ERROR (Status)) {
+    FileDir->Close (FileDir);
+    return Status;
+  }
+
+  for (Link = FileInfoList.ForwardLink; Link != &FileInfoList; Link = Link->ForwardLink) {
+    FileInfoEntry = CR (Link, FILE_INFO_ENTRY, Link, FILE_INFO_SIGNATURE);
+    FileInfo      = FileInfoEntry->FileInfo;
+    if ((FileInfo->FileSize < sizeof (CapsuleHeader)) ||
+        (FileInfo->FileSize > MAX_UINTN))
+    {
+      continue;
+    }
+
+    FileStatus = FileDir->Open (
+                           FileDir,
+                           &FileHandle,
+                           FileInfo->FileName,
+                           EFI_FILE_MODE_READ,
+                           0
+                           );
+    if (EFI_ERROR (FileStatus)) {
+      continue;
+    }
+
+    HeaderSize = sizeof (CapsuleHeader);
+    FileStatus = FileHandle->Read (FileHandle, &HeaderSize, &CapsuleHeader);
+    FileHandle->Close (FileHandle);
+    FileHandle = NULL;
+    if (!EFI_ERROR (FileStatus) &&
+        (HeaderSize == sizeof (CapsuleHeader)) &&
+        CoDIsValidCapsuleImage (&CapsuleHeader, FileInfo->FileSize))
+    {
+      (*ValidFileCount)++;
+    }
+  }
+
+  FileDir->Close (FileDir);
+  CoDFreeFileInfoList (&FileInfoList);
+  return EFI_SUCCESS;
+}
+
+STATIC
+BOOLEAN
+CoDIsEfiSystemPartition (
+  IN EFI_HANDLE  FsHandle
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Interface;
+
+  Status = gBS->HandleProtocol (FsHandle, &gEfiPartTypeSystemPartGuid, &Interface);
+  return !EFI_ERROR (Status);
+}
+
+/**
+  Select the filesystem containing capsule files.
+
+  The active boot option remains authoritative when it contains capsules.  In
+  capsule-in-RAM mode, connect devices and rescan EFI System Partitions when
+  that filesystem is not ready or has no candidates.  More than one fallback
+  ESP is rejected because there is no safe way to infer which one the OS used.
+  PreferredOptionNumber, when supplied, is updated with the allocation that
+  identifies a preferred filesystem found by the post-connect rescan.
+**/
+STATIC
+EFI_STATUS
+CoDSelectCapsuleFs (
+  IN  EFI_HANDLE  PreferredFsHandle OPTIONAL,
+  IN  UINTN       MaxRetry,
+  OUT EFI_HANDLE  *FsHandle,
+  OUT BOOLEAN     *UsedPreferred OPTIONAL,
+  IN OUT UINT16   **PreferredOptionNumber OPTIONAL,
+  OUT UINTN       *FileCount OPTIONAL
+  )
+{
+  EFI_STATUS  Status;
+  EFI_HANDLE  *HandleBuffer;
+  EFI_HANDLE  FallbackFsHandle;
+  EFI_HANDLE  ResolvedFsHandle;
+  UINT16      *ResolvedOptionNumber;
+  UINTN       NumberOfHandles;
+  UINTN       Index;
+  UINTN       CandidateCount;
+  UINTN       ValidCount;
+  UINTN       Attempt;
+
+  *FsHandle = NULL;
+  if (UsedPreferred != NULL) {
+    *UsedPreferred = FALSE;
+  }
+
+  if (FileCount != NULL) {
+    *FileCount = 0;
+  }
+
+  if (PreferredFsHandle != NULL) {
+    Status = CoDCountCapsulesOnFs (PreferredFsHandle, &ValidCount, &CandidateCount);
+    //
+    // Keep the active ESP authoritative even when every candidate is
+    // malformed.  CoDGetAll() must select the directory to remove those files
+    // and prevent a persistent capsule retry loop.  Fallback ESPs below still
+    // require a structurally valid capsule.
+    //
+    if (!EFI_ERROR (Status) && (CandidateCount > 0)) {
+      *FsHandle = PreferredFsHandle;
+      if (UsedPreferred != NULL) {
+        *UsedPreferred = TRUE;
+      }
+
+      if (FileCount != NULL) {
+        *FileCount = CandidateCount;
+      }
+
+      return EFI_SUCCESS;
+    }
+  }
+
+  //
+  // Disk relocation records a boot option for later cleanup.  Do not select a
+  // filesystem unrelated to that option when capsule-in-RAM is disabled.
+  //
+  if (!PcdGetBool (PcdCapsuleInRamSupport)) {
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // ConnectAll() may dispatch option ROMs.  The first capsule pass runs before
+  // EndOfDxe and platform security lockdown, so defer the fallback until the
+  // documented second pass after EndOfDxe.  The preferred ESP path above stays
+  // available during the first pass.
+  //
+  if (!mDxeCapsuleLibEndOfDxe) {
+    return EFI_NOT_READY;
+  }
+
+  //
+  // A global connection pass can change the final handle graph and memory map.
+  // Preserve the platform's S4 resume policy even if OsIndications is stale.
+  //
+  if (GetBootModeHob () == BOOT_ON_S4_RESUME) {
+    return EFI_NOT_READY;
+  }
+
+  Attempt          = 0;
+  FallbackFsHandle = NULL;
+  do {
+    EfiBootManagerConnectAll ();
+
+    //
+    // Resolve the active ESP again because connecting devices may have exposed
+    // a more complete path than the initial boot-option lookup could find.
+    //
+    ResolvedFsHandle      = NULL;
+    ResolvedOptionNumber = NULL;
+    Status               = GetEfiSysPartitionFromActiveBootOption (
+                             0,
+                             &ResolvedOptionNumber,
+                             &ResolvedFsHandle
+                             );
+    if (!EFI_ERROR (Status)) {
+      PreferredFsHandle = ResolvedFsHandle;
+      if (PreferredOptionNumber != NULL) {
+        if (*PreferredOptionNumber != NULL) {
+          FreePool (*PreferredOptionNumber);
+        }
+
+        *PreferredOptionNumber = ResolvedOptionNumber;
+        ResolvedOptionNumber   = NULL;
+      }
+    }
+
+    if (ResolvedOptionNumber != NULL) {
+      FreePool (ResolvedOptionNumber);
+    }
+
+    if (PreferredFsHandle != NULL) {
+      Status = CoDCountCapsulesOnFs (PreferredFsHandle, &ValidCount, &CandidateCount);
+      if (!EFI_ERROR (Status) && (CandidateCount > 0)) {
+        *FsHandle = PreferredFsHandle;
+        if (UsedPreferred != NULL) {
+          *UsedPreferred = TRUE;
+        }
+
+        if (FileCount != NULL) {
+          *FileCount = CandidateCount;
+        }
+
+        return EFI_SUCCESS;
+      }
+    }
+
+    HandleBuffer    = NULL;
+    NumberOfHandles = 0;
+    Status          = gBS->LocateHandleBuffer (
+                             ByProtocol,
+                             &gEfiSimpleFileSystemProtocolGuid,
+                             NULL,
+                             &NumberOfHandles,
+                             &HandleBuffer
+                             );
+    if (!EFI_ERROR (Status)) {
+      for (Index = 0; Index < NumberOfHandles; Index++) {
+        if ((HandleBuffer[Index] == PreferredFsHandle) ||
+            !CoDIsEfiSystemPartition (HandleBuffer[Index]))
+        {
+          continue;
+        }
+
+        Status = CoDCountCapsulesOnFs (HandleBuffer[Index], &ValidCount, &CandidateCount);
+        if (EFI_ERROR (Status) || (ValidCount == 0)) {
+          continue;
+        }
+
+        if ((FallbackFsHandle != NULL) &&
+            (FallbackFsHandle != HandleBuffer[Index]))
+        {
+          DEBUG ((DEBUG_ERROR, "%a(): capsule files found on multiple fallback ESPs\n", __func__));
+          FreePool (HandleBuffer);
+          return EFI_SECURITY_VIOLATION;
+        }
+
+        FallbackFsHandle = HandleBuffer[Index];
+      }
+
+      FreePool (HandleBuffer);
+    }
+
+    if (Attempt == MaxRetry) {
+      break;
+    }
+
+    gBS->Stall (100000);
+    Attempt++;
+  } while (TRUE);
+
+  if (FallbackFsHandle != NULL) {
+    Status = CoDCountCapsulesOnFs (FallbackFsHandle, &ValidCount, &CandidateCount);
+    if (!EFI_ERROR (Status) && (ValidCount > 0)) {
+      *FsHandle = FallbackFsHandle;
+      if (FileCount != NULL) {
+        *FileCount = CandidateCount;
+      }
+
+      return EFI_SUCCESS;
+    }
+  }
+
+  return EFI_NOT_FOUND;
+}
+
 /**
   This routine is called to get all qualified image from file from an given directory
   in alphabetic order. All the file image is copied to allocated boottime memory.
@@ -1014,6 +1465,15 @@ GetFileImageInAlphabetFromDir (
 
   DEBUG_CODE_END ();
 
+  //
+  // Individual files can disappear or fail to read while enumerating the
+  // directory.  Preserve any complete images already loaded so a sibling I/O
+  // error cannot discard them after the source files are removed.
+  //
+  if (FileCount > 0) {
+    Status = EFI_SUCCESS;
+  }
+
 EXIT:
 
   *FilePtr = TempFilePtrBuf;
@@ -1043,6 +1503,7 @@ EXIT:
   @param[in] FileAttr             Attribute of files to be deleted
 
   @retval EFI_SUCCESS  Succeed to remove all files from an given directory.
+  @return              Error returned while opening or deleting a file.
 
 **/
 EFI_STATUS
@@ -1052,6 +1513,7 @@ RemoveFileFromDir (
   )
 {
   EFI_STATUS       Status;
+  EFI_STATUS       FileStatus;
   LIST_ENTRY       *Link;
   LIST_ENTRY       FileInfoList;
   EFI_FILE_HANDLE  FileHandle;
@@ -1084,6 +1546,7 @@ RemoveFileFromDir (
   //
   // Delete all files with given attribute in Dir
   //
+  Status = EFI_SUCCESS;
   for (Link = FileInfoList.ForwardLink; Link != &(FileInfoList); Link = Link->ForwardLink) {
     //
     // Get FileInfo from the link list
@@ -1091,32 +1554,35 @@ RemoveFileFromDir (
     FileInfoEntry = CR (Link, FILE_INFO_ENTRY, Link, FILE_INFO_SIGNATURE);
     FileInfo      = FileInfoEntry->FileInfo;
 
-    Status = Dir->Open (
-                    Dir,
-                    &FileHandle,
-                    FileInfo->FileName,
-                    EFI_FILE_MODE_READ | EFI_FILE_MODE_WRITE,
-                    0
-                    );
-    if (EFI_ERROR (Status)) {
+    FileStatus = Dir->Open (
+                         Dir,
+                         &FileHandle,
+                         FileInfo->FileName,
+                         EFI_FILE_MODE_READ | EFI_FILE_MODE_WRITE,
+                         0
+                         );
+    if (EFI_ERROR (FileStatus)) {
+      if (!EFI_ERROR (Status)) {
+        Status = FileStatus;
+      }
+
       continue;
     }
 
-    Status = FileHandle->Delete (FileHandle);
+    FileStatus = FileHandle->Delete (FileHandle);
+    FileHandle = NULL;
+    if (FileStatus == EFI_WARN_DELETE_FAILURE) {
+      FileStatus = EFI_ACCESS_DENIED;
+    }
+
+    if (EFI_ERROR (FileStatus) && !EFI_ERROR (Status)) {
+      Status = FileStatus;
+    }
   }
 
 EXIT:
 
-  while (!IsListEmpty (&FileInfoList)) {
-    Link = FileInfoList.ForwardLink;
-    RemoveEntryList (Link);
-
-    FileInfoEntry = CR (Link, FILE_INFO_ENTRY, Link, FILE_INFO_SIGNATURE);
-
-    FreePool (FileInfoEntry->FileInfo);
-    FreePool (FileInfoEntry);
-  }
-
+  CoDFreeFileInfoList (&FileInfoList);
   return Status;
 }
 
@@ -1137,75 +1603,41 @@ CoDPresent (
   IN UINTN  MaxRetry
   )
 {
-  EFI_STATUS                       Status;
-  EFI_HANDLE                       FsHandle;
-  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL  *Fs;
-  EFI_FILE_HANDLE                  RootDir;
-  EFI_FILE_HANDLE                  FileDir;
-  UINT16                           *TempOptionNumber;
-  UINTN                            FileCount;
-  LIST_ENTRY                       FileInfoList;
-  LIST_ENTRY                       *Link;
-  FILE_INFO_ENTRY                  *FileInfoEntry;
+  EFI_STATUS  Status;
+  EFI_HANDLE  ActiveFsHandle;
+  EFI_HANDLE  CapsuleFsHandle;
+  UINT16      *TempOptionNumber;
+  UINTN       FileCount;
 
   if (!PcdGetBool (PcdCapsuleOnDiskSupport)) {
     return FALSE;
   }
 
   TempOptionNumber = NULL;
-  Status = GetEfiSysPartitionFromActiveBootOption (MaxRetry, &TempOptionNumber, &FsHandle);
+  ActiveFsHandle   = NULL;
+  CapsuleFsHandle  = NULL;
+  FileCount        = 0;
+
+  Status = GetEfiSysPartitionFromActiveBootOption (MaxRetry, &TempOptionNumber, &ActiveFsHandle);
   if (EFI_ERROR (Status)) {
-    return FALSE;
+    DEBUG ((DEBUG_INFO, "%a(): active boot option lookup failed: %r\n", __func__, Status));
   }
 
-  Status = gBS->HandleProtocol (FsHandle, &gEfiSimpleFileSystemProtocolGuid, (VOID **)&Fs);
-  if (EFI_ERROR (Status)) {
-    return FALSE;
-  }
-
-  Status = Fs->OpenVolume (Fs, &RootDir);
-  if (EFI_ERROR (Status)) {
-    return FALSE;
-  }
-
-  Status = RootDir->Open (
-                      RootDir,
-                      &FileDir,
-                      EFI_CAPSULE_FILE_DIRECTORY,
-                      EFI_FILE_MODE_READ,
-                      0
-                      );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "CoDPresent failed to open %s: %r\n", EFI_CAPSULE_FILE_DIRECTORY, Status));
-    RootDir->Close (RootDir);
-    return FALSE;
-  }
-
-  RootDir->Close (RootDir);
-
-  FileCount = 0;
-  Status = GetFileInfoListInAlphabetFromDir (
-             FileDir,
-             EFI_FILE_SYSTEM | EFI_FILE_ARCHIVE,
-             &FileInfoList,
+  Status = CoDSelectCapsuleFs (
+             ActiveFsHandle,
+             MaxRetry,
+             &CapsuleFsHandle,
+             NULL,
+             NULL,
              &FileCount
              );
-  FileDir->Close (FileDir);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "GetFileInfoListInAlphabetFromDir failed: %r\n", Status));
-    return FALSE;
+  if (TempOptionNumber != NULL) {
+    FreePool (TempOptionNumber);
   }
 
-  while (!IsListEmpty (&FileInfoList)) {
-    Link = FileInfoList.ForwardLink;
-    RemoveEntryList (Link);
-
-    FileInfoEntry = CR (Link, FILE_INFO_ENTRY, Link, FILE_INFO_SIGNATURE);
-
-    FreePool (FileInfoEntry->FileInfo);
-    FreePool (FileInfoEntry->FileNameFirstPart);
-    FreePool (FileInfoEntry->FileNameSecondPart);
-    FreePool (FileInfoEntry);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "%a(): found no capsule filesystem: %r\n", __func__, Status));
+    return FALSE;
   }
 
   DEBUG ((DEBUG_INFO, "%a(): found %u potential on-disk capsule(s)\n", __func__, FileCount));
@@ -1223,7 +1655,8 @@ CoDPresent (
   @param[out]   FsHandle             File system handle
   @param[out]   LoadOptionNumber     OptionNumber of boot option
 
-  @retval EFI_SUCCESS  Succeed to get all capsules.
+  @retval EFI_SUCCESS              Succeed to get all capsules.
+  @retval EFI_WARN_DELETE_FAILURE  Valid capsules were loaded, but at least one source file could not be removed.
 
 **/
 EFI_STATUS
@@ -1236,44 +1669,59 @@ CoDGetAll (
   OUT UINT16      *LoadOptionNumber
   )
 {
-  EFI_STATUS                       Status;
-  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL  *Fs;
-  EFI_FILE_HANDLE                  RootDir;
-  EFI_FILE_HANDLE                  FileDir;
-  UINT16                           *TempOptionNumber;
+  EFI_STATUS       Status;
+  EFI_STATUS       RemoveStatus;
+  EFI_STATUS       ClearStatus;
+  EFI_HANDLE       ActiveFsHandle;
+  EFI_FILE_HANDLE  FileDir;
+  UINT16           *TempOptionNumber;
+  BOOLEAN          UsedPreferred;
+  BOOLEAN          AllCandidatesRead;
+  UINTN            CandidateCount;
+  UINTN            LoadedCandidateCount;
 
-  TempOptionNumber = NULL;
-  *CapsuleNum      = 0;
+  TempOptionNumber       = NULL;
+  ActiveFsHandle         = NULL;
+  FileDir                = NULL;
+  UsedPreferred          = FALSE;
+  AllCandidatesRead      = FALSE;
+  CandidateCount         = 0;
+  LoadedCandidateCount   = 0;
+  *CapsulePtr            = NULL;
+  *CapsuleNum            = 0;
+  *FsHandle              = NULL;
 
-  Status = GetEfiSysPartitionFromActiveBootOption (MaxRetry, &TempOptionNumber, FsHandle);
+  Status = GetEfiSysPartitionFromActiveBootOption (MaxRetry, &TempOptionNumber, &ActiveFsHandle);
   if (EFI_ERROR (Status)) {
-    return Status;
+    DEBUG ((DEBUG_INFO, "%a(): active boot option lookup failed: %r\n", __func__, Status));
   }
 
-  Status = gBS->HandleProtocol (*FsHandle, &gEfiSimpleFileSystemProtocolGuid, (VOID **)&Fs);
+  Status = CoDSelectCapsuleFs (
+             ActiveFsHandle,
+             MaxRetry,
+             FsHandle,
+             &UsedPreferred,
+             &TempOptionNumber,
+             &CandidateCount
+             );
   if (EFI_ERROR (Status)) {
-    return Status;
+    goto EXIT;
   }
 
-  Status = Fs->OpenVolume (Fs, &RootDir);
-  if (EFI_ERROR (Status)) {
-    return Status;
+  if (LoadOptionNumber != NULL) {
+    if (!UsedPreferred || (TempOptionNumber == NULL)) {
+      Status = EFI_UNSUPPORTED;
+      goto EXIT;
+    }
+
+    *LoadOptionNumber = *TempOptionNumber;
   }
 
-  Status = RootDir->Open (
-                      RootDir,
-                      &FileDir,
-                      EFI_CAPSULE_FILE_DIRECTORY,
-                      EFI_FILE_MODE_READ,
-                      0
-                      );
+  Status = CoDOpenCapsuleDirectoryOnFs (*FsHandle, &FileDir);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "CodLibGetAllCapsuleOnDisk fail to open RootDir!\n"));
-    RootDir->Close (RootDir);
-    return Status;
+    DEBUG ((DEBUG_ERROR, "%a(): failed to open capsule directory: %r\n", __func__, Status));
+    goto EXIT;
   }
-
-  RootDir->Close (RootDir);
 
   //
   // Only Load files with EFI_FILE_SYSTEM or EFI_FILE_ARCHIVE attribute
@@ -1286,17 +1734,50 @@ CoDGetAll (
              CapsuleNum
              );
   DEBUG ((DEBUG_INFO, "GetFileImageInAlphabetFromDir status %x\n", Status));
+  if (!EFI_ERROR (Status)) {
+    LoadedCandidateCount = *CapsuleNum;
+    AllCandidatesRead    = (BOOLEAN)(LoadedCandidateCount == CandidateCount);
+    Status = CoDFilterInvalidCapsuleImages (*CapsulePtr, CapsuleNum);
+  }
 
   //
   // Always remove file to avoid deadloop in capsule process
   //
-  Status = RemoveFileFromDir (FileDir, EFI_FILE_SYSTEM | EFI_FILE_ARCHIVE);
-  DEBUG ((DEBUG_INFO, "RemoveFileFromDir status %x\n", Status));
+  RemoveStatus = RemoveFileFromDir (FileDir, EFI_FILE_SYSTEM | EFI_FILE_ARCHIVE);
+  DEBUG ((DEBUG_INFO, "RemoveFileFromDir status %x\n", RemoveStatus));
+  if (EFI_ERROR (RemoveStatus)) {
+    DEBUG ((DEBUG_ERROR, "%a(): failed to remove capsule files: %r\n", __func__, RemoveStatus));
+    if (AllCandidatesRead && CoDCheckCapsuleOnDiskFlag ()) {
+      //
+      // Every selected candidate was read.  Valid images remain in memory and
+      // malformed images were rejected, so an undeletable source must not keep
+      // the platform in the capsule boot path forever.
+      //
+      ClearStatus = CoDClearCapsuleOnDiskFlag ();
+      if (EFI_ERROR (ClearStatus)) {
+        DEBUG ((DEBUG_ERROR, "%a(): failed to retire capsule request: %r\n", __func__, ClearStatus));
+      }
+    }
+
+    if (*CapsuleNum > 0) {
+      //
+      // Preserve loaded images when cleanup is only partially successful.
+      // EFI_WARN_DELETE_FAILURE reports the cleanup problem without making
+      // callers discard capsules whose source files may already be gone.
+      //
+      Status = EFI_WARN_DELETE_FAILURE;
+    } else {
+      Status = RemoveStatus;
+    }
+  } else if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "%a(): removed invalid capsule files: %r\n", __func__, Status));
+  }
 
   FileDir->Close (FileDir);
 
-  if (LoadOptionNumber != NULL) {
-    *LoadOptionNumber = *TempOptionNumber;
+EXIT:
+  if (TempOptionNumber != NULL) {
+    FreePool (TempOptionNumber);
   }
 
   return Status;
@@ -1589,7 +2070,8 @@ RelocateCapsuleToDisk (
   Status = CoDGetAll (MaxRetry, &CapsuleOnDiskBuf, &CapsuleOnDiskNum, &Handle, &LoadOptionNumber);
   if (EFI_ERROR (Status) || (CapsuleOnDiskNum == 0) || (CapsuleOnDiskBuf == NULL)) {
     DEBUG ((DEBUG_INFO, "RelocateCapsule: CoDGetAll Status - 0x%x\n", Status));
-    return EFI_NOT_FOUND;
+    CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    return EFI_ERROR (Status) ? Status : EFI_NOT_FOUND;
   }
 
   //
@@ -1896,7 +2378,8 @@ RelocateCapsuleToRam (
   Status = CoDGetAll (MaxRetry, &CapsuleOnDiskBuf, &CapsuleOnDiskNum, &Handle, NULL);
   if (EFI_ERROR (Status) || (CapsuleOnDiskNum == 0) || (CapsuleOnDiskBuf == NULL)) {
     DEBUG ((DEBUG_ERROR, "CoDGetAll Status - 0x%x\n", Status));
-    return EFI_NOT_FOUND;
+    CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    return EFI_ERROR (Status) ? Status : EFI_NOT_FOUND;
   }
 
   //

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/CapsuleOnDisk.h
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/CapsuleOnDisk.h
@@ -58,15 +58,3 @@ typedef struct {
   CHAR16           *FileNameFirstPart;   ///  Text to the left of right-most period in the file name. String is capitialized
   CHAR16           *FileNameSecondPart;  ///  Text to the right of right-most period in the file name.String is capitialized. Maybe NULL
 } FILE_INFO_ENTRY;
-
-typedef struct {
-  //
-  // image address.
-  //
-  VOID             *ImageAddress;
-  //
-  // The file info of the image comes from.
-  //  if FileInfo == NULL. means image does not come from file
-  //
-  EFI_FILE_INFO    *FileInfo;
-} IMAGE_INFO;

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
@@ -72,7 +72,8 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleEmbeddedDriverSupport             ## CONSUMES
 
 [FeaturePcd]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportUpdateCapsuleReset ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportUpdateCapsuleReset           ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskConnectBootDevice      ## CONSUMES
 
 [Protocols]
   gEsrtManagementProtocolGuid                   ## CONSUMES

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -225,11 +225,18 @@ InitCapsulePtr (
   UINTN                 CapsuleNameCapsuleTotalNumber;
   VOID                  **CapsuleNameCapsulePtr;
   EFI_PHYSICAL_ADDRESS  *CapsuleNameAddress;
+  EFI_STATUS            Status;
+  UINTN                 CapsuleOnDiskNum;
+  IMAGE_INFO            *CapsuleOnDiskBuf;
+  EFI_HANDLE            EspFsHandle;
+  UINT16                LoadOptionNumber;
 
   CapsuleNameNumber             = 0;
   CapsuleNameTotalNumber        = 0;
   CapsuleNameCapsuleTotalNumber = 0;
+  CapsuleOnDiskNum              = 0;
   CapsuleNameCapsulePtr         = NULL;
+  CapsuleOnDiskBuf              = NULL;
 
   //
   // Find all capsule images from hob
@@ -249,6 +256,23 @@ InitCapsulePtr (
     HobPointer.Raw = GET_NEXT_HOB (HobPointer);
   }
 
+  if (CoDCheckCapsuleOnDiskFlag ()) {
+    Status = CoDGetAll (
+               3,
+               &CapsuleOnDiskBuf,
+               &CapsuleOnDiskNum,
+               &EspFsHandle,
+               &LoadOptionNumber
+               );
+    if (EFI_ERROR (Status) || (CapsuleOnDiskBuf == NULL)) {
+      DEBUG ((DEBUG_WARN, "%a(): CoDGetAll Status: %r\n", __func__, Status));
+      CapsuleOnDiskNum = 0;
+    }
+
+    mCapsuleTotalNumber += CapsuleOnDiskNum;
+    DEBUG ((DEBUG_INFO, "%a(): loaded %u on-disk capsule(s)\n", __func__, CapsuleOnDiskNum));
+  }
+
   DEBUG ((DEBUG_INFO, "mCapsuleTotalNumber - 0x%x\n", mCapsuleTotalNumber));
 
   if (mCapsuleTotalNumber == 0) {
@@ -262,12 +286,14 @@ InitCapsulePtr (
   if (mCapsulePtr == NULL) {
     DEBUG ((DEBUG_ERROR, "Allocate mCapsulePtr fail!\n"));
     mCapsuleTotalNumber = 0;
+    CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
     return;
   }
 
   mCapsuleStatusArray = (EFI_STATUS *)AllocateZeroPool (sizeof (EFI_STATUS) * mCapsuleTotalNumber);
   if (mCapsuleStatusArray == NULL) {
     DEBUG ((DEBUG_ERROR, "Allocate mCapsuleStatusArray fail!\n"));
+    CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
     FreePool (mCapsulePtr);
     mCapsulePtr         = NULL;
     mCapsuleTotalNumber = 0;
@@ -279,6 +305,7 @@ InitCapsulePtr (
   CapsuleNameCapsulePtr =  (VOID **)AllocateZeroPool (sizeof (VOID *) * CapsuleNameCapsuleTotalNumber);
   if (CapsuleNameCapsulePtr == NULL) {
     DEBUG ((DEBUG_ERROR, "Allocate CapsuleNameCapsulePtr fail!\n"));
+    CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
     FreePool (mCapsulePtr);
     FreePool (mCapsuleStatusArray);
     mCapsulePtr         = NULL;
@@ -317,6 +344,7 @@ InitCapsulePtr (
     mCapsuleNamePtr = (CHAR16 **)AllocateZeroPool (sizeof (CHAR16 *) * mCapsuleTotalNumber);
     if (mCapsuleNamePtr == NULL) {
       DEBUG ((DEBUG_ERROR, "Allocate mCapsuleNamePtr fail!\n"));
+      CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
       FreePool (mCapsulePtr);
       FreePool (mCapsuleStatusArray);
       FreePool (CapsuleNameCapsulePtr);
@@ -336,6 +364,15 @@ InitCapsulePtr (
     }
   } else {
     mCapsuleNamePtr = NULL;
+  }
+
+  if (CapsuleOnDiskBuf != NULL) {
+    for (Index2 = 0; Index2 < CapsuleOnDiskNum; Index2++) {
+      mCapsulePtr[Index++] = CapsuleOnDiskBuf[Index2].ImageAddress;
+      FreePool (CapsuleOnDiskBuf[Index2].FileInfo);
+    }
+
+    FreePool (CapsuleOnDiskBuf);
   }
 
   FreePool (CapsuleNameCapsulePtr);
@@ -511,7 +548,7 @@ ProcessTheseCapsules (
 
   REPORT_STATUS_CODE (EFI_PROGRESS_CODE, (EFI_SOFTWARE | PcdGet32 (PcdStatusCodeSubClassCapsule) | PcdGet32 (PcdCapsuleStatusCodeProcessCapsulesBegin)));
 
-  if (FirstRound) {
+  if (FirstRound || (PcdGetBool (PcdCapsuleOnDiskSupport) && (mCapsuleTotalNumber == 0))) {
     InitCapsulePtr ();
   }
 
@@ -686,7 +723,10 @@ ProcessCapsules (
     // Reboot System if and only if all capsule processed.
     // If not, defer reset to 2nd process.
     //
-    if (mNeedReset && AreAllImagesProcessed ()) {
+    if (mNeedReset &&
+        (!CoDCheckCapsuleOnDiskFlag () || (mCapsuleTotalNumber != 0)) &&
+        AreAllImagesProcessed ())
+    {
       DoResetSystem ();
     }
   } else {

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -780,7 +780,10 @@ ProcessTheseCapsules (
       CapsulesLoadedAfterEndOfDxe = (BOOLEAN)(mCapsuleTotalNumber != 0);
     } else if (mCapsuleOnDiskDeferred) {
       Status = AppendDeferredCapsulesOnDisk ();
-      if (Status == EFI_OUT_OF_RESOURCES) {
+      if (EFI_ERROR (Status) &&
+          (Status != EFI_NOT_FOUND) &&
+          (Status != EFI_NOT_READY))
+      {
         return Status;
       }
 

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -130,6 +130,7 @@ CHAR16      **mCapsuleNamePtr;
 EFI_STATUS  *mCapsuleStatusArray;
 UINT32      mCapsuleTotalNumber;
 BOOLEAN     mCapsuleOnDiskDeferred;
+STATIC EFI_STATUS  mCapsuleOnDiskStatus;
 STATIC IMAGE_INFO  *mQueuedCapsuleOnDiskBuf;
 STATIC UINTN       mQueuedCapsuleOnDiskNum;
 
@@ -293,6 +294,7 @@ InitCapsulePtr (
   CapsuleNameCapsulePtr         = NULL;
   CapsuleOnDiskBuf              = NULL;
   mCapsuleOnDiskDeferred        = FALSE;
+  mCapsuleOnDiskStatus          = EFI_SUCCESS;
 
   //
   // Find all capsule images from hob
@@ -322,6 +324,7 @@ InitCapsulePtr (
                &EspFsHandle,
                NULL
                );
+    mCapsuleOnDiskStatus = Status;
     if (EFI_ERROR (Status) || (CapsuleOnDiskBuf == NULL)) {
       DEBUG ((DEBUG_WARN, "%a(): CoDGetAll Status: %r\n", __func__, Status));
       mCapsuleOnDiskDeferred = (BOOLEAN)(Status == EFI_NOT_READY);
@@ -501,6 +504,7 @@ AppendDeferredCapsulesOnDisk (
                &EspFsHandle,
                NULL
                );
+    mCapsuleOnDiskStatus = Status;
     if (EFI_ERROR (Status) || (CapsuleOnDiskBuf == NULL)) {
       DEBUG ((DEBUG_WARN, "%a(): CoDGetAll Status: %r\n", __func__, Status));
       mCapsuleOnDiskDeferred = (BOOLEAN)(Status == EFI_NOT_READY);
@@ -590,6 +594,7 @@ AppendDeferredCapsulesOnDisk (
   mCapsuleNamePtr          = NewCapsuleNamePtr;
   mCapsuleTotalNumber      = NewCapsuleTotalNumber;
   mCapsuleOnDiskDeferred   = FALSE;
+  mCapsuleOnDiskStatus     = EFI_SUCCESS;
 
   DEBUG ((DEBUG_INFO, "%a(): appended %u on-disk capsule(s)\n", __func__, CapsuleOnDiskNum));
   return EFI_SUCCESS;
@@ -787,6 +792,17 @@ ProcessTheseCapsules (
     if (mCapsuleOnDiskDeferred) {
       DEBUG ((DEBUG_INFO, "%a(): on-disk capsule discovery deferred until EndOfDxe\n", __func__));
       return EFI_SUCCESS;
+    }
+
+    if (mCapsuleOnDiskStatus == EFI_NOT_FOUND) {
+      if (CoDCheckCapsuleOnDiskFlag ()) {
+        Status = CoDClearCapsuleOnDiskFlag ();
+        if (EFI_ERROR (Status)) {
+          return Status;
+        }
+      }
+    } else if (EFI_ERROR (mCapsuleOnDiskStatus)) {
+      return mCapsuleOnDiskStatus;
     }
 
     //

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -129,6 +129,62 @@ VOID        **mCapsulePtr;
 CHAR16      **mCapsuleNamePtr;
 EFI_STATUS  *mCapsuleStatusArray;
 UINT32      mCapsuleTotalNumber;
+BOOLEAN     mCapsuleOnDiskDeferred;
+STATIC IMAGE_INFO  *mQueuedCapsuleOnDiskBuf;
+STATIC UINTN       mQueuedCapsuleOnDiskNum;
+
+/**
+  Queue loaded on-disk capsules when capsule array allocation must be retried.
+
+  CoDGetAll() may already have removed the source files.  Keep ownership of the
+  loaded images until a later capsule-processing pass can append them.
+
+  @param[in] CapsuleBuffer  Loaded capsule image information.
+  @param[in] CapsuleCount   Number of loaded capsule images.
+**/
+STATIC
+VOID
+QueueLoadedCapsulesOnDisk (
+  IN IMAGE_INFO  *CapsuleBuffer,
+  IN UINTN       CapsuleCount
+  )
+{
+  ASSERT (CapsuleBuffer != NULL);
+  ASSERT (CapsuleCount != 0);
+  ASSERT (mQueuedCapsuleOnDiskBuf == NULL);
+
+  mQueuedCapsuleOnDiskBuf = CapsuleBuffer;
+  mQueuedCapsuleOnDiskNum = CapsuleCount;
+  mCapsuleOnDiskDeferred  = TRUE;
+}
+
+/**
+  Take ownership of previously queued on-disk capsules.
+
+  @param[out] CapsuleBuffer  Loaded capsule image information.
+  @param[out] CapsuleCount   Number of loaded capsule images.
+
+  @retval TRUE   Queued capsules were returned.
+  @retval FALSE  No loaded capsules were queued.
+**/
+STATIC
+BOOLEAN
+TakeQueuedCapsulesOnDisk (
+  OUT IMAGE_INFO  **CapsuleBuffer,
+  OUT UINTN       *CapsuleCount
+  )
+{
+  if (mQueuedCapsuleOnDiskBuf == NULL) {
+    return FALSE;
+  }
+
+  *CapsuleBuffer              = mQueuedCapsuleOnDiskBuf;
+  *CapsuleCount               = mQueuedCapsuleOnDiskNum;
+  mQueuedCapsuleOnDiskBuf     = NULL;
+  mQueuedCapsuleOnDiskNum     = 0;
+  mCapsuleOnDiskDeferred      = FALSE;
+  return TRUE;
+}
 
 /**
   The firmware implements to process the capsule image.
@@ -229,7 +285,6 @@ InitCapsulePtr (
   UINTN                 CapsuleOnDiskNum;
   IMAGE_INFO            *CapsuleOnDiskBuf;
   EFI_HANDLE            EspFsHandle;
-  UINT16                LoadOptionNumber;
 
   CapsuleNameNumber             = 0;
   CapsuleNameTotalNumber        = 0;
@@ -237,6 +292,7 @@ InitCapsulePtr (
   CapsuleOnDiskNum              = 0;
   CapsuleNameCapsulePtr         = NULL;
   CapsuleOnDiskBuf              = NULL;
+  mCapsuleOnDiskDeferred        = FALSE;
 
   //
   // Find all capsule images from hob
@@ -256,22 +312,37 @@ InitCapsulePtr (
     HobPointer.Raw = GET_NEXT_HOB (HobPointer);
   }
 
-  if (CoDCheckCapsuleOnDiskFlag ()) {
+  if (TakeQueuedCapsulesOnDisk (&CapsuleOnDiskBuf, &CapsuleOnDiskNum)) {
+    DEBUG ((DEBUG_INFO, "%a(): retrying %u queued on-disk capsule(s)\n", __func__, CapsuleOnDiskNum));
+  } else if (CoDCheckCapsuleOnDiskFlag ()) {
     Status = CoDGetAll (
                3,
                &CapsuleOnDiskBuf,
                &CapsuleOnDiskNum,
                &EspFsHandle,
-               &LoadOptionNumber
+               NULL
                );
     if (EFI_ERROR (Status) || (CapsuleOnDiskBuf == NULL)) {
       DEBUG ((DEBUG_WARN, "%a(): CoDGetAll Status: %r\n", __func__, Status));
+      mCapsuleOnDiskDeferred = (BOOLEAN)(Status == EFI_NOT_READY);
+      if (CapsuleOnDiskBuf != NULL) {
+        CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+        CapsuleOnDiskBuf = NULL;
+      }
+
       CapsuleOnDiskNum = 0;
     }
-
-    mCapsuleTotalNumber += CapsuleOnDiskNum;
-    DEBUG ((DEBUG_INFO, "%a(): loaded %u on-disk capsule(s)\n", __func__, CapsuleOnDiskNum));
   }
+
+  if (CapsuleOnDiskNum > (MAX_UINT32 - mCapsuleTotalNumber)) {
+    DEBUG ((DEBUG_ERROR, "%a(): too many capsules to initialize\n", __func__));
+    mCapsuleTotalNumber = 0;
+    QueueLoadedCapsulesOnDisk (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    return;
+  }
+
+  mCapsuleTotalNumber += (UINT32)CapsuleOnDiskNum;
+  DEBUG ((DEBUG_INFO, "%a(): loaded %u on-disk capsule(s)\n", __func__, CapsuleOnDiskNum));
 
   DEBUG ((DEBUG_INFO, "mCapsuleTotalNumber - 0x%x\n", mCapsuleTotalNumber));
 
@@ -286,14 +357,20 @@ InitCapsulePtr (
   if (mCapsulePtr == NULL) {
     DEBUG ((DEBUG_ERROR, "Allocate mCapsulePtr fail!\n"));
     mCapsuleTotalNumber = 0;
-    CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    if (CapsuleOnDiskBuf != NULL) {
+      QueueLoadedCapsulesOnDisk (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    }
+
     return;
   }
 
   mCapsuleStatusArray = (EFI_STATUS *)AllocateZeroPool (sizeof (EFI_STATUS) * mCapsuleTotalNumber);
   if (mCapsuleStatusArray == NULL) {
     DEBUG ((DEBUG_ERROR, "Allocate mCapsuleStatusArray fail!\n"));
-    CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    if (CapsuleOnDiskBuf != NULL) {
+      QueueLoadedCapsulesOnDisk (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    }
+
     FreePool (mCapsulePtr);
     mCapsulePtr         = NULL;
     mCapsuleTotalNumber = 0;
@@ -305,7 +382,10 @@ InitCapsulePtr (
   CapsuleNameCapsulePtr =  (VOID **)AllocateZeroPool (sizeof (VOID *) * CapsuleNameCapsuleTotalNumber);
   if (CapsuleNameCapsulePtr == NULL) {
     DEBUG ((DEBUG_ERROR, "Allocate CapsuleNameCapsulePtr fail!\n"));
-    CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    if (CapsuleOnDiskBuf != NULL) {
+      QueueLoadedCapsulesOnDisk (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    }
+
     FreePool (mCapsulePtr);
     FreePool (mCapsuleStatusArray);
     mCapsulePtr         = NULL;
@@ -344,7 +424,10 @@ InitCapsulePtr (
     mCapsuleNamePtr = (CHAR16 **)AllocateZeroPool (sizeof (CHAR16 *) * mCapsuleTotalNumber);
     if (mCapsuleNamePtr == NULL) {
       DEBUG ((DEBUG_ERROR, "Allocate mCapsuleNamePtr fail!\n"));
-      CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+      if (CapsuleOnDiskBuf != NULL) {
+        QueueLoadedCapsulesOnDisk (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+      }
+
       FreePool (mCapsulePtr);
       FreePool (mCapsuleStatusArray);
       FreePool (CapsuleNameCapsulePtr);
@@ -376,6 +459,140 @@ InitCapsulePtr (
   }
 
   FreePool (CapsuleNameCapsulePtr);
+}
+
+/**
+  Append capsules whose filesystem discovery was deferred until EndOfDxe.
+
+  @retval EFI_SUCCESS           Deferred capsules were appended.
+  @retval EFI_NOT_FOUND         No deferred capsules were found.
+  @retval EFI_OUT_OF_RESOURCES  The capsule arrays could not be extended.
+  @return                       Error returned by CoDGetAll().
+**/
+STATIC
+EFI_STATUS
+AppendDeferredCapsulesOnDisk (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  IMAGE_INFO  *CapsuleOnDiskBuf;
+  UINTN       CapsuleOnDiskNum;
+  EFI_HANDLE  EspFsHandle;
+  VOID        **NewCapsulePtr;
+  EFI_STATUS  *NewCapsuleStatusArray;
+  CHAR16      **NewCapsuleNamePtr;
+  UINT32      NewCapsuleTotalNumber;
+  UINTN       Index;
+
+  CapsuleOnDiskBuf      = NULL;
+  CapsuleOnDiskNum      = 0;
+  NewCapsulePtr         = NULL;
+  NewCapsuleStatusArray = NULL;
+  NewCapsuleNamePtr     = NULL;
+
+  if (TakeQueuedCapsulesOnDisk (&CapsuleOnDiskBuf, &CapsuleOnDiskNum)) {
+    DEBUG ((DEBUG_INFO, "%a(): retrying %u queued on-disk capsule(s)\n", __func__, CapsuleOnDiskNum));
+  } else {
+    Status = CoDGetAll (
+               3,
+               &CapsuleOnDiskBuf,
+               &CapsuleOnDiskNum,
+               &EspFsHandle,
+               NULL
+               );
+    if (EFI_ERROR (Status) || (CapsuleOnDiskBuf == NULL)) {
+      DEBUG ((DEBUG_WARN, "%a(): CoDGetAll Status: %r\n", __func__, Status));
+      mCapsuleOnDiskDeferred = (BOOLEAN)(Status == EFI_NOT_READY);
+      if (CapsuleOnDiskBuf != NULL) {
+        CoDFreeImages (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+      }
+
+      return EFI_ERROR (Status) ? Status : EFI_NOT_FOUND;
+    }
+  }
+
+  if ((CapsuleOnDiskNum > (MAX_UINT32 - mCapsuleTotalNumber)) ||
+      ((mCapsuleTotalNumber + CapsuleOnDiskNum) > (MAX_UINTN / sizeof (*NewCapsulePtr))) ||
+      ((mCapsuleTotalNumber + CapsuleOnDiskNum) > (MAX_UINTN / sizeof (*NewCapsuleStatusArray))) ||
+      ((mCapsuleTotalNumber + CapsuleOnDiskNum) > (MAX_UINTN / sizeof (*NewCapsuleNamePtr))))
+  {
+    QueueLoadedCapsulesOnDisk (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewCapsuleTotalNumber = (UINT32)(mCapsuleTotalNumber + CapsuleOnDiskNum);
+  NewCapsulePtr = AllocateZeroPool (
+                    sizeof (*NewCapsulePtr) * NewCapsuleTotalNumber
+                    );
+  NewCapsuleStatusArray = AllocateZeroPool (
+                            sizeof (*NewCapsuleStatusArray) * NewCapsuleTotalNumber
+                            );
+  if (mCapsuleNamePtr != NULL) {
+    NewCapsuleNamePtr = AllocateZeroPool (
+                          sizeof (*NewCapsuleNamePtr) * NewCapsuleTotalNumber
+                          );
+  }
+
+  if ((NewCapsulePtr == NULL) ||
+      (NewCapsuleStatusArray == NULL) ||
+      ((mCapsuleNamePtr != NULL) && (NewCapsuleNamePtr == NULL)))
+  {
+    QueueLoadedCapsulesOnDisk (CapsuleOnDiskBuf, CapsuleOnDiskNum);
+    if (NewCapsulePtr != NULL) {
+      FreePool (NewCapsulePtr);
+    }
+
+    if (NewCapsuleStatusArray != NULL) {
+      FreePool (NewCapsuleStatusArray);
+    }
+
+    if (NewCapsuleNamePtr != NULL) {
+      FreePool (NewCapsuleNamePtr);
+    }
+
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (
+    NewCapsulePtr,
+    mCapsulePtr,
+    sizeof (*NewCapsulePtr) * mCapsuleTotalNumber
+    );
+  CopyMem (
+    NewCapsuleStatusArray,
+    mCapsuleStatusArray,
+    sizeof (*NewCapsuleStatusArray) * mCapsuleTotalNumber
+    );
+  if (NewCapsuleNamePtr != NULL) {
+    CopyMem (
+      NewCapsuleNamePtr,
+      mCapsuleNamePtr,
+      sizeof (*NewCapsuleNamePtr) * mCapsuleTotalNumber
+      );
+  }
+
+  for (Index = 0; Index < CapsuleOnDiskNum; Index++) {
+    NewCapsulePtr[mCapsuleTotalNumber + Index] = CapsuleOnDiskBuf[Index].ImageAddress;
+    NewCapsuleStatusArray[mCapsuleTotalNumber + Index] = EFI_NOT_READY;
+    FreePool (CapsuleOnDiskBuf[Index].FileInfo);
+  }
+
+  FreePool (CapsuleOnDiskBuf);
+  FreePool (mCapsulePtr);
+  FreePool (mCapsuleStatusArray);
+  if (mCapsuleNamePtr != NULL) {
+    FreePool (mCapsuleNamePtr);
+  }
+
+  mCapsulePtr              = NewCapsulePtr;
+  mCapsuleStatusArray      = NewCapsuleStatusArray;
+  mCapsuleNamePtr          = NewCapsuleNamePtr;
+  mCapsuleTotalNumber      = NewCapsuleTotalNumber;
+  mCapsuleOnDiskDeferred   = FALSE;
+
+  DEBUG ((DEBUG_INFO, "%a(): appended %u on-disk capsule(s)\n", __func__, CapsuleOnDiskNum));
+  return EFI_SUCCESS;
 }
 
 /**
@@ -544,15 +761,34 @@ ProcessTheseCapsules (
   ESRT_MANAGEMENT_PROTOCOL  *EsrtManagement;
   UINT16                    EmbeddedDriverCount;
   BOOLEAN                   ResetRequired;
+  BOOLEAN                   CapsulesLoadedAfterEndOfDxe;
   CHAR16                    *CapsuleName;
 
   REPORT_STATUS_CODE (EFI_PROGRESS_CODE, (EFI_SOFTWARE | PcdGet32 (PcdStatusCodeSubClassCapsule) | PcdGet32 (PcdCapsuleStatusCodeProcessCapsulesBegin)));
 
-  if (FirstRound || (PcdGetBool (PcdCapsuleOnDiskSupport) && (mCapsuleTotalNumber == 0))) {
+  CapsulesLoadedAfterEndOfDxe = FALSE;
+  if (FirstRound) {
     InitCapsulePtr ();
+  } else if (PcdGetBool (PcdCapsuleOnDiskSupport)) {
+    if (mCapsuleTotalNumber == 0) {
+      InitCapsulePtr ();
+      CapsulesLoadedAfterEndOfDxe = (BOOLEAN)(mCapsuleTotalNumber != 0);
+    } else if (mCapsuleOnDiskDeferred) {
+      Status = AppendDeferredCapsulesOnDisk ();
+      if (Status == EFI_OUT_OF_RESOURCES) {
+        return Status;
+      }
+
+      CapsulesLoadedAfterEndOfDxe = (BOOLEAN)!EFI_ERROR (Status);
+    }
   }
 
   if (mCapsuleTotalNumber == 0) {
+    if (mCapsuleOnDiskDeferred) {
+      DEBUG ((DEBUG_INFO, "%a(): on-disk capsule discovery deferred until EndOfDxe\n", __func__));
+      return EFI_SUCCESS;
+    }
+
     //
     // We didn't find a hob, so had no errors.
     //
@@ -569,7 +805,7 @@ ProcessTheseCapsules (
   // Check the capsule flags,if contains CAPSULE_FLAGS_POPULATE_SYSTEM_TABLE, install
   // capsuleTable to configure table with EFI_CAPSULE_GUID
   //
-  if (FirstRound) {
+  if (FirstRound || CapsulesLoadedAfterEndOfDxe) {
     PopulateCapsuleInConfigurationTable ();
   }
 
@@ -581,7 +817,9 @@ ProcessTheseCapsules (
   for (Index = 0; Index < mCapsuleTotalNumber; Index++) {
     CapsuleHeader = (EFI_CAPSULE_HEADER *)mCapsulePtr[Index];
     CapsuleName   = (mCapsuleNamePtr == NULL) ? NULL : mCapsuleNamePtr[Index];
-    if (CompareGuid (&CapsuleHeader->CapsuleGuid, &gWindowsUxCapsuleGuid)) {
+    if ((mCapsuleStatusArray[Index] == EFI_NOT_READY) &&
+        CompareGuid (&CapsuleHeader->CapsuleGuid, &gWindowsUxCapsuleGuid))
+    {
       DEBUG ((DEBUG_INFO, "ProcessThisCapsuleImage (Ux) - 0x%x\n", CapsuleHeader));
       DEBUG ((DEBUG_INFO, "Display logo capsule is found.\n"));
       Status                     = ProcessThisCapsuleImage (CapsuleHeader, CapsuleName, NULL);
@@ -723,7 +961,7 @@ ProcessCapsules (
     // Reboot System if and only if all capsule processed.
     // If not, defer reset to 2nd process.
     //
-    if (mNeedReset &&
+    if (mNeedReset && !mCapsuleOnDiskDeferred &&
         (!CoDCheckCapsuleOnDiskFlag () || (mCapsuleTotalNumber != 0)) &&
         AreAllImagesProcessed ())
     {
@@ -734,7 +972,7 @@ ProcessCapsules (
     //
     // Reboot System if required after all capsule processed
     //
-    if (mNeedReset) {
+    if (mNeedReset && !mCapsuleOnDiskDeferred) {
       DoResetSystem ();
     }
   }

--- a/MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.c
@@ -103,6 +103,79 @@ CoDCheckCapsuleOnDiskFlag (
 }
 
 /**
+  Check if any on-disk capsules are present.
+
+  @param[in]  MaxRetry  Max Connection Retry. Stall 100ms between each
+                        connection try to ensure devices like USB can get
+                        enumerated.
+
+  @retval TRUE   At least one potential on-disk capsule was found on a boot
+                 drive.
+  @retval FALSE  No capsule candidates were discovered on a boot drive.
+**/
+BOOLEAN
+EFIAPI
+CoDPresent (
+  IN UINTN  MaxRetry
+  )
+{
+  (VOID)MaxRetry;
+
+  return FALSE;
+}
+
+/**
+  This routine is called to get all capsules from file. The capsule file image is
+  copied to BS memory. Caller is responsible to free them.
+
+  @param[in]    MaxRetry             Max Connection Retry. Stall 100ms between each connection try to ensure
+                                     devices like USB can get enumerated.
+  @param[out]   CapsulePtr           Copied Capsule file Image Info buffer
+  @param[out]   CapsuleNum           CapsuleNumber
+  @param[out]   FsHandle             File system handle
+  @param[out]   LoadOptionNumber     OptionNumber of boot option
+
+  @retval EFI_UNSUPPORTED  Capsule on disk is unsupported.
+
+**/
+EFI_STATUS
+EFIAPI
+CoDGetAll (
+  IN  UINTN       MaxRetry,
+  OUT IMAGE_INFO  **CapsulePtr,
+  OUT UINTN       *CapsuleNum,
+  OUT EFI_HANDLE  *FsHandle,
+  OUT UINT16      *LoadOptionNumber
+  )
+{
+  (VOID)MaxRetry;
+  (VOID)CapsulePtr;
+  (VOID)CapsuleNum;
+  (VOID)FsHandle;
+  (VOID)LoadOptionNumber;
+
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Free resources allocated by CoDGetAll.
+
+  @param[in]  ImageInfo  An array of data and information of files
+  @param[in]  Count      Length of the array.
+
+**/
+VOID
+EFIAPI
+CoDFreeImages (
+  IN IMAGE_INFO  *ImageInfo,
+  IN UINTN       Count
+  )
+{
+  (VOID)ImageInfo;
+  (VOID)Count;
+}
+
+/**
   This routine is called to clear CapsuleOnDisk flags including OsIndications and BootNext variable.
 
   @retval EFI_SUCCESS   All Capsule On Disk flags are cleared

--- a/MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibNull/DxeCapsuleLibNull.c
@@ -105,9 +105,15 @@ CoDCheckCapsuleOnDiskFlag (
 /**
   Check if any on-disk capsules are present.
 
-  @param[in]  MaxRetry  Max Connection Retry. Stall 100ms between each
-                        connection try to ensure devices like USB can get
-                        enumerated.
+  @param[in]  MaxRetry          Max Connection Retry. Stall 100ms between each
+                                connection try to ensure devices like USB can
+                                get enumerated.
+  @param[in]  ConnectBootDevice Connect the active boot device before expanding
+                                its media path.
+  @param[out] BootDeviceReady   Set to TRUE when the active boot option's
+                                filesystem is available. Optional.
+  @param[out] ConnectAllNeeded  Set to TRUE when an active media-only boot path
+                                needs global device connection. Optional.
 
   @retval TRUE   At least one potential on-disk capsule was found on a boot
                  drive.
@@ -116,10 +122,21 @@ CoDCheckCapsuleOnDiskFlag (
 BOOLEAN
 EFIAPI
 CoDPresent (
-  IN UINTN  MaxRetry
+  IN  UINTN    MaxRetry,
+  IN  BOOLEAN  ConnectBootDevice,
+  OUT BOOLEAN  *BootDeviceReady OPTIONAL,
+  OUT BOOLEAN  *ConnectAllNeeded OPTIONAL
   )
 {
   (VOID)MaxRetry;
+  (VOID)ConnectBootDevice;
+  if (BootDeviceReady != NULL) {
+    *BootDeviceReady = FALSE;
+  }
+
+  if (ConnectAllNeeded != NULL) {
+    *ConnectAllNeeded = FALSE;
+  }
 
   return FALSE;
 }

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -598,6 +598,7 @@ BmFindUsbDevice (
   @param FullPath      The full path returned by the routine in last call.
                        Set to NULL in first call.
   @param ShortformNode Pointer to the USB short-form device path node in the FilePath buffer.
+  @param ConnectAll    Whether short-form expansion may connect all devices.
 
   @return The next possible full path pointing to the load option.
           Caller is responsible to free the memory.
@@ -606,7 +607,8 @@ EFI_DEVICE_PATH_PROTOCOL *
 BmExpandUsbDevicePath (
   IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
   IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath,
-  IN  EFI_DEVICE_PATH_PROTOCOL  *ShortformNode
+  IN  EFI_DEVICE_PATH_PROTOCOL  *ShortformNode,
+  IN  BOOLEAN                   ConnectAll
   )
 {
   UINTN                     ParentDevicePathSize;
@@ -632,7 +634,7 @@ BmExpandUsbDevicePath (
       continue;
     }
 
-    NextFullPath = BmGetNextLoadOptionDevicePath (FilePath, NULL);
+    NextFullPath = BmGetNextLoadOptionDevicePath (FilePath, NULL, ConnectAll);
     FreePool (FilePath);
     if (NextFullPath == NULL) {
       //
@@ -664,6 +666,7 @@ BmExpandUsbDevicePath (
                        It could be a short-form device path.
   @param FullPath      The full path returned by the routine in last call.
                        Set to NULL in first call.
+  @param ConnectAll    Whether short-form expansion may connect all devices.
 
   @return The next possible full path pointing to the load option.
           Caller is responsible to free the memory.
@@ -671,7 +674,8 @@ BmExpandUsbDevicePath (
 EFI_DEVICE_PATH_PROTOCOL *
 BmExpandFileDevicePath (
   IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
-  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath,
+  IN  BOOLEAN                   ConnectAll
   )
 {
   EFI_STATUS                Status;
@@ -683,7 +687,9 @@ BmExpandFileDevicePath (
   EFI_DEVICE_PATH_PROTOCOL  *NextFullPath;
   BOOLEAN                   GetNext;
 
-  EfiBootManagerConnectAll ();
+  if (ConnectAll) {
+    EfiBootManagerConnectAll ();
+  }
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiSimpleFileSystemProtocolGuid, NULL, &HandleCount, &Handles);
   if (EFI_ERROR (Status)) {
     HandleCount = 0;
@@ -738,6 +744,7 @@ BmExpandFileDevicePath (
                        It could be a short-form device path.
   @param FullPath      The full path returned by the routine in last call.
                        Set to NULL in first call.
+  @param ConnectAll    Whether short-form expansion may connect all devices.
 
   @return The next possible full path pointing to the load option.
           Caller is responsible to free the memory.
@@ -745,7 +752,8 @@ BmExpandFileDevicePath (
 EFI_DEVICE_PATH_PROTOCOL *
 BmExpandUriDevicePath (
   IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
-  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath,
+  IN  BOOLEAN                   ConnectAll
   )
 {
   EFI_STATUS                Status;
@@ -756,7 +764,9 @@ BmExpandUriDevicePath (
   EFI_DEVICE_PATH_PROTOCOL  *RamDiskDevicePath;
   BOOLEAN                   GetNext;
 
-  EfiBootManagerConnectAll ();
+  if (ConnectAll) {
+    EfiBootManagerConnectAll ();
+  }
   Status = gBS->LocateHandleBuffer (ByProtocol, &gEfiLoadFileProtocolGuid, NULL, &HandleCount, &Handles);
   if (EFI_ERROR (Status)) {
     HandleCount = 0;
@@ -865,12 +875,14 @@ BmCachePartitionDevicePath (
 
   @param FilePath      The device path pointing to a load option.
                        It could be a short-form device path.
+  @param ConnectAll    Whether short-form expansion may connect all devices.
 
   @return The full device path pointing to the load option.
 **/
 EFI_DEVICE_PATH_PROTOCOL *
 BmExpandPartitionDevicePath (
-  IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
+  IN  BOOLEAN                   ConnectAll
   )
 {
   EFI_STATUS                Status;
@@ -941,7 +953,7 @@ BmExpandPartitionDevicePath (
           //   2. ACPI()/PCI()/ATA()/Partition()/Partition(A2)/EFI/BootX64.EFI
           // For simplicity, only #1 is returned.
           //
-          FullPath = BmGetNextLoadOptionDevicePath (TempDevicePath, NULL);
+          FullPath = BmGetNextLoadOptionDevicePath (TempDevicePath, NULL, ConnectAll);
           FreePool (TempDevicePath);
 
           if (FullPath != NULL) {
@@ -1010,7 +1022,7 @@ BmExpandPartitionDevicePath (
         // Find the matched partition device path
         //
         TempDevicePath = AppendDevicePath (BlockIoDevicePath, NextDevicePathNode (FilePath));
-        FullPath       = BmGetNextLoadOptionDevicePath (TempDevicePath, NULL);
+        FullPath       = BmGetNextLoadOptionDevicePath (TempDevicePath, NULL, ConnectAll);
         FreePool (TempDevicePath);
 
         if (FullPath != NULL) {
@@ -1038,7 +1050,7 @@ BmExpandPartitionDevicePath (
     // If we found a matching BLOCK_IO handle or we've already
     // tried a ConnectAll, we are done searching.
     //
-    if (MatchFound || ConnectAllAttempted) {
+    if (MatchFound || ConnectAllAttempted || !ConnectAll) {
       break;
     }
 
@@ -1674,6 +1686,7 @@ EfiBootManagerGetLoadOptionBuffer (
                    It could be a short-form device path.
   @param FullPath  The full path returned by the routine in last call.
                    Set to NULL in first call.
+  @param ConnectAll Whether short-form expansion may connect all devices.
 
   @return The next possible full path pointing to the load option.
           Caller is responsible to free the memory.
@@ -1681,7 +1694,8 @@ EfiBootManagerGetLoadOptionBuffer (
 EFI_DEVICE_PATH_PROTOCOL *
 BmGetNextLoadOptionDevicePath (
   IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
-  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath,
+  IN  BOOLEAN                   ConnectAll
   )
 {
   EFI_HANDLE                Handle;
@@ -1713,7 +1727,7 @@ BmGetNextLoadOptionDevicePath (
     // Expand the Harddrive device path
     //
     if (FullPath == NULL) {
-      return BmExpandPartitionDevicePath (FilePath);
+      return BmExpandPartitionDevicePath (FilePath, ConnectAll);
     } else {
       return NULL;
     }
@@ -1723,14 +1737,14 @@ BmGetNextLoadOptionDevicePath (
     //
     // Expand the File-path device path
     //
-    return BmExpandFileDevicePath (FilePath, FullPath);
+    return BmExpandFileDevicePath (FilePath, FullPath, ConnectAll);
   } else if ((DevicePathType (FilePath) == MESSAGING_DEVICE_PATH) &&
              (DevicePathSubType (FilePath) == MSG_URI_DP))
   {
     //
     // Expand the URI device path
     //
-    return BmExpandUriDevicePath (FilePath, FullPath);
+    return BmExpandUriDevicePath (FilePath, FullPath, ConnectAll);
   } else {
     Node   = FilePath;
     Status = gBS->LocateDevicePath (&gEfiUsbIoProtocolGuid, &Node, &Handle);
@@ -1761,7 +1775,7 @@ BmGetNextLoadOptionDevicePath (
           BmConnectUsbShortFormDevicePath (FilePath);
         }
 
-        return BmExpandUsbDevicePath (FilePath, FullPath, Node);
+        return BmExpandUsbDevicePath (FilePath, FullPath, Node, ConnectAll);
       }
     }
   }
@@ -2717,7 +2731,31 @@ EfiBootManagerGetNextLoadOptionDevicePath (
   IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath
   )
 {
-  return BmGetNextLoadOptionDevicePath (FilePath, FullPath);
+  return BmGetNextLoadOptionDevicePath (FilePath, FullPath, TRUE);
+}
+
+/**
+  Get the next possible full path pointing to the load option.
+
+  Unlike EfiBootManagerGetNextLoadOptionDevicePath(), short-form expansion does
+  not call EfiBootManagerConnectAll().
+
+  @param FilePath  The device path pointing to a load option.
+                   It could be a short-form device path.
+  @param FullPath  The full path returned by the routine in last call.
+                   Set to NULL in first call.
+
+  @return The next possible full path pointing to the load option.
+          Caller is responsible to free the memory.
+**/
+EFI_DEVICE_PATH_PROTOCOL *
+EFIAPI
+EfiBootManagerGetNextLoadOptionDevicePathNoConnectAll (
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath
+  )
+{
+  return BmGetNextLoadOptionDevicePath (FilePath, FullPath, FALSE);
 }
 
 /**

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -1331,7 +1331,7 @@ BmGetNextLoadOptionBuffer (
   CurFullPath   = *FullPath;
   do {
     PreFullPath = CurFullPath;
-    CurFullPath = BmGetNextLoadOptionDevicePath (FilePath, CurFullPath);
+    CurFullPath = BmGetNextLoadOptionDevicePath (FilePath, CurFullPath, TRUE);
     //
     // Only free the full path created *inside* this routine
     //

--- a/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
+++ b/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
@@ -429,6 +429,7 @@ BmDestroyRamDisk (
                    It could be a short-form device path.
   @param FullPath  The full path returned by the routine in last call.
                    Set to NULL in first call.
+  @param ConnectAll Whether short-form expansion may connect all devices.
 
   @return The next possible full path pointing to the load option.
           Caller is responsible to free the memory.
@@ -436,7 +437,8 @@ BmDestroyRamDisk (
 EFI_DEVICE_PATH_PROTOCOL *
 BmGetNextLoadOptionDevicePath (
   IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
-  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath
+  IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath,
+  IN  BOOLEAN                   ConnectAll
   );
 
 /**

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -769,6 +769,12 @@
   # @Prompt Enable update capsule across a system reset.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportUpdateCapsuleReset|FALSE|BOOLEAN|0x0001001d
 
+  ## Connect the active boot device while discovering Capsules On Disk before EndOfDxe.<BR><BR>
+  #  Device connection can discover and dispatch option ROMs. Platforms must only enable this
+  #  feature when an image-dispatch policy is active before Capsule On Disk discovery.<BR>
+  # @Prompt Connect the active boot device for early Capsule On Disk discovery.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskConnectBootDevice|FALSE|BOOLEAN|0x000100C8
+
   ## Indicates if all PCD PPI services will be enabled.<BR><BR>
   #   TRUE  - All PCD PPI services will be produced.<BR>
   #   FALSE - Minimal PCD PPI services (only GetService) will be produced.<BR>

--- a/MdeModulePkg/MdeModulePkg.uni
+++ b/MdeModulePkg/MdeModulePkg.uni
@@ -1156,6 +1156,11 @@
                                                                                            "Note:<BR>"
                                                                                            "If Both Capsule In Ram and Capsule On Disk are provisioned at the same time, the Capsule On Disk will be bypassed."
 
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdCapsuleOnDiskConnectBootDevice_PROMPT  #language en-US "Connect the active boot device for early Capsule On Disk discovery"
+
+#string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdCapsuleOnDiskConnectBootDevice_HELP  #language en-US   "Connect the active boot device while discovering Capsules On Disk before EndOfDxe.<BR>"
+                                                                                                      "Device connection can discover and dispatch option ROMs. Platforms must only enable this feature when an image-dispatch policy is active before Capsule On Disk discovery."
+
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdFwVolDxeMaxEncapsulationDepth_PROMPT #language en-US "Maximum permitted FwVol section nesting depth (exclusive)."
 
 #string STR_gEfiMdeModulePkgTokenSpaceGuid_PcdFwVolDxeMaxEncapsulationDepth_HELP   #language en-US "Maximum permitted encapsulation levels of sections in a firmware volume,<BR>"

--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -24,6 +24,7 @@
 
 [Components]
   MdeModulePkg/Library/DxeResetSystemLib/UnitTest/MockUefiRuntimeServicesTableLib.inf
+  MdeModulePkg/Universal/BdsDxe/BdsBootNextPolicyUnitTestHost.inf
 
   #
   # Build MdeModulePkg HOST_APPLICATION Tests

--- a/MdeModulePkg/Universal/BdsDxe/BdsBootNextPolicyUnitTestHost.inf
+++ b/MdeModulePkg/Universal/BdsDxe/BdsBootNextPolicyUnitTestHost.inf
@@ -1,0 +1,29 @@
+## @file
+# Host tests for BDS BootNext preservation policy.
+#
+# Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = BdsBootNextPolicyUnitTestHost
+  FILE_GUID                      = 2940E9C8-6F08-49AB-9E47-AF52FB0878AC
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+[Sources]
+  BootNextPolicy.c
+  BootNextPolicy.h
+  UnitTest/BdsBootNextPolicyUnitTest.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+  UnitTestLib

--- a/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+++ b/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
@@ -32,6 +32,8 @@
   HwErrRecSupport.h
   Language.c
   BdsEntry.c
+  BootNextPolicy.c
+  BootNextPolicy.h
 
 
 [Packages]
@@ -52,6 +54,7 @@
   UefiBootManagerLib
   VariablePolicyHelperLib
   PlatformBootManagerLib
+  HobLib
   PcdLib
   PrintLib
 

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -13,8 +13,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include "Bds.h"
+#include "BootNextPolicy.h"
 #include "Language.h"
 #include "HwErrRecSupport.h"
+#include <Library/HobLib.h>
 #include <Library/VariablePolicyHelperLib.h>
 
 #define SET_BOOT_OPTION_SUPPORT_KEY_COUNT(a, c)  { \
@@ -702,10 +704,14 @@ BdsEntry (
   EFI_STATUS                      BootManagerMenuStatus;
   EFI_BOOT_MANAGER_LOAD_OPTION    PlatformDefaultBootOption;
   BOOLEAN                         PlatformDefaultBootOptionValid;
+  UINT16                          *CurrentBootNext;
+  BOOLEAN                         CapsuleDeliveryRequested;
 
-  HotkeyTriggered = NULL;
-  Status          = EFI_SUCCESS;
-  BootSuccess     = FALSE;
+  HotkeyTriggered          = NULL;
+  Status                   = EFI_SUCCESS;
+  BootSuccess              = FALSE;
+  CurrentBootNext          = NULL;
+  CapsuleDeliveryRequested = FALSE;
 
   //
   // Insert the performance probe
@@ -808,6 +814,19 @@ BdsEntry (
 
     BootNext = NULL;
   }
+
+  DataSize = sizeof (OsIndication);
+  Status   = gRT->GetVariable (
+                    EFI_OS_INDICATIONS_VARIABLE_NAME,
+                    &gEfiGlobalVariableGuid,
+                    NULL,
+                    &DataSize,
+                    &OsIndication
+                    );
+  CapsuleDeliveryRequested = (BOOLEAN)(
+                                        !EFI_ERROR (Status) &&
+                                        ((OsIndication & EFI_OS_INDICATIONS_FILE_CAPSULE_DELIVERY_SUPPORTED) != 0)
+                                        );
 
   //
   // Initialize the platform language variables
@@ -1069,6 +1088,44 @@ BdsEntry (
     BdsReadKeys ();
 
     EfiBootManagerHotkeyBoot ();
+
+    DataSize = 0;
+    GetEfiGlobalVariable2 (
+      EFI_BOOT_NEXT_VARIABLE_NAME,
+      (VOID **)&CurrentBootNext,
+      &DataSize
+      );
+    if ((BootNext != NULL) &&
+        ((CurrentBootNext == NULL) ||
+         (DataSize != sizeof (UINT16)) ||
+         (*CurrentBootNext != *BootNext)))
+    {
+      //
+      // Platform policy cleared or replaced the cached request. A replacement
+      // remains non-volatile for the next boot and must not be consumed now.
+      //
+      FreePool (BootNext);
+      BootNext = NULL;
+    }
+
+    if (CurrentBootNext != NULL) {
+      FreePool (CurrentBootNext);
+      CurrentBootNext = NULL;
+    }
+
+    if (BdsShouldPreserveCapsuleBootNext (
+          BootNext != NULL,
+          CapsuleDeliveryRequested,
+          GetBootModeHob ()
+          ))
+    {
+      //
+      // Keep the capsule request for the next normal boot. Consuming BootNext
+      // would either replace an S4 resume or discard a deferred retry path.
+      //
+      FreePool (BootNext);
+      BootNext = NULL;
+    }
 
     if (BootNext != NULL) {
       //

--- a/MdeModulePkg/Universal/BdsDxe/BootNextPolicy.c
+++ b/MdeModulePkg/Universal/BdsDxe/BootNextPolicy.c
@@ -1,0 +1,23 @@
+/** @file
+  BootNext preservation policy for BDS.
+
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "BootNextPolicy.h"
+
+BOOLEAN
+BdsShouldPreserveCapsuleBootNext (
+  IN BOOLEAN        BootNextPresent,
+  IN BOOLEAN        CapsuleDeliveryRequested,
+  IN EFI_BOOT_MODE  BootMode
+  )
+{
+  return (BOOLEAN)(
+                    BootNextPresent &&
+                    CapsuleDeliveryRequested &&
+                    (BootMode == BOOT_ON_S4_RESUME)
+                    );
+}

--- a/MdeModulePkg/Universal/BdsDxe/BootNextPolicy.h
+++ b/MdeModulePkg/Universal/BdsDxe/BootNextPolicy.h
@@ -1,0 +1,22 @@
+/** @file
+  BootNext preservation policy for BDS.
+
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef BDS_BOOT_NEXT_POLICY_H_
+#define BDS_BOOT_NEXT_POLICY_H_
+
+#include <Uefi.h>
+#include <Pi/PiBootMode.h>
+
+BOOLEAN
+BdsShouldPreserveCapsuleBootNext (
+  IN BOOLEAN        BootNextPresent,
+  IN BOOLEAN        CapsuleDeliveryRequested,
+  IN EFI_BOOT_MODE  BootMode
+  );
+
+#endif

--- a/MdeModulePkg/Universal/BdsDxe/UnitTest/BdsBootNextPolicyUnitTest.c
+++ b/MdeModulePkg/Universal/BdsDxe/UnitTest/BdsBootNextPolicyUnitTest.c
@@ -1,0 +1,127 @@
+/** @file
+  Host tests for BDS BootNext preservation policy.
+
+  Copyright (c) 2026, Star Labs Systems. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UnitTestLib.h>
+
+#include "BootNextPolicy.h"
+
+#define UNIT_TEST_APP_NAME     "BDS BootNext Policy Unit Test"
+#define UNIT_TEST_APP_VERSION  "1.0"
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+NormalBootConsumesBootNext (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_FALSE (
+    BdsShouldPreserveCapsuleBootNext (
+      TRUE,
+      TRUE,
+      BOOT_WITH_FULL_CONFIGURATION
+      )
+    );
+
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+S4ResumePreservesCapsuleBootNext (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_TRUE (
+    BdsShouldPreserveCapsuleBootNext (
+      TRUE,
+      TRUE,
+      BOOT_ON_S4_RESUME
+      )
+    );
+
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+UNIT_TEST_STATUS
+EFIAPI
+UnrelatedBootNextIsNotPreserved (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UT_ASSERT_FALSE (
+    BdsShouldPreserveCapsuleBootNext (
+      TRUE,
+      FALSE,
+      BOOT_WITH_FULL_CONFIGURATION
+      )
+    );
+
+  return UNIT_TEST_PASSED;
+}
+
+STATIC
+EFI_STATUS
+EFIAPI
+UnitTestingEntry (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      Suite;
+
+  Framework = NULL;
+  Suite     = NULL;
+  Status    = InitUnitTestFramework (
+                &Framework,
+                UNIT_TEST_APP_NAME,
+                gEfiCallerBaseName,
+                UNIT_TEST_APP_VERSION
+                );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = CreateUnitTestSuite (
+             &Suite,
+             Framework,
+             "Capsule BootNext policy",
+             "Bds.BootNextPolicy",
+             NULL,
+             NULL
+             );
+  if (EFI_ERROR (Status)) {
+    FreeUnitTestFramework (Framework);
+    return Status;
+  }
+
+  AddTestCase (Suite, "Normal boot consumes BootNext", "NormalBootNext", NormalBootConsumesBootNext, NULL, NULL, NULL);
+  AddTestCase (Suite, "S4 preserves capsule BootNext", "S4BootNext", S4ResumePreservesCapsuleBootNext, NULL, NULL, NULL);
+  AddTestCase (Suite, "Unrelated BootNext is not preserved", "UnrelatedBootNext", UnrelatedBootNextIsNotPreserved, NULL, NULL, NULL);
+
+  Status = RunAllTestSuites (Framework);
+  FreeUnitTestFramework (Framework);
+  return Status;
+}
+
+#define BdsBootNextPolicyUnitTestMain  main
+
+INT32
+BdsBootNextPolicyUnitTestMain (
+  IN INT32  Argc,
+  IN CHAR8  *Argv[]
+  )
+{
+  return UnitTestingEntry ();
+}


### PR DESCRIPTION
Load capsule-on-disk files through the normal capsule-processing path and make discovery reliable when the active ESP is not connected during the first pass.

The series limits early connection to storage boot paths, preserves mixed HOB capsules across a deferred pass, rejects ambiguous capsule directories, reports terminal discovery errors and keeps a capsule-associated BootNext across S4 resume.

- [ ] Breaking change?
- [ ] Impacts security?
- [x] Includes tests?

## How This Was Tested

- PatchCheck.py
- MdeModulePkg NOOPT X64 Stuart build
- MdeModulePkg X64 host unit tests
- Byte Cezanne 26.06 to 26.07 capsule-on-disk update
- StarBook Cezanne preferred-path control

## Integration Instructions

Platforms that enable early storage connection must install an image-dispatch policy before capsule-on-disk discovery.