### PR TITLE
.pytool/UncrustifyCheck: add check before executing git command

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -313,6 +313,9 @@ class UncrustifyCheck(ICiBuildPlugin):
                 "Git is not found on this system. Git submodule paths will not be considered.")
             return []
 
+        if not os.path.exists(os.path.join(self._abs_workspace_path, ".git")):
+            return []
+
         outstream_buffer = StringIO()
         exit_code = RunCmd("git", "ls-files --other",
                            workingdir=self._abs_workspace_path, outstream=outstream_buffer, logging_level=logging.NOTSET)


### PR DESCRIPTION
In the UncrustifyCheck, git command is executed at workspace root to get the list of ignored files.
The UncrustifyCheck plugin would report error when workspace root is not a repository.
Add a check to see if .git exists before executing the git command.
