### PR TITLE
UefiPayloadPkg: widen parsed memory types

### DIFF
--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -20,10 +20,17 @@
 
 #define GET_BOOTLOADER_PARAMETER()  PcdGet64 (PcdBootloaderParameter)
 
+typedef struct {
+  UINT64    Base;
+  UINT64    Size;
+  UINT32    Type;
+  UINT8     Flag;
+} BL_MEMORY_MAP_ENTRY;
+
 typedef RETURN_STATUS \
 (*BL_MEM_INFO_CALLBACK) (
-  MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  VOID              *Param
+  BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  VOID                 *Param
   );
 
 typedef VOID \

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -386,7 +386,7 @@ ParseMemoryInfo (
   CB_MEMORY               *Rec;
   struct cb_memory_range  *Range;
   UINTN                   Index;
-  MEMORY_MAP_ENTRY        MemoryMap;
+  BL_MEMORY_MAP_ENTRY     MemoryMap;
 
   //
   // Get the coreboot memory table

--- a/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
+++ b/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
@@ -94,8 +94,9 @@ ParseMemoryInfo (
   IN  VOID                  *Params
   )
 {
-  MEMORY_MAP_INFO  *MemoryMapInfo;
-  UINTN            Idx;
+  MEMORY_MAP_INFO     *MemoryMapInfo;
+  BL_MEMORY_MAP_ENTRY  MemoryMap;
+  UINTN                Idx;
 
   MemoryMapInfo = (MEMORY_MAP_INFO *)GetGuidHobDataFromSbl (&gLoaderMemoryMapInfoGuid);
   if (MemoryMapInfo == NULL) {
@@ -104,7 +105,15 @@ ParseMemoryInfo (
   }
 
   for (Idx = 0; Idx < MemoryMapInfo->Count; Idx++) {
-    MemInfoCallback (&MemoryMapInfo->Entry[Idx], Params);
+    MemoryMap.Base = MemoryMapInfo->Entry[Idx].Base;
+    MemoryMap.Size = MemoryMapInfo->Entry[Idx].Size;
+    MemoryMap.Type = MemoryMapInfo->Entry[Idx].Type;
+    MemoryMap.Flag = MemoryMapInfo->Entry[Idx].Flag;
+    MemInfoCallback (&MemoryMap, Params);
+    MemoryMapInfo->Entry[Idx].Base = MemoryMap.Base;
+    MemoryMapInfo->Entry[Idx].Size = MemoryMap.Size;
+    MemoryMapInfo->Entry[Idx].Type = (UINT8)MemoryMap.Type;
+    MemoryMapInfo->Entry[Idx].Flag = MemoryMap.Flag;
   }
 
   return RETURN_SUCCESS;

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -37,8 +37,8 @@ EFI_MEMORY_TYPE_INFORMATION  mDefaultMemoryTypeInformation[] = {
 **/
 EFI_STATUS
 MemInfoCallbackMmio (
-  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  IN VOID              *Params
+  IN BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID                 *Params
   )
 {
   EFI_PHYSICAL_ADDRESS         Base;
@@ -116,8 +116,8 @@ MemInfoCallbackMmio (
 **/
 EFI_STATUS
 FindToludCallback (
-  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  IN VOID              *Params
+  IN BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID                 *Params
   )
 {
   //
@@ -185,13 +185,13 @@ FindToludCallback (
 **/
 EFI_STATUS
 FindFreeMemForHobCallback (
-  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  IN VOID              *Params
+  IN BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID                 *Params
   )
 {
-  EFI_STATUS        Status;
-  MEMORY_MAP_ENTRY  MemoryMapEntrySplit;
-  UINTN             *HobMemBase = (UINTN *)Params;
+  EFI_STATUS           Status;
+  BL_MEMORY_MAP_ENTRY  MemoryMapEntrySplit;
+  UINTN                *HobMemBase = (UINTN *)Params;
 
   //
   // Found new base, nothing to do
@@ -284,8 +284,8 @@ FindFreeMemForHobCallback (
 **/
 EFI_STATUS
 MemInfoCallback (
-  IN MEMORY_MAP_ENTRY  *MemoryMapEntry,
-  IN VOID              *Params
+  IN BL_MEMORY_MAP_ENTRY  *MemoryMapEntry,
+  IN VOID                 *Params
   )
 {
   EFI_PHYSICAL_ADDRESS         Base;


### PR DESCRIPTION
# Description

Keep Slim Bootloader's revision-1 memory-map HOB unchanged, but use a
32-bit memory type internally in BlParseLib. This allows bootloaders with
full-width E820 types to preserve them without changing the SBL ABI.

This is a prerequisite for #12851, which preserves coreboot
soft-reserved memory.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- PatchCheck.py passes.
- A clean Stuart X64 GCC FIT build of UefiPayloadPkg passes.

## Integration Instructions

N/A
