### PR TITLE
EmulatorPkg: Fix transposed ConOut row/column in PlatformBmLib

### DIFF
--- a/EmulatorPkg/Library/PlatformBmLib/PlatformBm.c
+++ b/EmulatorPkg/Library/PlatformBmLib/PlatformBm.c
@@ -37,8 +37,8 @@ SetupVariableInit (
     //
     // SetupVariable is corrupt
     //
-    SystemConfigData.ConOutRow    = PcdGet32 (PcdConOutColumn);
-    SystemConfigData.ConOutColumn = PcdGet32 (PcdConOutRow);
+    SystemConfigData.ConOutRow    = PcdGet32 (PcdConOutRow);
+    SystemConfigData.ConOutColumn = PcdGet32 (PcdConOutColumn);
 
     Status = gRT->SetVariable (
                     L"Setup",


### PR DESCRIPTION
# Description





- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested


## Integration Instructions


EmulatorPkg: Fix transposed ConOut row/column in PlatformBmLib

The ConOutRow and ConOutColumn settings in SetupVariable were
incorrectly initialized with swapped PCD values. This caused
setup resolution to remain incorrect when overriding PCD values.

Fix the variable assignments to use the correct PCD values:
- ConOutRow should use PcdConOutRow
- ConOutColumn should use PcdConOutColumn

---

Fixes: https://github.com/tianocore/edk2/issues/12766
