### PR TITLE
UefiPayloadPkg/FdtParserLib: Keep IA32 HOBs below 4 GiB

### DIFF
--- a/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
+++ b/UefiPayloadPkg/Library/FdtParserLib/FdtParserLib.c
@@ -989,6 +989,17 @@ ParseDtb (
           NodePtr    = (FDT_NODE_HEADER *)((CONST CHAR8 *)Fdt + ParentNode + Fdt32ToCpu (((FDT_HEADER *)Fdt)->OffsetDtStruct));
           NodeType   = CheckNodeType (NodePtr->Name, Depth);
           if (!IsHobConstructed && (NodeType != ReservedMemory)) {
+            if (sizeof (UINTN) == sizeof (UINT32)) {
+              if (StartAddress >= (BASE_4GB - EFI_PAGE_SIZE)) {
+                DEBUG ((DEBUG_INFO, "Skipping memory outside the IA32 HOB address limit\n"));
+                continue;
+              }
+
+              if (NumberOfBytes > (BASE_4GB - EFI_PAGE_SIZE - StartAddress)) {
+                NumberOfBytes = BASE_4GB - EFI_PAGE_SIZE - StartAddress;
+              }
+            }
+
             if (NumberOfBytes > MinimalNeededSize) {
               MemoryBottom     = StartAddress + NumberOfBytes - MinimalNeededSize;
               FreeMemoryBottom = MemoryBottom;
@@ -1018,6 +1029,11 @@ ParseDtb (
         RootBridgeCount++;
       }
     }
+  }
+
+  if (!IsHobConstructed) {
+    DEBUG ((DEBUG_ERROR, "No addressable memory range is large enough for HOBs\n"));
+    return 0;
   }
 
   NumRsv = FdtGetNumberOfReserveMapEntries (Fdt);

--- a/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/FitUniversalPayloadEntry.c
@@ -525,6 +525,10 @@ FitUplEntryPoint (
   DEBUG ((DEBUG_INFO, "Start init Hobs...\n"));
  #if FixedPcdGetBool (PcdHandOffFdtEnable) == 1
   HobListPtr = UplInitHob ((VOID *)BootloaderParameter);
+  if (HobListPtr == 0) {
+    DEBUG ((DEBUG_ERROR, "Failed to initialize HOBs from FDT\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   //
   // Found hob list node


### PR DESCRIPTION
The FIT entry builds HOBs before an IA32 payload switches to long mode. An FDT memory node above 4 GiB therefore truncates the HOB pointers and hangs before DXE.

Skip or clip memory that IA32 cannot address and return `EFI_OUT_OF_RESOURCES` when no suitable range exists. X64 behavior is unchanged.

Tested on StarBook MTL with a 32-bit FIT entry and X64 DXE. The payload skips the high-memory node, builds HOBs below 4 GiB and boots the OS. PatchCheck and the UefiPayloadPkg Stuart build pass.