### PR TITLE
Global: Add Resource Descriptor Hob 2 support

### DIFF
--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -7,6 +7,7 @@
 **/
 
 #include <PiPei.h>
+#include <Uefi.h>
 
 #include <Library/ArmMmuLib.h>
 #include <Library/ArmPlatformLib.h>
@@ -98,9 +99,12 @@ MemoryPeim (
   //
   // Check if the resource for the main system memory has been declared
   //
-  Found       = FALSE;
-  NextHob.Raw = GetHobList ();
-  while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL) {
+  Found = FALSE;
+  for (NextHob.Raw = GetHobList (); !END_OF_HOB_LIST (NextHob); NextHob.Raw = GET_NEXT_HOB (NextHob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (NextHob)) {
+      continue;
+    }
+
     if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
         (SystemMemoryBase >= NextHob.ResourceDescriptor->PhysicalStart) &&
         (NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength <= SystemMemoryTop))
@@ -108,8 +112,6 @@ MemoryPeim (
       Found = TRUE;
       break;
     }
-
-    NextHob.Raw = GET_NEXT_HOB (NextHob);
   }
 
   if (!Found) {
@@ -135,13 +137,16 @@ MemoryPeim (
     Found = FALSE;
 
     // Search for System Memory Hob that contains the firmware
-    NextHob.Raw = GetHobList ();
-    while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL) {
+    for (NextHob.Raw = GetHobList (); !END_OF_HOB_LIST (NextHob); NextHob.Raw = GET_NEXT_HOB (NextHob)) {
+      if (!IS_RESOURCE_DESCRIPTOR_HOB (NextHob)) {
+        continue;
+      }
+
       if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
           (PcdGet64 (PcdFdBaseAddress) >= NextHob.ResourceDescriptor->PhysicalStart) &&
           (FdTop <= NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength))
       {
-        ResourceAttributes = NextHob.ResourceDescriptor->ResourceAttribute;
+        ResourceAttributes = GET_RESOURCE_HOB_ATTRIBUTE (NextHob);
         ResourceLength     = NextHob.ResourceDescriptor->ResourceLength;
         ResourceTop        = NextHob.ResourceDescriptor->PhysicalStart + ResourceLength;
 
@@ -193,8 +198,6 @@ MemoryPeim (
         Found = TRUE;
         break;
       }
-
-      NextHob.Raw = GET_NEXT_HOB (NextHob);
     }
 
     ASSERT (Found);

--- a/ArmVirtPkg/Library/ArmVirtDxeHobLib/HobLib.c
+++ b/ArmVirtPkg/Library/ArmVirtDxeHobLib/HobLib.c
@@ -280,6 +280,34 @@ BuildModuleHob (
 }
 
 /**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/EmbeddedPkg/Library/PrePiHobLib/Hob.c
+++ b/EmbeddedPkg/Library/PrePiHobLib/Hob.c
@@ -177,6 +177,51 @@ BuildResourceDescriptorHob (
   Hob->ResourceLength    = NumberOfBytes;
 }
 
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  EFI_HOB_RESOURCE_DESCRIPTOR2  *Hob;
+
+  Hob = CreateHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, sizeof (EFI_HOB_RESOURCE_DESCRIPTOR2));
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->ResourceType             = ResourceType;
+  Hob->ResourceCapabilities     = ResourceCapabilities;
+  Hob->PhysicalStart            = PhysicalStart;
+  Hob->ResourceLength           = ResourceLength;
+  Hob->ResourceMemoryAttributes = ResourceMemoryAttributes;
+
+  if (OwnerGUID != NULL) {
+    CopyGuid (&Hob->Owner, OwnerGUID);
+  } else {
+    ZeroMem (&Hob->Owner, sizeof (EFI_GUID));
+  }
+}
+
 VOID
 EFIAPI
 BuildFvHobs (

--- a/EmulatorPkg/PlatformSmbiosDxe/PlatformSmbiosDxe.c
+++ b/EmulatorPkg/PlatformSmbiosDxe/PlatformSmbiosDxe.c
@@ -54,8 +54,12 @@ CreatePlatformSmbiosMemoryRecords (
 
   // Generate Type16 records
   gSmbiosType19Template.MemoryArrayHandle = PhyscialMemoryArrayHandle;
-  HobPtr.Raw                              = GetHobList ();
-  while ((HobPtr.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, HobPtr.Raw)) != NULL) {
+
+  for (HobPtr.Raw = GetHobList (); !END_OF_HOB_LIST (HobPtr); HobPtr.Raw = GET_NEXT_HOB (HobPtr)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (HobPtr)) {
+      continue;
+    }
+
     if (HobPtr.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {
       gSmbiosType19Template.ExtendedStartingAddress = HobPtr.ResourceDescriptor->PhysicalStart;
       gSmbiosType19Template.ExtendedEndingAddress   =
@@ -64,8 +68,6 @@ CreatePlatformSmbiosMemoryRecords (
 
       SmbiosLibCreateEntry ((SMBIOS_STRUCTURE *)&gSmbiosType19Template, NULL);
     }
-
-    HobPtr.Raw = GET_NEXT_HOB (HobPtr);
   }
 }
 

--- a/IntelFsp2Pkg/Library/BaseFspPlatformLib/FspPlatformMemory.c
+++ b/IntelFsp2Pkg/Library/BaseFspPlatformLib/FspPlatformMemory.c
@@ -40,7 +40,7 @@ FspGetResourceDescriptorByOwner (
   // Collect memory ranges
   //
   while (!END_OF_HOB_LIST (Hob)) {
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       if ((Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_RESERVED) && \
           (CompareGuid (&Hob.ResourceDescriptor->Owner, OwnerGuid)))
       {
@@ -99,7 +99,7 @@ FspGetSystemMemorySize (
   // Collect memory ranges
   //
   while (!END_OF_HOB_LIST (Hob)) {
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       if ((Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) ||
           ((Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_RESERVED) &&
            (Hob.ResourceDescriptor->ResourceAttribute == ResourceAttribute)))

--- a/IntelFsp2WrapperPkg/Library/PeiFspWrapperHobProcessLibSample/FspWrapperHobProcessLibSample.c
+++ b/IntelFsp2WrapperPkg/Library/PeiFspWrapperHobProcessLibSample/FspWrapperHobProcessLibSample.c
@@ -172,10 +172,14 @@ PostFspmHobProcess (
   // Parse the hob list from fsp
   // Report all the resource hob except the memory between 1M and 4G
   //
-  Hob.Raw = (UINT8 *)(UINTN)FspHobList;
+
   DEBUG ((DEBUG_INFO, "FspHobList - 0x%x\n", FspHobList));
 
-  while ((Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw)) != NULL) {
+  for (Hob.Raw = (UINT8 *)(UINTN)FspHobList; !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
     DEBUG ((DEBUG_INFO, "\nResourceType: 0x%x\n", Hob.ResourceDescriptor->ResourceType));
     if ((Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) ||
         (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_RESERVED))
@@ -191,7 +195,6 @@ PostFspmHobProcess (
        && (Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength <= BASE_4GB))
     {
       LowMemorySize += Hob.ResourceDescriptor->ResourceLength;
-      Hob.Raw        = GET_NEXT_HOB (Hob);
       continue;
     }
 
@@ -215,8 +218,6 @@ PostFspmHobProcess (
       Hob.ResourceDescriptor->PhysicalStart,
       Hob.ResourceDescriptor->ResourceLength
       );
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
   }
 
   if (!FoundFspMemHob) {

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2260,6 +2260,7 @@ CoreInitializeMemoryServices (
   UINT32                       ReservedCodePageNumber;
   UINT64                       MinimalMemorySizeNeeded;
   EFI_PHYSICAL_ADDRESS         ResourceHobMemoryTop;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceHobAttribute;
   EFI_STATUS                   Status;
 
   //
@@ -2326,19 +2327,20 @@ CoreInitializeMemoryServices (
     //
     // Skip all HOBs except Resource Descriptor HOBs
     //
-    if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       continue;
     }
 
     //
     // Skip Resource Descriptor HOBs that do not describe tested system memory
     //
-    ResourceHob = Hob.ResourceDescriptor;
+    ResourceHob          = Hob.ResourceDescriptor;
+    ResourceHobAttribute = GET_RESOURCE_HOB_ATTRIBUTE (Hob);
     if (ResourceHob->ResourceType != EFI_RESOURCE_SYSTEM_MEMORY) {
       continue;
     }
 
-    if ((ResourceHob->ResourceAttribute & MEMORY_ATTRIBUTE_MASK) != TESTED_MEMORY_ATTRIBUTES) {
+    if ((ResourceHobAttribute & MEMORY_ATTRIBUTE_MASK) != TESTED_MEMORY_ATTRIBUTES) {
       continue;
     }
 
@@ -2381,7 +2383,7 @@ CoreInitializeMemoryServices (
     //
     // Compute range between PHIT EfiMemoryTop and the end of the Resource Descriptor HOB
     //
-    Attributes  = PhitResourceHob->ResourceAttribute;
+    Attributes  = ResourceHobAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
 
     if (BaseAddress > ResourceHobMemoryTop) {
@@ -2450,19 +2452,20 @@ CoreInitializeMemoryServices (
       //
       // Skip all HOBs except Resource Descriptor HOBs
       //
-      if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+      if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
         continue;
       }
 
       //
       // Skip Resource Descriptor HOBs that do not describe tested system memory below MAX_ALLOC_ADDRESS
       //
-      ResourceHob = Hob.ResourceDescriptor;
+      ResourceHob          = Hob.ResourceDescriptor;
+      ResourceHobAttribute = GET_RESOURCE_HOB_ATTRIBUTE (Hob);
       if (ResourceHob->ResourceType != EFI_RESOURCE_SYSTEM_MEMORY) {
         continue;
       }
 
-      if ((ResourceHob->ResourceAttribute & MEMORY_ATTRIBUTE_MASK) != TESTED_MEMORY_ATTRIBUTES) {
+      if ((ResourceHobAttribute & MEMORY_ATTRIBUTE_MASK) != TESTED_MEMORY_ATTRIBUTES) {
         continue;
       }
 
@@ -2502,7 +2505,7 @@ CoreInitializeMemoryServices (
       //
       BaseAddress = TestedMemoryBaseAddress;
       Length      = TestedMemoryLength;
-      Attributes  = ResourceHob->ResourceAttribute;
+      Attributes  = ResourceHobAttribute;
       HighAddress = ResourceHob->PhysicalStart;
     }
   }
@@ -2598,6 +2601,7 @@ CoreInitializeGcdServices (
   UINT64                           Capabilities;
   EFI_HOB_CPU                      *CpuHob;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMapHobList;
+  EFI_RESOURCE_ATTRIBUTE_TYPE      ResourceHobAttribute;
 
   //
   // Cache the PHIT HOB for later use
@@ -2653,34 +2657,35 @@ CoreInitializeGcdServices (
     GcdMemoryType = EfiGcdMemoryTypeNonExistent;
     GcdIoType     = EfiGcdIoTypeNonExistent;
 
-    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
-      ResourceHob = Hob.ResourceDescriptor;
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      ResourceHob          = Hob.ResourceDescriptor;
+      ResourceHobAttribute = GET_RESOURCE_HOB_ATTRIBUTE (Hob);
 
       switch (ResourceHob->ResourceType) {
         case EFI_RESOURCE_SYSTEM_MEMORY:
-          if ((ResourceHob->ResourceAttribute & MEMORY_ATTRIBUTE_MASK) == TESTED_MEMORY_ATTRIBUTES) {
-            if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE) == EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE) {
+          if ((ResourceHobAttribute & MEMORY_ATTRIBUTE_MASK) == TESTED_MEMORY_ATTRIBUTES) {
+            if ((ResourceHobAttribute & EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE) == EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE) {
               GcdMemoryType = EfiGcdMemoryTypeMoreReliable;
             } else {
               GcdMemoryType = EfiGcdMemoryTypeSystemMemory;
             }
           }
 
-          if ((ResourceHob->ResourceAttribute & MEMORY_ATTRIBUTE_MASK) == INITIALIZED_MEMORY_ATTRIBUTES) {
+          if ((ResourceHobAttribute & MEMORY_ATTRIBUTE_MASK) == INITIALIZED_MEMORY_ATTRIBUTES) {
             GcdMemoryType = EfiGcdMemoryTypeReserved;
           }
 
-          if ((ResourceHob->ResourceAttribute & MEMORY_ATTRIBUTE_MASK) == PRESENT_MEMORY_ATTRIBUTES) {
+          if ((ResourceHobAttribute & MEMORY_ATTRIBUTE_MASK) == PRESENT_MEMORY_ATTRIBUTES) {
             GcdMemoryType = EfiGcdMemoryTypeReserved;
           }
 
           // Mark special purpose memory as system memory, if it was system memory in the HOB
           // However, if this is also marked as persistent, let persistent take precedence
-          if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) == EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) {
+          if ((ResourceHobAttribute & EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) == EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) {
             GcdMemoryType = EfiGcdMemoryTypeSystemMemory;
           }
 
-          if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_PERSISTENT) == EFI_RESOURCE_ATTRIBUTE_PERSISTENT) {
+          if ((ResourceHobAttribute & EFI_RESOURCE_ATTRIBUTE_PERSISTENT) == EFI_RESOURCE_ATTRIBUTE_PERSISTENT) {
             GcdMemoryType = EfiGcdMemoryTypePersistent;
           }
 
@@ -2708,14 +2713,14 @@ CoreInitializeGcdServices (
         //
         // Validate the Resource HOB Attributes
         //
-        CoreValidateResourceDescriptorHobAttributes (ResourceHob->ResourceAttribute);
+        CoreValidateResourceDescriptorHobAttributes (ResourceHobAttribute);
 
         //
         // Convert the Resource HOB Attributes to an EFI Memory Capabilities mask
         //
         Capabilities = CoreConvertResourceDescriptorHobAttributesToCapabilities (
                          GcdMemoryType,
-                         ResourceHob->ResourceAttribute
+                         ResourceHobAttribute
                          );
 
         Status = CoreInternalAddMemorySpace (

--- a/MdeModulePkg/Core/Dxe/Mem/MemoryBin.c
+++ b/MdeModulePkg/Core/Dxe/Mem/MemoryBin.c
@@ -219,6 +219,7 @@ GetMemoryTypeInformationResourceHob (
   EFI_PEI_HOB_POINTERS         Hob;
   EFI_HOB_RESOURCE_DESCRIPTOR  *ResourceHob;
   EFI_HOB_RESOURCE_DESCRIPTOR  *MemoryTypeInformationResourceHob;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceHobAttribute;
   EFI_PHYSICAL_ADDRESS         BinTop;
 
   ASSERT (HobStart != NULL);
@@ -233,11 +234,12 @@ GetMemoryTypeInformationResourceHob (
   MemoryTypeInformationResourceHob = NULL;
   Count                            = 0;
   for (Hob.Raw = *HobStart; !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
-    if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       continue;
     }
 
-    ResourceHob = Hob.ResourceDescriptor;
+    ResourceHob          = Hob.ResourceDescriptor;
+    ResourceHobAttribute = GET_RESOURCE_HOB_ATTRIBUTE (Hob);
     if (!CompareGuid (&ResourceHob->Owner, &gEfiMemoryTypeInformationGuid)) {
       continue;
     }
@@ -247,7 +249,7 @@ GetMemoryTypeInformationResourceHob (
       continue;
     }
 
-    if ((ResourceHob->ResourceAttribute & MEMORY_ATTRIBUTE_MASK) != TESTED_MEMORY_ATTRIBUTES) {
+    if ((ResourceHobAttribute & MEMORY_ATTRIBUTE_MASK) != TESTED_MEMORY_ATTRIBUTES) {
       continue;
     }
 

--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -703,7 +703,7 @@ PeiLoadFixAddressHook (
     //
     // See if this is a resource descriptor HOB
     //
-    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       ResourceHob = Hob.ResourceDescriptor;
       //
       // If range described in this HOB is not system memory or higher than MAX_ADDRESS, ignored.
@@ -722,14 +722,14 @@ PeiLoadFixAddressHook (
         //
         // See if this is a resource descriptor HOB
         //
-        if (GET_HOB_TYPE (NextHob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+        if (IS_RESOURCE_DESCRIPTOR_HOB (NextHob)) {
           NextResourceHob = NextHob.ResourceDescriptor;
           //
           // test if range described in this NextResourceHob is system memory and have the same attribute.
           // Note: Here is a assumption that system memory should always be healthy even without test.
           //
           if ((NextResourceHob->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
-              (((NextResourceHob->ResourceAttribute^ResourceHob->ResourceAttribute) & (~EFI_RESOURCE_ATTRIBUTE_TESTED)) == 0))
+              (((GET_RESOURCE_HOB_ATTRIBUTE (NextHob)^GET_RESOURCE_HOB_ATTRIBUTE (Hob)) & (~EFI_RESOURCE_ATTRIBUTE_TESTED)) == 0))
           {
             //
             // See if the memory range described in ResourceHob and NextResourceHob is adjacent
@@ -773,7 +773,7 @@ PeiLoadFixAddressHook (
         //
         // See if this is a resource descriptor HOB
         //
-        if (GET_HOB_TYPE (NextHob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+        if (IS_RESOURCE_DESCRIPTOR_HOB (NextHob)) {
           NextResourceHob = NextHob.ResourceDescriptor;
           //
           // If range described in this HOB is not system memory or higher than MAX_ADDRESS, ignored.
@@ -794,7 +794,7 @@ PeiLoadFixAddressHook (
             if (MemoryHob->AllocDescriptor.MemoryBaseAddress > NextResourceHob->PhysicalStart) {
               BuildResourceDescriptorHob (
                 EFI_RESOURCE_SYSTEM_MEMORY,
-                NextResourceHob->ResourceAttribute,
+                GET_RESOURCE_HOB_ATTRIBUTE (NextHob),
                 NextResourceHob->PhysicalStart,
                 (MemoryHob->AllocDescriptor.MemoryBaseAddress - NextResourceHob->PhysicalStart)
                 );
@@ -803,7 +803,7 @@ PeiLoadFixAddressHook (
             if (MemoryHob->AllocDescriptor.MemoryBaseAddress + MemoryHob->AllocDescriptor.MemoryLength < NextResourceHob->PhysicalStart + NextResourceHob->ResourceLength) {
               BuildResourceDescriptorHob (
                 EFI_RESOURCE_SYSTEM_MEMORY,
-                NextResourceHob->ResourceAttribute,
+                GET_RESOURCE_HOB_ATTRIBUTE (NextHob),
                 MemoryHob->AllocDescriptor.MemoryBaseAddress + MemoryHob->AllocDescriptor.MemoryLength,
                 (NextResourceHob->PhysicalStart + NextResourceHob->ResourceLength -(MemoryHob->AllocDescriptor.MemoryBaseAddress + MemoryHob->AllocDescriptor.MemoryLength))
                 );
@@ -842,7 +842,7 @@ PeiLoadFixAddressHook (
       //
       // See if this is a resource descriptor HOB
       //
-      if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+      if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
         ResourceHob = Hob.ResourceDescriptor;
         //
         // See if this resource descriptor HOB describes tested system memory below MAX_ADDRESS
@@ -878,7 +878,7 @@ PeiLoadFixAddressHook (
         //
         // See if this is a resource descriptor HOB
         //
-        if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+        if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
           ResourceHob = Hob.ResourceDescriptor;
           //
           // See if this resource descriptor HOB describes tested system memory below MAX_ADDRESS
@@ -919,7 +919,7 @@ PeiLoadFixAddressHook (
       //
       // See if this is a resource descriptor HOB
       //
-      if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+      if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
         ResourceHob = Hob.ResourceDescriptor;
         //
         // See if this resource descriptor HOB describes tested system memory below MAX_ADDRESS

--- a/MdeModulePkg/Core/Pei/Memory/MemoryBin.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryBin.c
@@ -219,6 +219,7 @@ GetMemoryTypeInformationResourceHob (
   EFI_PEI_HOB_POINTERS         Hob;
   EFI_HOB_RESOURCE_DESCRIPTOR  *ResourceHob;
   EFI_HOB_RESOURCE_DESCRIPTOR  *MemoryTypeInformationResourceHob;
+  EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceHobAttribute;
   EFI_PHYSICAL_ADDRESS         BinTop;
 
   ASSERT (HobStart != NULL);
@@ -233,11 +234,12 @@ GetMemoryTypeInformationResourceHob (
   MemoryTypeInformationResourceHob = NULL;
   Count                            = 0;
   for (Hob.Raw = *HobStart; !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
-    if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       continue;
     }
 
-    ResourceHob = Hob.ResourceDescriptor;
+    ResourceHob          = Hob.ResourceDescriptor;
+    ResourceHobAttribute = GET_RESOURCE_HOB_ATTRIBUTE (Hob);
     if (!CompareGuid (&ResourceHob->Owner, &gEfiMemoryTypeInformationGuid)) {
       continue;
     }
@@ -247,7 +249,7 @@ GetMemoryTypeInformationResourceHob (
       continue;
     }
 
-    if ((ResourceHob->ResourceAttribute & MEMORY_ATTRIBUTE_MASK) != TESTED_MEMORY_ATTRIBUTES) {
+    if ((ResourceHobAttribute & MEMORY_ATTRIBUTE_MASK) != TESTED_MEMORY_ATTRIBUTES) {
       continue;
     }
 

--- a/MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.c
+++ b/MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.c
@@ -232,6 +232,34 @@ BuildResourceDescriptorWithOwnerHob (
 }
 
 /**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
+++ b/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
@@ -187,13 +187,13 @@ PrintMemoryAllocationHob (
 }
 
 /**
-  Print the information in Resource Discriptor Hob.
+  Print the information in Resource Descriptor Hob.
   @param[in]  HobStart       A pointer to HOB of type EFI_HOB_TYPE_RESOURCE_DESCRIPTOR.
   @param[in]  HobLength      The Length in bytes of HOB of type EFI_HOB_TYPE_RESOURCE_DESCRIPTOR.
   @retval EFI_SUCCESS        If it completed successfully.
 **/
 EFI_STATUS
-PrintResourceDiscriptorHob (
+PrintResourceDescriptorHob (
   IN  VOID    *HobStart,
   IN  UINT16  HobLength
   )
@@ -211,6 +211,35 @@ PrintResourceDiscriptorHob (
   DEBUG ((DEBUG_INFO, "   ResourceAttribute = 0x%x\n", Hob.ResourceDescriptor->ResourceAttribute));
   DEBUG ((DEBUG_INFO, "   PhysicalStart     = 0x%lx\n", Hob.ResourceDescriptor->PhysicalStart));
   DEBUG ((DEBUG_INFO, "   ResourceLength    = 0x%lx\n", Hob.ResourceDescriptor->ResourceLength));
+  return EFI_SUCCESS;
+}
+
+/**
+  Print the information in Resource Descriptor Hob.
+  @param[in]  HobStart       A pointer to HOB of type EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2.
+  @param[in]  HobLength      The Length in bytes of HOB of type EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2.
+  @retval EFI_SUCCESS        If it completed successfully.
+**/
+EFI_STATUS
+PrintResourceDescriptor2Hob (
+  IN  VOID    *HobStart,
+  IN  UINT16  HobLength
+  )
+{
+  EFI_PEI_HOB_POINTERS  Hob;
+
+  Hob.Raw = (UINT8 *)HobStart;
+  ASSERT (HobLength >= sizeof (*Hob.ResourceDescriptor2));
+
+  DEBUG ((DEBUG_INFO, "   ResourceType             = %a\n", mResource_Type_List[Hob.ResourceDescriptor2->ResourceType]));
+  if (!IsZeroGuid (&Hob.ResourceDescriptor2->Owner)) {
+    DEBUG ((DEBUG_INFO, "   Owner                  = %g\n", &Hob.ResourceDescriptor2->Owner));
+  }
+
+  DEBUG ((DEBUG_INFO, "   ResourceCapabilities     = 0x%x\n", Hob.ResourceDescriptor2->ResourceCapabilities));
+  DEBUG ((DEBUG_INFO, "   PhysicalStart            = 0x%lx\n", Hob.ResourceDescriptor2->PhysicalStart));
+  DEBUG ((DEBUG_INFO, "   ResourceLength           = 0x%lx\n", Hob.ResourceDescriptor2->ResourceLength));
+  DEBUG ((DEBUG_INFO, "   ResourceMemoryAttributes = 0x%x\n", Hob.ResourceDescriptor2->ResourceMemoryAttributes));
   return EFI_SUCCESS;
 }
 
@@ -386,17 +415,18 @@ PrintFv3Hob (
 // Mapping table from Hob type to Hob print function.
 //
 HOB_PRINT_HANDLER_TABLE  mHobHandles[] = {
-  { EFI_HOB_TYPE_HANDOFF,             "EFI_HOB_TYPE_HANDOFF",             PrintHandOffHob            },
-  { EFI_HOB_TYPE_MEMORY_ALLOCATION,   "EFI_HOB_TYPE_MEMORY_ALLOCATION",   PrintMemoryAllocationHob   },
-  { EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, "EFI_HOB_TYPE_RESOURCE_DESCRIPTOR", PrintResourceDiscriptorHob },
-  { EFI_HOB_TYPE_GUID_EXTENSION,      "EFI_HOB_TYPE_GUID_EXTENSION",      PrintGuidHob               },
-  { EFI_HOB_TYPE_FV,                  "EFI_HOB_TYPE_FV",                  PrintFvHob                 },
-  { EFI_HOB_TYPE_CPU,                 "EFI_HOB_TYPE_CPU",                 PrintCpuHob                },
-  { EFI_HOB_TYPE_MEMORY_POOL,         "EFI_HOB_TYPE_MEMORY_POOL",         PrintMemoryPoolHob         },
-  { EFI_HOB_TYPE_FV2,                 "EFI_HOB_TYPE_FV2",                 PrintFv2Hob                },
-  { EFI_HOB_TYPE_UEFI_CAPSULE,        "EFI_HOB_TYPE_UEFI_CAPSULE",        PrintCapsuleHob            },
-  { EFI_HOB_TYPE_FV3,                 "EFI_HOB_TYPE_FV3",                 PrintFv3Hob                },
-  { EFI_HOB_TYPE_UNUSED,              "EFI_HOB_TYPE_UNUSED",              NULL                       }
+  { EFI_HOB_TYPE_HANDOFF,              "EFI_HOB_TYPE_HANDOFF",              PrintHandOffHob             },
+  { EFI_HOB_TYPE_MEMORY_ALLOCATION,    "EFI_HOB_TYPE_MEMORY_ALLOCATION",    PrintMemoryAllocationHob    },
+  { EFI_HOB_TYPE_RESOURCE_DESCRIPTOR,  "EFI_HOB_TYPE_RESOURCE_DESCRIPTOR",  PrintResourceDescriptorHob  },
+  { EFI_HOB_TYPE_GUID_EXTENSION,       "EFI_HOB_TYPE_GUID_EXTENSION",       PrintGuidHob                },
+  { EFI_HOB_TYPE_FV,                   "EFI_HOB_TYPE_FV",                   PrintFvHob                  },
+  { EFI_HOB_TYPE_CPU,                  "EFI_HOB_TYPE_CPU",                  PrintCpuHob                 },
+  { EFI_HOB_TYPE_MEMORY_POOL,          "EFI_HOB_TYPE_MEMORY_POOL",          PrintMemoryPoolHob          },
+  { EFI_HOB_TYPE_FV2,                  "EFI_HOB_TYPE_FV2",                  PrintFv2Hob                 },
+  { EFI_HOB_TYPE_UEFI_CAPSULE,         "EFI_HOB_TYPE_UEFI_CAPSULE",         PrintCapsuleHob             },
+  { EFI_HOB_TYPE_FV3,                  "EFI_HOB_TYPE_FV3",                  PrintFv3Hob                 },
+  { EFI_HOB_TYPE_UNUSED,               "EFI_HOB_TYPE_UNUSED",               NULL                        },
+  { EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, "EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2", PrintResourceDescriptor2Hob }
 };
 
 /**

--- a/MdeModulePkg/Universal/CapsulePei/UefiCapsule.c
+++ b/MdeModulePkg/Universal/CapsulePei/UefiCapsule.c
@@ -741,16 +741,16 @@ BuildMemoryResourceDescriptor (
   //
   // Get the count of memory resource descriptor.
   //
-  Index   = 0;
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
-    ResourceDescriptor = (EFI_HOB_RESOURCE_DESCRIPTOR *)Hob.Raw;
+  Index = 0;
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
+    ResourceDescriptor = Hob.ResourceDescriptor;
     if (ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {
       Index++;
     }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   if (Index == 0) {
@@ -789,10 +789,13 @@ BuildMemoryResourceDescriptor (
   //
   // Get the content of memory resource descriptor.
   //
-  Index   = 0;
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
-    ResourceDescriptor = (EFI_HOB_RESOURCE_DESCRIPTOR *)Hob.Raw;
+  Index = 0;
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
+    ResourceDescriptor = Hob.ResourceDescriptor;
     if (ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {
       DEBUG ((
         DEBUG_INFO,
@@ -805,9 +808,6 @@ BuildMemoryResourceDescriptor (
       MemoryResource[Index].ResourceLength = ResourceDescriptor->ResourceLength;
       Index++;
     }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   SortMemoryResourceDescriptor (MemoryResource);

--- a/MdePkg/Include/Library/HobLib.h
+++ b/MdePkg/Include/Library/HobLib.h
@@ -228,6 +228,31 @@ BuildResourceDescriptorHob (
   );
 
 /**
+Builds a HOB that describes a chunk of system memory with memory attributes.
+
+This function builds a HOB that describes a chunk of system memory.
+If there is no additional space for HOB creation, then ASSERT().
+
+@param  ResourceType               The type of resource described by this HOB.
+@param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+@param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+@param  ResourceLength             The length of the memory described by this HOB in bytes.
+@param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+@param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  );
+
+/**
   Builds a customized HOB tagged with a GUID for identification and returns
   the start address of GUID HOB data.
 
@@ -602,3 +627,37 @@ TagMemoryAllocationHobWithGuid (
 **/
 #define GET_GUID_HOB_DATA_SIZE(HobStart) \
   (UINT16)(GET_HOB_LENGTH (HobStart) - sizeof (EFI_HOB_GUID_TYPE))
+
+/**
+  Determines if a HOB is a Resource Descriptor HOB (v1 or v2).
+
+  This macro returns TRUE if the HOB specified by Hob is of type
+  EFI_HOB_TYPE_RESOURCE_DESCRIPTOR or EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2.
+
+  @param  Hob   A pointer to a HOB.
+
+  @retval TRUE   The HOB is a Resource Descriptor v1 or v2.
+  @retval FALSE  The HOB is not a Resource Descriptor.
+
+**/
+#define IS_RESOURCE_DESCRIPTOR_HOB(Hob)  \
+  ((GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) || \
+   (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2))
+
+/**
+  Returns the resource attribute from a Resource Descriptor HOB (v1 or v2).
+
+  This macro returns the ResourceAttribute field for a Resource Descriptor v1
+  HOB, or the ResourceCapabilities field for a Resource Descriptor v2 HOB.
+  Hob is assumed to be a HOB of type EFI_HOB_TYPE_RESOURCE_DESCRIPTOR or
+  EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2.
+
+  @param  Hob   A pointer to a HOB.
+
+  @return The resource attribute (v1) or resource capabilities (v2) value.
+
+**/
+#define GET_RESOURCE_HOB_ATTRIBUTE(Hob)  \
+  ((GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2) ? \
+   (Hob).ResourceDescriptor2->ResourceCapabilities :            \
+   (Hob).ResourceDescriptor->ResourceAttribute)

--- a/MdePkg/Include/Pi/PiHob.h
+++ b/MdePkg/Include/Pi/PiHob.h
@@ -14,19 +14,20 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // HobType of EFI_HOB_GENERIC_HEADER.
 //
-#define EFI_HOB_TYPE_HANDOFF              0x0001
-#define EFI_HOB_TYPE_MEMORY_ALLOCATION    0x0002
-#define EFI_HOB_TYPE_RESOURCE_DESCRIPTOR  0x0003
-#define EFI_HOB_TYPE_GUID_EXTENSION       0x0004
-#define EFI_HOB_TYPE_FV                   0x0005
-#define EFI_HOB_TYPE_CPU                  0x0006
-#define EFI_HOB_TYPE_MEMORY_POOL          0x0007
-#define EFI_HOB_TYPE_FV2                  0x0009
-#define EFI_HOB_TYPE_LOAD_PEIM_UNUSED     0x000A
-#define EFI_HOB_TYPE_UEFI_CAPSULE         0x000B
-#define EFI_HOB_TYPE_FV3                  0x000C
-#define EFI_HOB_TYPE_UNUSED               0xFFFE
-#define EFI_HOB_TYPE_END_OF_HOB_LIST      0xFFFF
+#define EFI_HOB_TYPE_HANDOFF               0x0001
+#define EFI_HOB_TYPE_MEMORY_ALLOCATION     0x0002
+#define EFI_HOB_TYPE_RESOURCE_DESCRIPTOR   0x0003
+#define EFI_HOB_TYPE_GUID_EXTENSION        0x0004
+#define EFI_HOB_TYPE_FV                    0x0005
+#define EFI_HOB_TYPE_CPU                   0x0006
+#define EFI_HOB_TYPE_MEMORY_POOL           0x0007
+#define EFI_HOB_TYPE_FV2                   0x0009
+#define EFI_HOB_TYPE_LOAD_PEIM_UNUSED      0x000A
+#define EFI_HOB_TYPE_UEFI_CAPSULE          0x000B
+#define EFI_HOB_TYPE_FV3                   0x000C
+#define EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2  0x000D
+#define EFI_HOB_TYPE_UNUSED                0xFFFE
+#define EFI_HOB_TYPE_END_OF_HOB_LIST       0xFFFF
 
 ///
 /// Describes the format and size of the data inside the HOB.
@@ -333,6 +334,43 @@ typedef struct {
 } EFI_HOB_RESOURCE_DESCRIPTOR;
 
 ///
+/// Describes the resource properties and memory attributes
+/// of all fixed, non-relocatable resource ranges found on the
+/// processor host bus during the HOB producer phase.
+///
+typedef struct {
+  ///
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_RESOURCE_DESCRIPTOR.
+  ///
+  EFI_HOB_GENERIC_HEADER         Header;
+  ///
+  /// A GUID representing the owner of the resource. This GUID is used by HOB
+  /// consumer phase components to correlate device ownership of a resource.
+  ///
+  EFI_GUID                       Owner;
+  ///
+  /// The resource type as defined by EFI_RESOURCE_TYPE.
+  ///
+  EFI_RESOURCE_TYPE              ResourceType;
+  ///
+  /// Resource Capabilities as defined by EFI_RESOURCE_ATTRIBUTE_TYPE.
+  ///
+  EFI_RESOURCE_ATTRIBUTE_TYPE    ResourceCapabilities;
+  ///
+  /// The physical start address of the resource region.
+  ///
+  EFI_PHYSICAL_ADDRESS           PhysicalStart;
+  ///
+  /// The number of bytes of the resource region.
+  ///
+  UINT64                         ResourceLength;
+  ///
+  /// The memory attributes (paging and caching) of the resource region.
+  ///
+  UINT64                         ResourceMemoryAttributes;
+} EFI_HOB_RESOURCE_DESCRIPTOR2;
+
+///
 /// Allows writers of executable content in the HOB producer phase to
 /// maintain and manage HOBs with specific GUID.
 ///
@@ -505,5 +543,6 @@ typedef union {
   EFI_HOB_CPU                            *Cpu;
   EFI_HOB_MEMORY_POOL                    *Pool;
   EFI_HOB_UEFI_CAPSULE                   *Capsule;
+  EFI_HOB_RESOURCE_DESCRIPTOR2           *ResourceDescriptor2;
   UINT8                                  *Raw;
 } EFI_PEI_HOB_POINTERS;

--- a/MdePkg/Library/DxeCoreHobLib/HobLib.c
+++ b/MdePkg/Library/DxeCoreHobLib/HobLib.c
@@ -270,6 +270,34 @@ BuildResourceDescriptorWithOwnerHob (
 }
 
 /**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/MdePkg/Library/DxeHobLib/HobLib.c
+++ b/MdePkg/Library/DxeHobLib/HobLib.c
@@ -305,6 +305,34 @@ BuildResourceDescriptorWithOwnerHob (
 }
 
 /**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/MdePkg/Library/PeiHobLib/HobLib.c
+++ b/MdePkg/Library/PeiHobLib/HobLib.c
@@ -343,6 +343,51 @@ BuildResourceDescriptorWithOwnerHob (
 }
 
 /**
+Builds a HOB that describes a chunk of system memory with memory attributes.
+
+This function builds a HOB that describes a chunk of system memory.
+If there is no additional space for HOB creation, then ASSERT().
+
+@param  ResourceType               The type of resource described by this HOB.
+@param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+@param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+@param  ResourceLength             The length of the memory described by this HOB in bytes.
+@param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+@param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  EFI_HOB_RESOURCE_DESCRIPTOR2  *Hob;
+
+  Hob = InternalPeiCreateHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, (UINT16)sizeof (EFI_HOB_RESOURCE_DESCRIPTOR2));
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->ResourceType             = ResourceType;
+  Hob->ResourceCapabilities     = ResourceCapabilities;
+  Hob->PhysicalStart            = PhysicalStart;
+  Hob->ResourceLength           = ResourceLength;
+  Hob->ResourceMemoryAttributes = ResourceMemoryAttributes;
+
+  if (OwnerGUID != NULL) {
+    CopyGuid (&Hob->Owner, OwnerGUID);
+  } else {
+    ZeroMem (&Hob->Owner, sizeof (EFI_GUID));
+  }
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockHobLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockHobLib.h
@@ -76,6 +76,16 @@ struct MockHobLib {
      IN UINT64                       NumberOfBytes)
     );
   MOCK_FUNCTION_DECLARATION (
+    VOID,
+    BuildResourceDescriptor2Hob,
+    (IN EFI_RESOURCE_TYPE            ResourceType,
+     IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+     IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+     IN UINT64                       ResourceLength,
+     IN UINT64                       ResourceMemoryAttributes,
+     IN EFI_GUID                     *OwnerGUID)
+    );
+  MOCK_FUNCTION_DECLARATION (
     VOID *,
     BuildGuidHob,
     (IN CONST EFI_GUID  *Guid,

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockHobLib/MockHobLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockHobLib/MockHobLib.cpp
@@ -30,3 +30,4 @@ MOCK_FUNCTION_DEFINITION (MockHobLib, BuildBspStoreHob, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockHobLib, BuildMemoryAllocationHob, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockHobLib, GetNextMemoryAllocationGuidHob, 2, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockHobLib, TagMemoryAllocationHobWithGuid, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHobLib, BuildResourceDescriptor2Hob, 6, EFIAPI);

--- a/OvmfPkg/IntelTdx/TdxHelperLib/SecTdxHelper.c
+++ b/OvmfPkg/IntelTdx/TdxHelperLib/SecTdxHelper.c
@@ -376,7 +376,7 @@ AcceptMemoryForAPsStack (
   // Parse the HOB list until end of list or matching type is found.
   //
   while (!END_OF_HOB_LIST (Hob) && !MemoryRegionFound) {
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       DEBUG ((DEBUG_INFO, "\nResourceType: 0x%x\n", Hob.ResourceDescriptor->ResourceType));
 
       if (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_UNACCEPTED) {
@@ -454,7 +454,7 @@ AcceptMemory (
   // Parse the HOB list until end of list or matching type is found.
   //
   while (!END_OF_HOB_LIST (Hob)) {
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       if (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_UNACCEPTED) {
         PhysicalStart = Hob.ResourceDescriptor->PhysicalStart;
         PhysicalEnd   = PhysicalStart + Hob.ResourceDescriptor->ResourceLength;
@@ -636,8 +636,11 @@ ValidateHobList (
         break;
 
       case EFI_HOB_TYPE_RESOURCE_DESCRIPTOR:
-        if (Hob.Header->HobLength != sizeof (EFI_HOB_RESOURCE_DESCRIPTOR)) {
-          DEBUG ((DEBUG_ERROR, "HOB: Hob length is not equal corresponding hob structure. Type: 0x%04x\n", EFI_HOB_TYPE_RESOURCE_DESCRIPTOR));
+      case EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2:
+        if (((GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) && (Hob.Header->HobLength != sizeof (EFI_HOB_RESOURCE_DESCRIPTOR))) ||
+            ((GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2) && (Hob.Header->HobLength != sizeof (EFI_HOB_RESOURCE_DESCRIPTOR2))))
+        {
+          DEBUG ((DEBUG_ERROR, "HOB: Hob length is not equal corresponding hob structure. Type: 0x%04x\n", GET_HOB_TYPE (Hob)));
           return FALSE;
         }
 
@@ -646,34 +649,34 @@ ValidateHobList (
           return FALSE;
         }
 
-        if ((Hob.ResourceDescriptor->ResourceAttribute & (~(EFI_RESOURCE_ATTRIBUTE_PRESENT |
-                                                            EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
-                                                            EFI_RESOURCE_ATTRIBUTE_TESTED |
-                                                            EFI_RESOURCE_ATTRIBUTE_READ_PROTECTED |
-                                                            EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTED |
-                                                            EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTED |
-                                                            EFI_RESOURCE_ATTRIBUTE_PERSISTENT |
-                                                            EFI_RESOURCE_ATTRIBUTE_SINGLE_BIT_ECC |
-                                                            EFI_RESOURCE_ATTRIBUTE_MULTIPLE_BIT_ECC |
-                                                            EFI_RESOURCE_ATTRIBUTE_ECC_RESERVED_1 |
-                                                            EFI_RESOURCE_ATTRIBUTE_ECC_RESERVED_2 |
-                                                            EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_16_BIT_IO |
-                                                            EFI_RESOURCE_ATTRIBUTE_32_BIT_IO |
-                                                            EFI_RESOURCE_ATTRIBUTE_64_BIT_IO |
-                                                            EFI_RESOURCE_ATTRIBUTE_UNCACHED_EXPORTED |
-                                                            EFI_RESOURCE_ATTRIBUTE_READ_PROTECTABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_PERSISTABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED |
-                                                            EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE |
-                                                            EFI_RESOURCE_ATTRIBUTE_ENCRYPTED|
-                                                            EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE |
-                                                            EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE))) != 0)
+        if ((GET_RESOURCE_HOB_ATTRIBUTE (Hob) & (~(EFI_RESOURCE_ATTRIBUTE_PRESENT |
+                                                   EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+                                                   EFI_RESOURCE_ATTRIBUTE_TESTED |
+                                                   EFI_RESOURCE_ATTRIBUTE_READ_PROTECTED |
+                                                   EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTED |
+                                                   EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTED |
+                                                   EFI_RESOURCE_ATTRIBUTE_PERSISTENT |
+                                                   EFI_RESOURCE_ATTRIBUTE_SINGLE_BIT_ECC |
+                                                   EFI_RESOURCE_ATTRIBUTE_MULTIPLE_BIT_ECC |
+                                                   EFI_RESOURCE_ATTRIBUTE_ECC_RESERVED_1 |
+                                                   EFI_RESOURCE_ATTRIBUTE_ECC_RESERVED_2 |
+                                                   EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_16_BIT_IO |
+                                                   EFI_RESOURCE_ATTRIBUTE_32_BIT_IO |
+                                                   EFI_RESOURCE_ATTRIBUTE_64_BIT_IO |
+                                                   EFI_RESOURCE_ATTRIBUTE_UNCACHED_EXPORTED |
+                                                   EFI_RESOURCE_ATTRIBUTE_READ_PROTECTABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_PERSISTABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED |
+                                                   EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE |
+                                                   EFI_RESOURCE_ATTRIBUTE_ENCRYPTED|
+                                                   EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE |
+                                                   EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE))) != 0)
         {
           DEBUG ((DEBUG_ERROR, "HOB: Unknow ResourceDescriptor ResourceAttribute type. Type: 0x%08x\n", Hob.ResourceDescriptor->ResourceAttribute));
           return FALSE;

--- a/OvmfPkg/Library/PeilessStartupLib/Hob.c
+++ b/OvmfPkg/Library/PeilessStartupLib/Hob.c
@@ -91,7 +91,7 @@ ConstructFwHobList (
   // Parse the HOB list until end of list or matching type is found.
   //
   while (!END_OF_HOB_LIST (Hob)) {
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       if (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_UNACCEPTED) {
         PhysicalEnd    = Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength;
         ResourceLength = Hob.ResourceDescriptor->ResourceLength;

--- a/OvmfPkg/Library/PlatformInitLib/IntelTdx.c
+++ b/OvmfPkg/Library/PlatformInitLib/IntelTdx.c
@@ -101,6 +101,7 @@ TransferTdxHobList (
   while (!END_OF_HOB_LIST (Hob)) {
     switch (Hob.Header->HobType) {
       case EFI_HOB_TYPE_RESOURCE_DESCRIPTOR:
+      case EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2:
         ResourceType      = Hob.ResourceDescriptor->ResourceType;
         ResourceAttribute = Hob.ResourceDescriptor->ResourceAttribute;
 

--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -115,7 +115,7 @@ PlatformScanE820Tdx (
   Hob.Raw = (UINT8 *)(UINTN)FixedPcdGet32 (PcdOvmfSecGhcbBase);
 
   while (!END_OF_HOB_LIST (Hob)) {
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       if ((Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_UNACCEPTED) ||
           (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY))
       {

--- a/OvmfPkg/PlatformPei/AmdSev.c
+++ b/OvmfPkg/PlatformPei/AmdSev.c
@@ -144,7 +144,7 @@ AmdSevSnpInitialize (
   // Iterate through the system RAM and validate it.
   //
   for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
-    if ((Hob.Raw != NULL) && (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR)) {
+    if ((Hob.Raw != NULL) && IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       ResourceHob = Hob.ResourceDescriptor;
 
       if (ResourceHob->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {

--- a/OvmfPkg/RiscVVirt/PlatformPei/PlatformPeim.c
+++ b/OvmfPkg/RiscVVirt/PlatformPei/PlatformPeim.c
@@ -79,7 +79,7 @@ FindInstallPeiMemory (
   // Iterate through the HOB list
   Hob.Raw = HobList;
   while (!END_OF_HOB_LIST (Hob)) {
-    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       ResourceHob = (EFI_HOB_RESOURCE_DESCRIPTOR *)Hob.Raw;
       if (  (ResourceHob->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY)
          && (ResourceHob->PhysicalStart > PeiMemoryBase)

--- a/OvmfPkg/TdxDxe/TdxDxe.c
+++ b/OvmfPkg/TdxDxe/TdxDxe.c
@@ -196,8 +196,11 @@ GetResourceDescriptor (
   EFI_PEI_HOB_POINTERS         Hob;
   EFI_HOB_RESOURCE_DESCRIPTOR  *ResourceDescriptor = NULL;
 
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
     DEBUG ((
       DEBUG_INFO,
       "%a:%d: resource type 0x%x %llx %llx\n",
@@ -215,9 +218,6 @@ GetResourceDescriptor (
       ResourceDescriptor = Hob.ResourceDescriptor;
       break;
     }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   return ResourceDescriptor;
@@ -242,8 +242,11 @@ GetHighestResourceDescriptor (
   EFI_PEI_HOB_POINTERS         Hob;
   EFI_HOB_RESOURCE_DESCRIPTOR  *ResourceDescriptor = NULL;
 
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
     if ((Hob.ResourceDescriptor->ResourceType == Type) &&
         (Hob.ResourceDescriptor->PhysicalStart < End))
     {
@@ -253,9 +256,6 @@ GetHighestResourceDescriptor (
         ResourceDescriptor = Hob.ResourceDescriptor;
       }
     }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   return ResourceDescriptor;
@@ -285,7 +285,7 @@ SetMmioSharedBit (
   // Parse the HOB list until end of list or matching type is found.
   //
   while (!END_OF_HOB_LIST (Hob)) {
-    if (  (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR)
+    if (  IS_RESOURCE_DESCRIPTOR_HOB (Hob)
        && (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_MAPPED_IO))
     {
       MemEncryptTdxSetPageSharedBit (

--- a/StandaloneMmPkg/Core/StandaloneMmCore.c
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.c
@@ -773,7 +773,7 @@ InitializeMmHobList (
   Hob.Raw = (UINT8 *)HobStart;
   while (!END_OF_HOB_LIST (Hob)) {
     Hob.Raw = GET_NEXT_HOB (Hob);
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       ResourceHobBase = Hob.ResourceDescriptor->PhysicalStart;
       ResourceHobEnd  = Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength;
 

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
@@ -557,7 +557,7 @@ CollectPlatformMemoryRegions (
   // Collect memory ranges
   //
   while (Hob.Raw < PlatformHobList + PlatformHobSize) {
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       if (  (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_MEMORY_MAPPED_IO)
          || (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY)
          || (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_FIRMWARE_DEVICE)

--- a/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.c
@@ -48,6 +48,34 @@ BuildModuleHob (
 }
 
 /**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.c
@@ -286,6 +286,34 @@ BuildModuleHob (
 }
 
 /**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/StandaloneMmPkg/Library/StandaloneMmMemLib/X86StandaloneMmMemLibInternal.c
+++ b/StandaloneMmPkg/Library/StandaloneMmMemLib/X86StandaloneMmMemLibInternal.c
@@ -186,11 +186,10 @@ MmMemLibInitializeValidNonMmramRanges (
   //
   // 1. Get the count.
   //
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
-    Count++;
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      Count++;
+    }
   }
 
   //
@@ -200,14 +199,14 @@ MmMemLibInitializeValidNonMmramRanges (
   mValidNonMmramRanges = (NON_MM_MEMORY_RANGE *)AllocateZeroPool (RangeSize);
   ASSERT (mValidNonMmramRanges != NULL);
 
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
     mValidNonMmramRanges[Index].Base   = Hob.ResourceDescriptor->PhysicalStart;
     mValidNonMmramRanges[Index].Length = Hob.ResourceDescriptor->ResourceLength;
     Index++;
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   ASSERT (Index == Count);

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -202,10 +202,10 @@ GetWakeupBuffer (
   // Collect memory ranges
   //
   while (!END_OF_HOB_LIST (Hob)) {
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       if ((Hob.ResourceDescriptor->PhysicalStart < BASE_1MB) &&
           (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
-          ((Hob.ResourceDescriptor->ResourceAttribute &
+          ((GET_RESOURCE_HOB_ATTRIBUTE (Hob) &
             (EFI_RESOURCE_ATTRIBUTE_READ_PROTECTED |
              EFI_RESOURCE_ATTRIBUTE_WRITE_PROTECTED |
              EFI_RESOURCE_ATTRIBUTE_EXECUTION_PROTECTED

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/NonMmramMapStandaloneMm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/NonMmramMapStandaloneMm.c
@@ -65,8 +65,11 @@ IsNonMmramLoggingAddress (
 {
   EFI_PEI_HOB_POINTERS  Hob;
 
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
     if ((Address >= Hob.ResourceDescriptor->PhysicalStart) && (Address < Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength)) {
       if ((Hob.ResourceDescriptor->ResourceAttribute & MM_RESOURCE_ATTRIBUTE_LOGGING) != 0) {
         return TRUE;
@@ -74,9 +77,6 @@ IsNonMmramLoggingAddress (
 
       return FALSE;
     }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   return FALSE;
@@ -97,14 +97,14 @@ IsSmmCommBufferForbiddenAddress (
 {
   EFI_PEI_HOB_POINTERS  Hob;
 
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
     if ((Address >= Hob.ResourceDescriptor->PhysicalStart) && (Address < Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength)) {
       return FALSE;
     }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   return TRUE;
@@ -137,9 +137,12 @@ BuildMemoryMapFromResDescHobs (
   //
   // Get the count.
   //
-  Count   = 0;
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
+  Count = 0;
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
     if ((Hob.ResourceDescriptor->ResourceAttribute & MM_RESOURCE_ATTRIBUTE_LOGGING) == 0) {
       ResourceHobEnd = Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength;
 
@@ -154,9 +157,6 @@ BuildMemoryMapFromResDescHobs (
       //
       Count++;
     }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   *MemoryRegionCount = Count;
@@ -164,9 +164,12 @@ BuildMemoryMapFromResDescHobs (
   *MemoryRegion = (MM_CPU_MEMORY_REGION *)AllocateZeroPool (sizeof (MM_CPU_MEMORY_REGION) * Count);
   ASSERT (*MemoryRegion != NULL);
 
-  Index   = 0;
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
-  while (Hob.Raw != NULL) {
+  Index = 0;
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
+
     if ((Hob.ResourceDescriptor->ResourceAttribute & MM_RESOURCE_ATTRIBUTE_LOGGING) == 0) {
       ASSERT (Index < Count);
       (*MemoryRegion)[Index].Base      = Hob.ResourceDescriptor->PhysicalStart;
@@ -178,9 +181,6 @@ BuildMemoryMapFromResDescHobs (
 
       Index++;
     }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
   }
 
   return;

--- a/UefiPayloadPkg/BlSupportDxe/AArch64/BlSupport.c
+++ b/UefiPayloadPkg/BlSupportDxe/AArch64/BlSupport.c
@@ -34,12 +34,12 @@ BlUpdateMemoryMap (
   UINTN                        TranslationTableSize;
   UINTN                        Idx = 0;
 
-  Hob.Raw = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
+      continue;
+    }
 
-  while (Hob.Raw != NULL) {
     Resource = (EFI_HOB_RESOURCE_DESCRIPTOR *)Hob.Raw;
-    Hob.Raw  = GET_NEXT_HOB (Hob);
-    Hob.Raw  = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, Hob.Raw);
 
     VirtualMemoryTable[Idx].PhysicalBase = Resource->PhysicalStart;
     VirtualMemoryTable[Idx].VirtualBase  = VirtualMemoryTable[Idx].PhysicalBase;

--- a/UefiPayloadPkg/Library/BuildFdtLib/X86_BuildFdtLib.c
+++ b/UefiPayloadPkg/Library/BuildFdtLib/X86_BuildFdtLib.c
@@ -95,7 +95,6 @@ BuildFdtForMemory (
   EFI_STATUS                   Status;
   EFI_PEI_HOB_POINTERS         Hob;
   EFI_HOB_RESOURCE_DESCRIPTOR  *ResourceHob;
-  VOID                         *HobStart;
   VOID                         *Fdt;
   INT32                        TempNode;
   CHAR8                        TempStr[32];
@@ -103,12 +102,11 @@ BuildFdtForMemory (
 
   Fdt = FdtBase;
 
-  HobStart = GetFirstHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR);
   //
   // Scan resource descriptor hobs to set memory nodes
   //
-  for (Hob.Raw = HobStart; !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
-    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       ResourceHob = Hob.ResourceDescriptor;
       // Memory
       if (ResourceHob->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {

--- a/UefiPayloadPkg/Library/CustomFdtNodeParserLib/CustomFdtNodeParserLib.c
+++ b/UefiPayloadPkg/Library/CustomFdtNodeParserLib/CustomFdtNodeParserLib.c
@@ -80,7 +80,7 @@ FitIsHobNeed (
       }
     }
 
-    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       if (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {
         return FALSE;
       }

--- a/UefiPayloadPkg/Library/DxeHobLib/HobLib.c
+++ b/UefiPayloadPkg/Library/DxeHobLib/HobLib.c
@@ -277,6 +277,34 @@ BuildResourceDescriptorWithOwnerHob (
 }
 
 /**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/UefiPayloadPkg/Library/HobParseLib/HobParseLib.c
+++ b/UefiPayloadPkg/Library/HobParseLib/HobParseLib.c
@@ -138,7 +138,7 @@ FindResourceDescriptorByRange (
     //
     // Skip all HOBs except Resource Descriptor HOBs
     //
-    if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       continue;
     }
 
@@ -197,7 +197,7 @@ FindAnotherHighestBelow4GResourceDescriptor (
     //
     // Skip all HOBs except Resource Descriptor HOBs
     //
-    if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       continue;
     }
 

--- a/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
+++ b/UefiPayloadPkg/Library/PayloadEntryHobLib/Hob.c
@@ -87,6 +87,53 @@ HobConstructor (
 }
 
 /**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType               The type of resource described by this HOB.
+  @param  ResourceCapabilities       The resource capabilities of the memory described by this HOB.
+  @param  PhysicalStart              The 64 bit physical address of memory described by this HOB.
+  @param  ResourceLength             The length of the memory described by this HOB in bytes.
+  @param  ResourceMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID                  GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptor2Hob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceCapabilities,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       ResourceLength,
+  IN UINT64                       ResourceMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  EFI_HOB_RESOURCE_DESCRIPTOR2  *Hob;
+
+  Hob = CreateHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, sizeof (EFI_HOB_RESOURCE_DESCRIPTOR2));
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->ResourceType             = ResourceType;
+  Hob->ResourceCapabilities     = ResourceCapabilities;
+  Hob->PhysicalStart            = PhysicalStart;
+  Hob->ResourceLength           = ResourceLength;
+  Hob->ResourceMemoryAttributes = ResourceMemoryAttributes;
+
+  if (OwnerGUID != NULL) {
+    CopyGuid (&Hob->Owner, OwnerGUID);
+  } else {
+    ZeroMem (&Hob->Owner, sizeof (EFI_GUID));
+  }
+
+  return Hob;
+}
+
+/**
   Builds a HOB that describes a chunk of system memory.
 
   This function builds a HOB that describes a chunk of system memory.

--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -151,7 +151,7 @@ FindResourceDescriptorByRange (
     //
     // Skip all HOBs except Resource Descriptor HOBs
     //
-    if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       continue;
     }
 
@@ -210,7 +210,7 @@ FindAnotherHighestBelow4GResourceDescriptor (
     //
     // Skip all HOBs except Resource Descriptor HOBs
     //
-    if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if (!IS_RESOURCE_DESCRIPTOR_HOB (Hob)) {
       continue;
     }
 


### PR DESCRIPTION
# Description
Add PI 1.10 Resource Descriptor Hob definitions.
Update HobLib instances to allow creation of Resource Descriptor2 Hobs
Update PrintLibs to understand Descriptor2 hobs
Update Pei and Dxe Cores to consume Descriptor2 hobs

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

## Integration Instructions
