### PR TITLE
RedfishPkg/RedfishHttpDxe: Fix CopyHttpHeaders memory leak

### DIFF
--- a/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/src/service.c
+++ b/RedfishPkg/PrivateLibrary/RedfishLib/edk2libredfish/src/service.c
@@ -9,7 +9,7 @@
 //----------------------------------------------------------------------------
 
   Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
-  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2021 - 2026, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
   Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -163,6 +163,7 @@ UnicodeStrDupToAsciiStr (
 
   Status = UnicodeStrToAsciiStrS (String, AsciiStr, BufLen);
   if (EFI_ERROR (Status)) {
+    FreePool (AsciiStr);
     return NULL;
   }
 

--- a/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
+++ b/RedfishPkg/RedfishHttpDxe/RedfishHttpOperation.c
@@ -2,6 +2,7 @@
   RedfishHttpOperation handles HTTP operations.
 
   Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  Copyright (c) 2026, Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -60,16 +61,33 @@ CopyHttpHeaders (
   for (Index = 0; Index < SrcHeaderCount; Index++) {
     (*DstHeaders)[Index].FieldName = ASCII_STR_DUPLICATE (SrcHeaders[Index].FieldName);
     if ((*DstHeaders)[Index].FieldName == NULL) {
-      return EFI_OUT_OF_RESOURCES;
+      goto ON_ERROR;
     }
 
     (*DstHeaders)[Index].FieldValue = ASCII_STR_DUPLICATE (SrcHeaders[Index].FieldValue);
     if ((*DstHeaders)[Index].FieldValue == NULL) {
-      return EFI_OUT_OF_RESOURCES;
+      goto ON_ERROR;
     }
   }
 
   return EFI_SUCCESS;
+
+ON_ERROR:
+  for (Index = 0; Index < SrcHeaderCount; Index++) {
+    if ((*DstHeaders)[Index].FieldName != NULL) {
+      FreePool ((*DstHeaders)[Index].FieldName);
+    }
+
+    if ((*DstHeaders)[Index].FieldValue != NULL) {
+      FreePool ((*DstHeaders)[Index].FieldValue);
+    }
+  }
+
+  FreePool (*DstHeaders);
+  *DstHeaders     = NULL;
+  *DstHeaderCount = 0;
+
+  return EFI_OUT_OF_RESOURCES;
 }
 
 /**


### PR DESCRIPTION
# Description

1.service.c (UnicodeStrDupToAsciiStr): When UnicodeStrToAsciiStrS() fails, the previously allocated AsciiStr buffer was not freed before returning NULL, causing a memory leak. Added FreePool(AsciiStr) in the error path.

2.RedfishHttpOperation.c (CopyHttpHeaders): When ASCII_STR_DUPLICATE fails mid-loop for either FieldName or FieldValue, the function returned EFI_OUT_OF_RESOURCES immediately without freeing the already-duplicated headers. Replaced early returns with goto ON_ERROR cleanup path that frees all previously allocated FieldName/FieldValue strings and the DstHeaders array.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Code inspection to verify all allocated memory is properly freed on error paths.

## Integration Instructions

N/A
