### PR TITLE
SecurityPkg: Remove global use pre-memory

### DIFF
--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
@@ -26,7 +26,7 @@
 [Sources.common]
   Tpm2DeviceLibFfa.c
   Tpm2ServiceFfaRaw.c
-  Tpm2DeviceLibFfaBase.c
+  Tpm2DeviceSecLibFfaBase.c
   Tpm2Ptp.c
   Tpm2DeviceLibFfa.h
   Tpm2InfoSecFfa.c

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfaBase.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfaBase.c
@@ -14,8 +14,6 @@
 #include <Library/Tpm2DeviceLib.h>
 #include "Tpm2DeviceLibFfa.h"
 
-UINT8  mCRBIdleByPass;
-
 /**
   Return cached PTP CRB interface IdleByPass state.
 
@@ -26,7 +24,7 @@ GetCachedIdleByPass (
   VOID
   )
 {
-  return mCRBIdleByPass;
+  return Tpm2GetIdleByPass ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
 }
 
 /**
@@ -42,20 +40,9 @@ InternalTpm2DeviceLibFfaConstructor (
   VOID
   )
 {
-  EFI_STATUS  Status;
-
-  mCRBIdleByPass = 0xFF;
-
   if (PcdGet64 (PcdTpmBaseAddress) == 0) {
     return EFI_NO_MAPPING;
   }
 
-  Status = ValidateTpmInterfaceType ();
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  mCRBIdleByPass = Tpm2GetIdleByPass ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
-
-  return EFI_SUCCESS;
+  return ValidateTpmInterfaceType ();
 }

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
@@ -26,18 +26,16 @@
 
 #include "Tpm2DeviceLibFfa.h"
 
-UINT16  mFfaTpm2PartitionId = TPM2_FFA_PARTITION_ID_INVALID;
-
 /**
   Check the return status from the FF-A call and returns EFI_STATUS
 
-  @param EFI_LOAD_ERROR  FF-A status code returned in x0
+  @param TpmReturnStatus  FF-A status code returned in x0
 
   @retval EFI_SUCCESS    The entry point is executed successfully.
 **/
 EFI_STATUS
 TranslateTpmReturnStatus (
-  UINTN  TpmReturnStatus
+  IN UINTN  TpmReturnStatus
   )
 {
   EFI_STATUS  Status;
@@ -142,27 +140,25 @@ Tpm2GetInterfaceVersion (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
   if (Version == NULL) {
-    Status = EFI_INVALID_PARAMETER;
-    goto Exit;
+    return EFI_INVALID_PARAMETER;
   }
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_GET_INTERFACE_VERSION;
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
     Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
   Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
@@ -171,7 +167,6 @@ Tpm2GetInterfaceVersion (
     *Version = FfaDirectReq2Args.Arg1;
   }
 
-Exit:
   return Status;
 }
 
@@ -193,34 +188,29 @@ Tpm2GetFeatureInfo (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
   if (FeatureInfo == NULL) {
-    Status = EFI_INVALID_PARAMETER;
-    goto Exit;
+    return EFI_INVALID_PARAMETER;
   }
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_GET_FEATURE_INFO;
   FfaDirectReq2Args.Arg1 = TPM_SERVICE_FEATURE_SUPPORT_NOTIFICATION;
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
     Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }
 
 /**
@@ -241,30 +231,26 @@ Tpm2ServiceStart (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_START;
   FfaDirectReq2Args.Arg1 = (FuncQualifier & 0xFF);
   FfaDirectReq2Args.Arg2 = (LocalityQualifier & 0xFF);
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
     Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }
 
 /**
@@ -286,30 +272,26 @@ Tpm2RegisterNotification (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_REGISTER_FOR_NOTIFICATION;
   FfaDirectReq2Args.Arg1 = (NotificationTypeQualifier << 16 | vCpuId);
   FfaDirectReq2Args.Arg2 = (NotificationId & 0xFF);
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
     Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }
 
 /**
@@ -325,28 +307,24 @@ Tpm2UnregisterNotification (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_UNREGISTER_FROM_NOTIFICATION;
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
     Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }
 
 /**
@@ -362,26 +340,22 @@ Tpm2FinishNotified (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  FfaDirectReq2Args;
+  UINT16           FfaTpm2PartitionId;
 
-  if (mFfaTpm2PartitionId == TPM2_FFA_PARTITION_ID_INVALID) {
-    GetTpmServicePartitionId (&mFfaTpm2PartitionId);
-  }
+  GetTpmServicePartitionId (&FfaTpm2PartitionId);
 
   ZeroMem (&FfaDirectReq2Args, sizeof (DIRECT_MSG_ARGS));
   FfaDirectReq2Args.Arg0 = TPM2_FFA_FINISH_NOTIFIED;
 
-  Status = ArmFfaLibMsgSendDirectReq2 (mFfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
+  Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
     Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
-    goto Exit;
+    return Status;
   }
 
-  Status = TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
-
-Exit:
-  return Status;
+  return TranslateTpmReturnStatus (FfaDirectReq2Args.Arg0);
 }


### PR DESCRIPTION
# Description

Updated Tpm2DeviceLibFfa to no longer use globals. Created an SEC version of Tpm2DeviceLibFfaBase to not use globals when including TPM libraries in the SEC phase. Includes various cleanup regarding the updated files.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran CI locally.

## Integration Instructions

N/A
