### PR TITLE
UefiPayloadPkg: make boot discovery selective

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -9,7 +9,41 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "PlatformBootManager.h"
 #include "PlatformConsole.h"
+#include <Guid/GlobalVariable.h>
+#include <IndustryStandard/Pci.h>
+#include <IndustryStandard/Usb.h>
 #include <Protocol/FirmwareVolume2.h>
+#include <Protocol/PciIo.h>
+
+#define PLATFORM_USB_MASS_STORAGE_CLASS  0x08
+
+typedef struct {
+  USB_CLASS_DEVICE_PATH       UsbClass;
+  EFI_DEVICE_PATH_PROTOCOL    End;
+} USB_MASS_STORAGE_DEVICE_PATH;
+
+STATIC USB_MASS_STORAGE_DEVICE_PATH  mUsbMassStorageDevicePath = {
+  {
+    {
+      MESSAGING_DEVICE_PATH,
+      MSG_USB_CLASS_DP,
+      {
+        (UINT8)(sizeof (USB_CLASS_DEVICE_PATH)),
+        (UINT8)(sizeof (USB_CLASS_DEVICE_PATH) >> 8)
+      }
+    },
+    0xffff,
+    0xffff,
+    PLATFORM_USB_MASS_STORAGE_CLASS,
+    0xff,
+    0xff
+  },
+  {
+    END_DEVICE_PATH_TYPE,
+    END_ENTIRE_DEVICE_PATH_SUBTYPE,
+    { END_DEVICE_PATH_LENGTH, 0 }
+  }
+};
 
 /**
   Signal EndOfDxe event and install SMM Ready to lock protocol.
@@ -212,6 +246,162 @@ PlatformRegisterFvBootOption (
   }
 }
 
+STATIC
+BOOLEAN
+PlatformBootOptionUsesInternalDisk (
+  IN CONST EFI_BOOT_MANAGER_LOAD_OPTION  *BootOption
+  )
+{
+  EFI_DEVICE_PATH_PROTOCOL  *Node;
+  BOOLEAN                   HasHardDrive;
+
+  if ((BootOption == NULL) || (BootOption->FilePath == NULL)) {
+    return FALSE;
+  }
+
+  HasHardDrive = FALSE;
+  for (Node = BootOption->FilePath; !IsDevicePathEnd (Node); Node = NextDevicePathNode (Node)) {
+    if ((DevicePathType (Node) == MESSAGING_DEVICE_PATH) &&
+        ((DevicePathSubType (Node) == MSG_USB_DP) ||
+         (DevicePathSubType (Node) == MSG_USB_CLASS_DP) ||
+         (DevicePathSubType (Node) == MSG_USB_WWID_DP)))
+    {
+      return FALSE;
+    }
+
+    if ((DevicePathType (Node) == MEDIA_DEVICE_PATH) &&
+        (DevicePathSubType (Node) == MEDIA_HARDDRIVE_DP))
+    {
+      HasHardDrive = TRUE;
+    }
+  }
+
+  return HasHardDrive;
+}
+
+STATIC
+BOOLEAN
+PlatformSelectedBootOptionUsesInternalDisk (
+  VOID
+  )
+{
+  EFI_STATUS                    Status;
+  UINT16                        BootNext;
+  UINTN                         DataSize;
+  CHAR16                        BootOptionName[16];
+  EFI_BOOT_MANAGER_LOAD_OPTION  BootNextOption;
+  EFI_BOOT_MANAGER_LOAD_OPTION  *BootOptions;
+  EFI_BOOT_MANAGER_LOAD_OPTION  *SelectedOption;
+  UINTN                         BootOptionCount;
+  UINTN                         Index;
+  BOOLEAN                       HaveBootNext;
+  BOOLEAN                       UsesInternalDisk;
+
+  BootOptions      = NULL;
+  BootOptionCount  = 0;
+  SelectedOption   = NULL;
+  HaveBootNext     = FALSE;
+  UsesInternalDisk = FALSE;
+  ZeroMem (&BootNextOption, sizeof (BootNextOption));
+
+  DataSize = sizeof (BootNext);
+  Status   = gRT->GetVariable (
+                    EFI_BOOT_NEXT_VARIABLE_NAME,
+                    &gEfiGlobalVariableGuid,
+                    NULL,
+                    &DataSize,
+                    &BootNext
+                    );
+  if (!EFI_ERROR (Status) && (DataSize == sizeof (BootNext))) {
+    UnicodeSPrint (BootOptionName, sizeof (BootOptionName), L"Boot%04x", BootNext);
+    Status = EfiBootManagerVariableToLoadOption (BootOptionName, &BootNextOption);
+    if (!EFI_ERROR (Status)) {
+      SelectedOption = &BootNextOption;
+      HaveBootNext   = TRUE;
+    }
+  }
+
+  if (!HaveBootNext) {
+    BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
+    for (Index = 0; Index < BootOptionCount; Index++) {
+      if ((BootOptions[Index].Attributes & LOAD_OPTION_ACTIVE) != 0) {
+        SelectedOption = &BootOptions[Index];
+        break;
+      }
+    }
+  }
+
+  if (SelectedOption != NULL) {
+    UsesInternalDisk = PlatformBootOptionUsesInternalDisk (SelectedOption);
+    DEBUG ((
+      DEBUG_INFO,
+      "Selected boot path is %a an internal disk\n",
+      UsesInternalDisk ? "" : "not"
+      ));
+  } else {
+    DEBUG ((DEBUG_INFO, "No active boot option selected\n"));
+  }
+
+  if (HaveBootNext) {
+    EfiBootManagerFreeLoadOption (&BootNextOption);
+  }
+
+  EfiBootManagerFreeLoadOptions (BootOptions, BootOptionCount);
+  return UsesInternalDisk;
+}
+
+STATIC
+VOID
+PlatformConnectRemovableMedia (
+  VOID
+  )
+{
+  EFI_STATUS           Status;
+  EFI_HANDLE           *Handles;
+  EFI_PCI_IO_PROTOCOL  *PciIo;
+  UINTN                HandleCount;
+  UINTN                Index;
+  UINT8                ClassCode[3];
+
+  Status = gBS->LocateHandleBuffer (
+                  ByProtocol,
+                  &gEfiPciIoProtocolGuid,
+                  NULL,
+                  &HandleCount,
+                  &Handles
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "No PCI handles available for removable-media discovery\n"));
+    return;
+  }
+
+  for (Index = 0; Index < HandleCount; Index++) {
+    Status = gBS->HandleProtocol (Handles[Index], &gEfiPciIoProtocolGuid, (VOID **)&PciIo);
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    Status = PciIo->Pci.Read (PciIo, EfiPciIoWidthUint8, 0x09, sizeof (ClassCode), ClassCode);
+    if (EFI_ERROR (Status) ||
+        (ClassCode[2] != PCI_CLASS_SERIAL) ||
+        (ClassCode[1] != PCI_CLASS_SERIAL_USB))
+    {
+      continue;
+    }
+
+    DEBUG ((DEBUG_INFO, "Connecting USB mass-storage paths on PCI controller\n"));
+    gBS->ConnectController (
+             Handles[Index],
+             NULL,
+             (EFI_DEVICE_PATH_PROTOCOL *)&mUsbMassStorageDevicePath,
+             TRUE
+             );
+  }
+
+  FreePool (Handles);
+  EfiBootManagerRefreshAllBootOption ();
+}
+
 /**
   Do the platform specific action before the console is connected.
 
@@ -320,8 +510,21 @@ PlatformBootManagerAfterConsole (
     BootLogoEnableLogo ();
   }
 
-  EfiBootManagerConnectAll ();
-  EfiBootManagerRefreshAllBootOption ();
+  if (FeaturePcdGet (PcdConnectAllDevices)) {
+    EfiBootManagerConnectAll ();
+    EfiBootManagerRefreshAllBootOption ();
+  } else if (!PlatformSelectedBootOptionUsesInternalDisk ()) {
+    DEBUG ((
+      DEBUG_INFO,
+      "Selected boot path is removable or unavailable; discovering removable media\n"
+      ));
+    PlatformConnectRemovableMedia ();
+  } else {
+    DEBUG ((
+      DEBUG_INFO,
+      "Skipping global device discovery; connecting the selected boot path on demand\n"
+      ));
+  }
 
   //
   // Active BOOT_ON_FLASH_UPDATE mode means that at least one capsule has been

--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -52,6 +52,7 @@
 
 [Guids]
   gEfiEndOfDxeEventGroupGuid
+  gEfiGlobalVariableGuid
   gUefiShellFileGuid
 
 [Protocols]
@@ -62,6 +63,7 @@
   gEfiSmmAccess2ProtocolGuid
   gEfiSerialIoProtocolGuid
   gEfiPciRootBridgeIoProtocolGuid
+  gEfiPciIoProtocolGuid
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut
@@ -73,3 +75,6 @@
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultParity
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultStopBits
   gUefiPayloadPkgTokenSpaceGuid.PcdBootManagerEscape
+
+[FeaturePcd]
+  gUefiPayloadPkgTokenSpaceGuid.PcdConnectAllDevices

--- a/UefiPayloadPkg/UefiPayloadPkg.dec
+++ b/UefiPayloadPkg/UefiPayloadPkg.dec
@@ -116,3 +116,9 @@ gUefiPayloadPkgTokenSpaceGuid.PcdUseUniversalPayloadSerialPort|TRUE|BOOLEAN|0x00
 
 ## Indicates whether allows PCI Root Bridge to allocate DMA memory resource above 4G
 gUefiPayloadPkgTokenSpaceGuid.PcdPciAllocateMemoryAbove4GB|FALSE|BOOLEAN|0x0000002E
+
+[PcdsFeatureFlag]
+## Indicates whether all boot devices are connected before the selected boot
+## option is launched. Platforms that disable this can connect the selected
+## path on demand and discover removable media only when needed.
+gUefiPayloadPkgTokenSpaceGuid.PcdConnectAllDevices|TRUE|BOOLEAN|0x0000002F

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -47,6 +47,7 @@
   DEFINE NVME_ENABLE                  = TRUE
   DEFINE LOCKBOX_SUPPORT              = FALSE
   DEFINE LOAD_OPTION_ROMS             = FALSE
+  DEFINE CONNECT_ALL_DEVICES          = TRUE
 
   #
   # Capsule updates
@@ -586,6 +587,7 @@
 ################################################################################
 [PcdsFeatureFlag]
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutGopSupport|TRUE
+  gUefiPayloadPkgTokenSpaceGuid.PcdConnectAllDevices|$(CONNECT_ALL_DEVICES)
   ## This PCD specified whether ACPI SDT protocol is installed.
   gEfiMdeModulePkgTokenSpaceGuid.PcdInstallAcpiSdtProtocol|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdHiiOsRuntimeSupport|FALSE


### PR DESCRIPTION
Allow payload platforms to opt out of the unconditional `ConnectAll()` and `RefreshAllBootOption()` pass. The default remains unchanged.

When global discovery is disabled, UefiPayloadPkg checks `BootNext` and the first active `BootOrder` entry. Internal disk paths are left for normal on-demand connection; removable or unavailable paths trigger USB mass-storage discovery so fallback boot remains available.

This avoids paying the full USB discovery delay on systems that are going to boot a known internal disk.

Validation:
- `BaseTools/Scripts/PatchCheck.py upstream/master..HEAD`
- UefiPayloadPkg RELEASE X64 build with `CONNECT_ALL_DEVICES=FALSE`
- UefiPayloadPkg X64 Stuart FIT build