### PR TITLE
UefiPayloadPkg/FdtParserLib: parse flash-update boot mode

### DIFF
--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -485,6 +485,8 @@ ParseOptions (
           *BootMode = BOOT_ON_S4_RESUME;
         } else if (AsciiStrCmp (TempStr, "s3") == 0) {
           *BootMode = BOOT_ON_S3_RESUME;
+        } else if (AsciiStrCmp (TempStr, "flash-update") == 0) {
+          *BootMode = BOOT_ON_FLASH_UPDATE;
         }
       }
     }


### PR DESCRIPTION
Map the Universal Payload flash-update token to BOOT_ON_FLASH_UPDATE so payloads can process capsule-on-disk updates.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- PatchCheck.py
- UefiPayloadPkg RELEASE X64 Stuart build
- UefiPayloadPkg X64 FIT platform build

The generic NOOPT package build compiles but exceeds the current upstream FV size by 0x310a0.

## Integration Instructions

The bootloader FDT should set `boot-mode` to `flash-update` while flash writes are permitted.