### PR TITLE
MdeModulePkg: VariableStorage Protocol and VariableStorageRouterLib

### DIFF
--- a/MdeModulePkg/Include/Library/VariableStorageRouterLib.h
+++ b/MdeModulePkg/Include/Library/VariableStorageRouterLib.h
@@ -1,0 +1,394 @@
+/** @file
+  Variable Storage Lib for Smm.
+
+Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Guid/VariableFormat.h>
+#include <Protocol/VarCheck.h>
+#include <Protocol/VariableStorage.h>
+
+/**
+  Check whether Variable Storage use Auth Formet.
+
+  @return TRUE    Use Auth format.
+  @return FALSE   Not use Auth format.
+
+**/
+BOOLEAN
+EFIAPI
+VariableStorageRouterLibCheckAuthFormat (
+  VOID
+  );
+
+/**
+  Get maximum variable size, covering both non-volatile and volatile variables.
+
+  @return Maximum variable size.
+
+**/
+UINTN
+EFIAPI
+VariableStorageRouterLibGetMaxVariableSize (
+  VOID
+  );
+
+/**
+
+  This code finds variable in storage blocks (Volatile or Non-Volatile).
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize is external input.
+  This function will do basic validation, before parse the data.
+
+  @param VariableName               Name of Variable to be found.
+  @param VendorGuid                 Variable vendor GUID.
+  @param Attributes                 Attribute value of the variable found.
+  @param DataSize                   Size of Data found. If size is less than the
+                                    data, this value contains the required size.
+  @param Data                       The buffer to return the contents of the variable. May be NULL
+                                    with a zero DataSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER     The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION    The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibGetVariable (
+  IN      CHAR16    *VariableName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINT32    *Attributes OPTIONAL,
+  IN OUT  UINTN     *DataSize,
+  OUT     VOID      *Data OPTIONAL
+  );
+
+/**
+
+  This code Finds the Next available variable.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode. This function will do basic validation, before parse the data.
+
+  @param VariableNameSize           The size of the VariableName buffer. The size must be large
+                                    enough to fit input string supplied in VariableName buffer.
+  @param VariableName               Pointer to variable name.
+  @param VendorGuid                 Variable Vendor Guid.
+
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The next variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The VariableNameSize is too small for the result.
+                                    VariableNameSize has been updated with the size needed to complete the request.
+  @retval EFI_INVALID_PARAMETER     VariableNameSize is NULL.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     The input values of VariableName and VendorGuid are not a name and
+                                    GUID of an existing variable.
+  @retval EFI_INVALID_PARAMETER     Null-terminator is not found in the first VariableNameSize bytes of
+                                    the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibGetNextVariableName (
+  IN OUT  UINTN     *VariableNameSize,
+  IN OUT  CHAR16    *VariableName,
+  IN OUT  EFI_GUID  *VendorGuid
+  );
+
+/**
+
+  This code sets variable in storage blocks (Volatile or Non-Volatile).
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize and data are external input.
+  This function will do basic validation, before parse the data.
+  This function will parse the authentication carefully to avoid security issues, like
+  buffer overflow, integer overflow.
+  This function will check attribute carefully to avoid authentication bypass.
+
+  @param VariableName                     Name of Variable to be found.
+  @param VendorGuid                       Variable vendor GUID.
+  @param Attributes                       Attribute value of the variable found
+  @param DataSize                         Size of Data found. If size is less than the
+                                          data, this value contains the required size.
+  @param Data                             Data pointer.
+  @param FromTrusted                      Whether request comes from trusted.
+
+  @retval EFI_SUCCESS                     The function completed successfully.
+  @retval EFI_NOT_FOUND                   The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL            The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER           VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER           VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER           DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER           The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR                The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION          The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED                 After ExitBootServices() has been called, this return code may be returned
+                                          if no variable storage is supported. The platform should describe this
+                                          runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                          configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibSetVariable (
+  IN CHAR16    *VariableName,
+  IN EFI_GUID  *VendorGuid,
+  IN UINT32    Attributes,
+  IN UINTN     DataSize,
+  IN VOID      *Data,
+  IN BOOLEAN   FromTrusted
+  );
+
+/**
+  This code returns information about the EFI variables.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode. This function will do basic validation, before parse the data.
+
+  @param Attributes                     Attributes bitmask to specify the type of variables
+                                        on which to return information.
+  @param MaximumVariableStorageSize     Pointer to the maximum size of the storage space available
+                                        for the EFI variables associated with the attributes specified.
+  @param RemainingVariableStorageSize   Pointer to the remaining size of the storage space available
+                                        for EFI variables associated with the attributes specified.
+  @param MaximumVariableSize            Pointer to the maximum size of an individual EFI variables
+                                        associated with the attributes specified.
+
+  @return EFI_INVALID_PARAMETER         An invalid combination of attribute bits was supplied.
+  @return EFI_SUCCESS                   Query successfully.
+  @return EFI_UNSUPPORTED               The attribute is not supported on this platform.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibQueryVariableInfo (
+  IN  UINT32  Attributes,
+  OUT UINT64  *MaximumVariableStorageSize,
+  OUT UINT64  *RemainingVariableStorageSize,
+  OUT UINT64  *MaximumVariableSize
+  );
+
+/**
+  Callback function at End of DXE phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibEndOfDxe (
+  IN VOID
+  );
+
+/**
+  Callback function at READY_TO_BOOT phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibReadyToBoot (
+  IN VOID
+  );
+
+/**
+  Callback function for EXIT_BOOT phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibExitBootService (
+  IN VOID
+  );
+
+/**
+  Get the variable statistics information from the information buffer pointed by gVariableInfo.
+
+  Caution: This function may be invoked at SMM runtime.
+  InfoEntry and InfoSize are external input. Care must be taken to make sure not security issue at runtime.
+
+  @param[in, out]  InfoEntry    A pointer to the buffer of variable information entry.
+                                On input, point to the variable information returned last time. if
+                                InfoEntry->VendorGuid is zero, return the first information.
+                                On output, point to the next variable information.
+  @param[in, out]  InfoSize     On input, the size of the variable information buffer.
+                                On output, the returned variable information size.
+
+  @retval EFI_SUCCESS           The variable information is found and returned successfully.
+  @retval EFI_UNSUPPORTED       No variable inoformation exists in variable driver.
+  @retval EFI_BUFFER_TOO_SMALL  The buffer is too small to hold the next variable information.
+  @retval EFI_INVALID_PARAMETER Input parameter is invalid.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibGetStatics (
+  IN OUT VARIABLE_INFO_ENTRY  *InfoEntry,
+  IN OUT UINTN                *InfoSize
+  );
+
+/**
+  Mark a variable that will become read-only after leaving the DXE phase of execution.
+
+  @param[in] VariableName  A pointer to the variable name that will be made read-only subsequently.
+  @param[in] VendorGuid    A pointer to the vendor GUID that will be made read-only subsequently.
+
+  @retval EFI_SUCCESS           The variable specified by the VariableName and the VendorGuid was marked
+                                as pending to be read-only.
+  @retval EFI_INVALID_PARAMETER VariableName or VendorGuid is NULL.
+                                Or VariableName is an empty string.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource to hold the lock request.
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibRequestToLock (
+  IN       CHAR16    *VariableName,
+  IN       EFI_GUID  *VendorGuid
+  );
+
+/**
+  Variable property set.
+
+  @param[in] Name               Pointer to the variable name.
+  @param[in] Guid               Pointer to the vendor GUID.
+  @param[in] VariableProperty   Pointer to the input variable property.
+
+  @retval EFI_SUCCESS           The property of variable specified by the Name and Guid was set successfully.
+  @retval EFI_INVALID_PARAMETER Name, Guid or VariableProperty is NULL, or Name is an empty string,
+                                or the fields of VariableProperty are not valid.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource for the variable property set request.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibPropertySet (
+  IN CHAR16                       *Name,
+  IN EFI_GUID                     *Guid,
+  IN VAR_CHECK_VARIABLE_PROPERTY  *VariableProperty
+  );
+
+/**
+  Variable property get.
+
+  @param[in]  Name              Pointer to the variable name.
+  @param[in]  Guid              Pointer to the vendor GUID.
+  @param[out] VariableProperty  Pointer to the output variable property.
+
+  @retval EFI_SUCCESS           The property of variable specified by the Name and Guid was got successfully.
+  @retval EFI_INVALID_PARAMETER Name, Guid or VariableProperty is NULL, or Name is an empty string.
+  @retval EFI_NOT_FOUND         The property of variable specified by the Name and Guid was not found.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibPropertyGet (
+  IN CHAR16                        *Name,
+  IN EFI_GUID                      *Guid,
+  OUT VAR_CHECK_VARIABLE_PROPERTY  *VariableProperty
+  );
+
+/**
+  Initialise Variable Runtime Cache.
+
+  @param[in]   HobCache             Address of cache for variables in HobList.
+  @param[in]   VolatileCache        Address of cache for variables in  volatile memory.
+  @param[in]   NvCache              Address of cache for variables in  in non-volatile memory.
+  @param[in]   PendingUpdate        Address to bool to check pending update.
+  @param[in]   ReadLock             Address to bool to check read operation is locked.
+  @param[in]   HobFlushComplete     Address to bool to check flush hob is completed.
+
+  @return      EFI_SUCCESS
+  @return      EFI_UNSUPPORTED      Runtime variable cache isn't supported
+  @return      Others               Errors
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibInitCache (
+  IN  VARIABLE_STORE_HEADER  *HobCache,
+  IN  VARIABLE_STORE_HEADER  *VolatileCache,
+  IN  VARIABLE_STORE_HEADER  *NvCache,
+  IN  BOOLEAN                *PendingUpdate,
+  IN  BOOLEAN                *ReadLock,
+  IN  BOOLEAN                *HobFlushComplete
+  );
+
+/**
+  Copies any pending updates to runtime variable caches.
+
+  @retval EFI_SUCCESS             The cache store was updated successfully.
+  @retval EFI_UNSUPPORTED         The cache store to be updated is not initialized properly.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibSyncCache (
+  VOID
+  );
+
+/**
+  Get runtime variable caches info.
+
+  @param[out]    HobCacheSize                  Cache size of variables in Hob list.
+  @param[out]    VolatileCacheSize             Cache size of variables in volatile memory.
+  @param[out]    NvCacheSize                   Cache size of variables in non-volatile memory.
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibGetCacheInfo (
+  OUT UINTN  *HobCacheSize,
+  OUT UINTN  *VolatileCacheSize,
+  OUT UINTN  *NvCacheSize
+  );
+
+/**
+  Initialise Variable Write Service.
+  This function should install gSmmVariableWriteGuid or register notifier to install
+
+  @param[in] WriteReadyNotify   Notifier to be called when varaibles are
+                                writable.
+
+  @return EFI_SUCCESS
+  @return Others                Failed to initialise write service.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibInitWriteService (
+  IN WRITE_READY_NOTIFY_FN  WriteReadyNotify
+  );

--- a/MdeModulePkg/Include/Protocol/VariableStorage.h
+++ b/MdeModulePkg/Include/Protocol/VariableStorage.h
@@ -1,0 +1,427 @@
+/** @file
+  Fvb Variable Storage Lib for Smm.
+
+Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <Guid/VariableFormat.h>
+#include <Protocol/VarCheck.h>
+
+#define EDKII_VARIABLE_STORAGE_PROTOCOL_GUID \
+  { \
+    0xf9aff246, 0x81f3, 0x11f1, { 0x99, 0x1c, 0xaf, 0xf9, 0xcc, 0x08, 0x41, 0x35 } \
+  }
+
+typedef
+VOID
+(*WRITE_READY_NOTIFY_FN)(
+  VOID
+  );
+
+/**
+  Check whether Variable Storage use Auth Format.
+
+  @return TRUE    Use Auth format.
+  @return FALSE   Not use Auth format.
+
+**/
+typedef
+BOOLEAN
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_CHECK_AUTH_FORMAT)(
+  VOID
+  );
+
+/**
+  Get maximum variable size, covering both non-volatile and volatile variables.
+
+  @return Maximum variable size.
+
+**/
+typedef
+UINTN
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_GET_MAX_VARIABLE_SIZE)(
+  VOID
+  );
+
+/**
+
+  This code finds variable in storage blocks (Volatile or Non-Volatile).
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize is external input.
+  This function will do basic validation, before parse the data.
+
+  @param VariableName               Name of Variable to be found.
+  @param VendorGuid                 Variable vendor GUID.
+  @param Attributes                 Attribute value of the variable found.
+  @param DataSize                   Size of Data found. If size is less than the
+                                    data, this value contains the required size.
+  @param Data                       The buffer to return the contents of the variable. May be NULL
+                                    with a zero DataSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER     The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION    The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_GET_VARIABLE)(
+  IN      CHAR16    *VariableName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINT32    *Attributes OPTIONAL,
+  IN OUT  UINTN     *DataSize,
+  OUT     VOID      *Data OPTIONAL
+  );
+
+/**
+
+  This code Finds the Next available variable.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode. This function will do basic validation, before parse the data.
+
+  @param VariableNameSize           The size of the VariableName buffer. The size must be large
+                                    enough to fit input string supplied in VariableName buffer.
+  @param VariableName               Pointer to variable name.
+  @param VendorGuid                 Variable Vendor Guid.
+
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The next variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The VariableNameSize is too small for the result.
+                                    VariableNameSize has been updated with the size needed to complete the request.
+  @retval EFI_INVALID_PARAMETER     VariableNameSize is NULL.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     The input values of VariableName and VendorGuid are not a name and
+                                    GUID of an existing variable.
+  @retval EFI_INVALID_PARAMETER     Null-terminator is not found in the first VariableNameSize bytes of
+                                    the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_GET_NEXT_VARIABLE_NAME)(
+  IN OUT  UINTN     *VariableNameSize,
+  IN OUT  CHAR16    *VariableName,
+  IN OUT  EFI_GUID  *VendorGuid
+  );
+
+/**
+
+  This code sets variable in storage blocks (Volatile or Non-Volatile).
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize and data are external input.
+  This function will do basic validation, before parse the data.
+  This function will parse the authentication carefully to avoid security issues, like
+  buffer overflow, integer overflow.
+  This function will check attribute carefully to avoid authentication bypass.
+
+  @param VariableName                     Name of Variable to be found.
+  @param VendorGuid                       Variable vendor GUID.
+  @param Attributes                       Attribute value of the variable found
+  @param DataSize                         Size of Data found. If size is less than the
+                                          data, this value contains the required size.
+  @param Data                             Data pointer.
+  @param FromTrusted                      Whether request comes from trusted.
+
+  @retval EFI_SUCCESS                     The function completed successfully.
+  @retval EFI_NOT_FOUND                   The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL            The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER           VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER           VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER           DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER           The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR                The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION          The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED                 After ExitBootServices() has been called, this return code may be returned
+                                          if no variable storage is supported. The platform should describe this
+                                          runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                          configuration table.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_SET_VARIABLE)(
+  IN CHAR16    *VariableName,
+  IN EFI_GUID  *VendorGuid,
+  IN UINT32    Attributes,
+  IN UINTN     DataSize,
+  IN VOID      *Data,
+  IN BOOLEAN   FromTrusted
+  );
+
+/**
+  This code returns information about the EFI variables.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode. This function will do basic validation, before parse the data.
+
+  @param Attributes                     Attributes bitmask to specify the type of variables
+                                        on which to return information.
+  @param MaximumVariableStorageSize     Pointer to the maximum size of the storage space available
+                                        for the EFI variables associated with the attributes specified.
+  @param RemainingVariableStorageSize   Pointer to the remaining size of the storage space available
+                                        for EFI variables associated with the attributes specified.
+  @param MaximumVariableSize            Pointer to the maximum size of an individual EFI variables
+                                        associated with the attributes specified.
+
+  @return EFI_INVALID_PARAMETER         An invalid combination of attribute bits was supplied.
+  @return EFI_SUCCESS                   Query successfully.
+  @return EFI_UNSUPPORTED               The attribute is not supported on this platform.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_QUERY_VARIABLE_INFO)(
+  IN  UINT32  Attributes,
+  OUT UINT64  *MaximumVariableStorageSize,
+  OUT UINT64  *RemainingVariableStorageSize,
+  OUT UINT64  *MaximumVariableSize
+  );
+
+/**
+  Callback function at End of DXE phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_END_OF_DXE)(
+  IN VOID
+  );
+
+/**
+  Callback function at READY_TO_BOOT phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_READY_TO_BOOT)(
+  IN VOID
+  );
+
+/**
+  Callback function for EXIT_BOOT phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_EXIT_BOOT_SERVICE)(
+  IN VOID
+  );
+
+/**
+  Get the variable statistics information from the information buffer pointed by gVariableInfo.
+
+  Caution: This function may be invoked at SMM runtime.
+  InfoEntry and InfoSize are external input. Care must be taken to make sure not security issue at runtime.
+
+  @param[in, out]  InfoEntry    A pointer to the buffer of variable information entry.
+                                On input, point to the variable information returned last time. if
+                                InfoEntry->VendorGuid is zero, return the first information.
+                                On output, point to the next variable information.
+  @param[in, out]  InfoSize     On input, the size of the variable information buffer.
+                                On output, the returned variable information size.
+
+  @retval EFI_SUCCESS           The variable information is found and returned successfully.
+  @retval EFI_UNSUPPORTED       No variable information exists in variable driver.
+  @retval EFI_BUFFER_TOO_SMALL  The buffer is too small to hold the next variable information.
+  @retval EFI_INVALID_PARAMETER Input parameter is invalid.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_GET_STATICS)(
+  IN OUT VARIABLE_INFO_ENTRY  *InfoEntry,
+  IN OUT UINTN                *InfoSize
+  );
+
+/**
+  Mark a variable that will become read-only after leaving the DXE phase of execution.
+
+  @param[in] VariableName  A pointer to the variable name that will be made read-only subsequently.
+  @param[in] VendorGuid    A pointer to the vendor GUID that will be made read-only subsequently.
+
+  @retval EFI_SUCCESS           The variable specified by the VariableName and the VendorGuid was marked
+                                as pending to be read-only.
+  @retval EFI_INVALID_PARAMETER VariableName or VendorGuid is NULL.
+                                Or VariableName is an empty string.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource to hold the lock request.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_REQUEST_TO_LOCK)(
+  IN       CHAR16    *VariableName,
+  IN       EFI_GUID  *VendorGuid
+  );
+
+/**
+  Variable property set.
+
+  @param[in] Name               Pointer to the variable name.
+  @param[in] Guid               Pointer to the vendor GUID.
+  @param[in] VariableProperty   Pointer to the input variable property.
+
+  @retval EFI_SUCCESS           The property of variable specified by the Name and Guid was set successfully.
+  @retval EFI_INVALID_PARAMETER Name, Guid or VariableProperty is NULL, or Name is an empty string,
+                                or the fields of VariableProperty are not valid.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource for the variable property set request.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_PROPERTY_SET)(
+  IN CHAR16                       *Name,
+  IN EFI_GUID                     *Guid,
+  IN VAR_CHECK_VARIABLE_PROPERTY  *VariableProperty
+  );
+
+/**
+  Variable property get.
+
+  @param[in]  Name              Pointer to the variable name.
+  @param[in]  Guid              Pointer to the vendor GUID.
+  @param[out] VariableProperty  Pointer to the output variable property.
+
+  @retval EFI_SUCCESS           The property of variable specified by the Name and Guid was got successfully.
+  @retval EFI_INVALID_PARAMETER Name, Guid or VariableProperty is NULL, or Name is an empty string.
+  @retval EFI_NOT_FOUND         The property of variable specified by the Name and Guid was not found.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_PROPERTY_GET)(
+  IN CHAR16                        *Name,
+  IN EFI_GUID                      *Guid,
+  OUT VAR_CHECK_VARIABLE_PROPERTY  *VariableProperty
+  );
+
+/**
+  Initialise Variable Runtime Cache.
+
+  @param[in]   HobCache             Address of cache for variables in HobList.
+  @param[in]   VolatileCache        Address of cache for variables in  volatile memory.
+  @param[in]   NvCache              Address of cache for variables in  in non-volatile memory.
+  @param[in]   PendingUpdate        Address to bool to check pending update.
+  @param[in]   ReadLock             Address to bool to check read operation is locked.
+  @param[in]   HobFlushComplete     Address to bool to check flush hob is completed.
+
+  @return      EFI_SUCCESS
+  @return      EFI_UNSUPPORTED      Runtime variable cache isn't supported
+  @return      Others               Errors
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_INIT_CACHE)(
+  IN  VARIABLE_STORE_HEADER  *HobCache,
+  IN  VARIABLE_STORE_HEADER  *VolatileCache,
+  IN  VARIABLE_STORE_HEADER  *NvCache,
+  IN  BOOLEAN                *PendingUpdate,
+  IN  BOOLEAN                *ReadLock,
+  IN  BOOLEAN                *HobFlushComplete
+  );
+
+/**
+  Copies any pending updates to runtime variable caches.
+
+  @retval EFI_SUCCESS             The cache store was updated successfully.
+  @retval EFI_UNSUPPORTED         The cache store to be updated is not initialized properly.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_SYNC_CACHE)(
+  VOID
+  );
+
+/**
+  Get runtime variable caches info.
+
+  @param[out]    HobCacheSize                  Cache size of variables in Hob list.
+  @param[out]    VolatileCacheSize             Cache size of variables in volatile memory.
+  @param[out]    NvCacheSize                   Cache size of variables in non-volatile memory.
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_GET_CACHE_INFO)(
+  OUT UINTN  *HobCacheSize,
+  OUT UINTN  *VolatileCacheSize,
+  OUT UINTN  *NvCacheSize
+  );
+
+/**
+  Initialise Variable Write Service.
+  This function should install gSmmVariableWriteGuid or register notifier to install
+
+  @param[in] WriteReadyNotify   Notifier to be called when variables are
+                                writable.
+
+  @return EFI_SUCCESS
+  @return Others                Failed to initialise write service.
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_STORAGE_PROTOCOL_INIT_WRITE_SERVICE)(
+  IN WRITE_READY_NOTIFY_FN  WriteReadyNotify
+  );
+
+typedef struct _EDKII_VARIABLE_STORAGE_PROTOCOL {
+  EDKII_VARIABLE_STORAGE_PROTOCOL_CHECK_AUTH_FORMAT         CheckAuthFormat;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_GET_MAX_VARIABLE_SIZE     GetMaxVariableSize;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_GET_VARIABLE              GetVariable;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_GET_NEXT_VARIABLE_NAME    GetNextVariableName;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_SET_VARIABLE              SetVariable;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_QUERY_VARIABLE_INFO       QueryVariableInfo;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_END_OF_DXE                EndOfDxe;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_READY_TO_BOOT             ReadyToBoot;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_EXIT_BOOT_SERVICE         ExitBootService;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_GET_STATICS               GetStatics;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_REQUEST_TO_LOCK           RequestToLock;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_PROPERTY_SET              PropertySet;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_PROPERTY_GET              PropertyGet;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_INIT_CACHE                InitCache;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_SYNC_CACHE                SyncCache;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_GET_CACHE_INFO            GetCacheInfo;
+  EDKII_VARIABLE_STORAGE_PROTOCOL_INIT_WRITE_SERVICE        InitWriteService;
+} EDKII_VARIABLE_STORAGE_PROTOCOL;
+
+extern EFI_GUID  gEdkiiVariableStorageProtocolGuid;

--- a/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBase.c
+++ b/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBase.c
@@ -1,0 +1,497 @@
+/** @file
+  Variable Storage Router Base Library
+
+Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/MmServicesTableLib.h>
+#include <Library/VariableStorageRouterLib.h>
+
+#include <Protocol/VariableStorage.h>
+
+EDKII_VARIABLE_STORAGE_PROTOCOL  *mVariableStorage;
+
+/**
+  Check whether Variable Storage use Auth Formet.
+
+  @return TRUE    Use Auth format.
+  @return FALSE   Not use Auth format.
+
+**/
+BOOLEAN
+EFIAPI
+VariableStorageRouterLibCheckAuthFormat (
+  VOID
+  )
+{
+  return mVariableStorage->CheckAuthFormat ();
+}
+
+/**
+  Get maximum variable size, covering both non-volatile and volatile variables.
+
+  @return Maximum variable size.
+
+**/
+UINTN
+EFIAPI
+VariableStorageRouterLibGetMaxVariableSize (
+  VOID
+  )
+{
+  return mVariableStorage->GetMaxVariableSize ();
+}
+
+/**
+
+  This code finds variable in storage blocks (Volatile or Non-Volatile).
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize is external input.
+  This function will do basic validation, before parse the data.
+
+  @param VariableName               Name of Variable to be found.
+  @param VendorGuid                 Variable vendor GUID.
+  @param Attributes                 Attribute value of the variable found.
+  @param DataSize                   Size of Data found. If size is less than the
+                                    data, this value contains the required size.
+  @param Data                       The buffer to return the contents of the variable. May be NULL
+                                    with a zero DataSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER     The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION    The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibGetVariable (
+  IN      CHAR16    *VariableName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINT32    *Attributes OPTIONAL,
+  IN OUT  UINTN     *DataSize,
+  OUT     VOID      *Data OPTIONAL
+  )
+{
+  return mVariableStorage->GetVariable (
+                             VariableName,
+                             VendorGuid,
+                             Attributes,
+                             DataSize,
+                             Data
+                             );
+}
+
+/**
+
+  This code Finds the Next available variable.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode. This function will do basic validation, before parse the data.
+
+  @param VariableNameSize           The size of the VariableName buffer. The size must be large
+                                    enough to fit input string supplied in VariableName buffer.
+  @param VariableName               Pointer to variable name.
+  @param VendorGuid                 Variable Vendor Guid.
+
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The next variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The VariableNameSize is too small for the result.
+                                    VariableNameSize has been updated with the size needed to complete the request.
+  @retval EFI_INVALID_PARAMETER     VariableNameSize is NULL.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     The input values of VariableName and VendorGuid are not a name and
+                                    GUID of an existing variable.
+  @retval EFI_INVALID_PARAMETER     Null-terminator is not found in the first VariableNameSize bytes of
+                                    the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibGetNextVariableName (
+  IN OUT  UINTN     *VariableNameSize,
+  IN OUT  CHAR16    *VariableName,
+  IN OUT  EFI_GUID  *VendorGuid
+  )
+{
+  return mVariableStorage->GetNextVariableName (
+                             VariableNameSize,
+                             VariableName,
+                             VendorGuid
+                             );
+}
+
+/**
+
+  This code sets variable in storage blocks (Volatile or Non-Volatile).
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize and data are external input.
+  This function will do basic validation, before parse the data.
+  This function will parse the authentication carefully to avoid security issues, like
+  buffer overflow, integer overflow.
+  This function will check attribute carefully to avoid authentication bypass.
+
+  @param VariableName                     Name of Variable to be found.
+  @param VendorGuid                       Variable vendor GUID.
+  @param Attributes                       Attribute value of the variable found
+  @param DataSize                         Size of Data found. If size is less than the
+                                          data, this value contains the required size.
+  @param Data                             Data pointer.
+  @param FromTrusted                      Whether request comes from trusted.
+
+  @retval EFI_SUCCESS                     The function completed successfully.
+  @retval EFI_NOT_FOUND                   The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL            The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER           VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER           VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER           DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER           The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR                The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION          The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED                 After ExitBootServices() has been called, this return code may be returned
+                                          if no variable storage is supported. The platform should describe this
+                                          runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                          configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibSetVariable (
+  IN CHAR16    *VariableName,
+  IN EFI_GUID  *VendorGuid,
+  IN UINT32    Attributes,
+  IN UINTN     DataSize,
+  IN VOID      *Data,
+  IN BOOLEAN   FromTrusted
+  )
+{
+  return mVariableStorage->SetVariable (
+                             VariableName,
+                             VendorGuid,
+                             Attributes,
+                             DataSize,
+                             Data,
+                             FromTrusted
+                             );
+}
+
+/**
+  This code returns information about the EFI variables.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode. This function will do basic validation, before parse the data.
+
+  @param Attributes                     Attributes bitmask to specify the type of variables
+                                        on which to return information.
+  @param MaximumVariableStorageSize     Pointer to the maximum size of the storage space available
+                                        for the EFI variables associated with the attributes specified.
+  @param RemainingVariableStorageSize   Pointer to the remaining size of the storage space available
+                                        for EFI variables associated with the attributes specified.
+  @param MaximumVariableSize            Pointer to the maximum size of an individual EFI variables
+                                        associated with the attributes specified.
+
+  @return EFI_INVALID_PARAMETER         An invalid combination of attribute bits was supplied.
+  @return EFI_SUCCESS                   Query successfully.
+  @return EFI_UNSUPPORTED               The attribute is not supported on this platform.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibQueryVariableInfo (
+  IN  UINT32  Attributes,
+  OUT UINT64  *MaximumVariableStorageSize,
+  OUT UINT64  *RemainingVariableStorageSize,
+  OUT UINT64  *MaximumVariableSize
+  )
+{
+  return mVariableStorage->QueryVariableInfo (
+                             Attributes,
+                             MaximumVariableStorageSize,
+                             RemainingVariableStorageSize,
+                             MaximumVariableSize
+                             );
+}
+
+/**
+  Callback function at End of DXE phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibEndOfDxe (
+  IN VOID
+  )
+{
+  return mVariableStorage->EndOfDxe ();
+}
+
+/**
+  Callback function at READY_TO_BOOT phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibReadyToBoot (
+  IN VOID
+  )
+{
+  return mVariableStorage->ReadyToBoot ();
+}
+
+/**
+  Callback function for EXIT_BOOT phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibExitBootService (
+  IN VOID
+  )
+{
+  return mVariableStorage->ExitBootService ();
+}
+
+/**
+  Get the variable statistics information from the information buffer pointed by gVariableInfo.
+
+  Caution: This function may be invoked at SMM runtime.
+  InfoEntry and InfoSize are external input. Care must be taken to make sure not security issue at runtime.
+
+  @param[in, out]  InfoEntry    A pointer to the buffer of variable information entry.
+                                On input, point to the variable information returned last time. if
+                                InfoEntry->VendorGuid is zero, return the first information.
+                                On output, point to the next variable information.
+  @param[in, out]  InfoSize     On input, the size of the variable information buffer.
+                                On output, the returned variable information size.
+
+  @retval EFI_SUCCESS           The variable information is found and returned successfully.
+  @retval EFI_UNSUPPORTED       No variable inoformation exists in variable driver.
+  @retval EFI_BUFFER_TOO_SMALL  The buffer is too small to hold the next variable information.
+  @retval EFI_INVALID_PARAMETER Input parameter is invalid.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibGetStatics (
+  IN OUT VARIABLE_INFO_ENTRY  *InfoEntry,
+  IN OUT UINTN                *InfoSize
+  )
+{
+  return mVariableStorage->GetStatics (
+                             InfoEntry,
+                             InfoSize
+                             );
+}
+
+/**
+  Mark a variable that will become read-only after leaving the DXE phase of execution.
+
+  @param[in] VariableName  A pointer to the variable name that will be made read-only subsequently.
+  @param[in] VendorGuid    A pointer to the vendor GUID that will be made read-only subsequently.
+
+  @retval EFI_SUCCESS           The variable specified by the VariableName and the VendorGuid was marked
+                                as pending to be read-only.
+  @retval EFI_INVALID_PARAMETER VariableName or VendorGuid is NULL.
+                                Or VariableName is an empty string.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource to hold the lock request.
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibRequestToLock (
+  IN       CHAR16    *VariableName,
+  IN       EFI_GUID  *VendorGuid
+  )
+{
+  return mVariableStorage->RequestToLock (
+                             VariableName,
+                             VendorGuid
+                             );
+}
+
+/**
+  Variable property set.
+
+  @param[in] Name               Pointer to the variable name.
+  @param[in] Guid               Pointer to the vendor GUID.
+  @param[in] VariableProperty   Pointer to the input variable property.
+
+  @retval EFI_SUCCESS           The property of variable specified by the Name and Guid was set successfully.
+  @retval EFI_INVALID_PARAMETER Name, Guid or VariableProperty is NULL, or Name is an empty string,
+                                or the fields of VariableProperty are not valid.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource for the variable property set request.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibPropertySet (
+  IN CHAR16                       *Name,
+  IN EFI_GUID                     *Guid,
+  IN VAR_CHECK_VARIABLE_PROPERTY  *VariableProperty
+  )
+{
+  return mVariableStorage->PropertySet (
+                             Name,
+                             Guid,
+                             VariableProperty
+                             );
+}
+
+/**
+  Variable property get.
+
+  @param[in]  Name              Pointer to the variable name.
+  @param[in]  Guid              Pointer to the vendor GUID.
+  @param[out] VariableProperty  Pointer to the output variable property.
+
+  @retval EFI_SUCCESS           The property of variable specified by the Name and Guid was got successfully.
+  @retval EFI_INVALID_PARAMETER Name, Guid or VariableProperty is NULL, or Name is an empty string.
+  @retval EFI_NOT_FOUND         The property of variable specified by the Name and Guid was not found.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibPropertyGet (
+  IN CHAR16                        *Name,
+  IN EFI_GUID                      *Guid,
+  OUT VAR_CHECK_VARIABLE_PROPERTY  *VariableProperty
+  )
+{
+  return mVariableStorage->PropertyGet (
+                             Name,
+                             Guid,
+                             VariableProperty
+                             );
+}
+
+/**
+  Initialise Variable Runtime Cache.
+
+  @param[in]   HobCache             Address of cache for variables in HobList.
+  @param[in]   VolatileCache        Address of cache for variables in  volatile memory.
+  @param[in]   NvCache              Address of cache for variables in  in non-volatile memory.
+  @param[in]   PendingUpdate        Address to bool to check pending update.
+  @param[in]   ReadLock             Address to bool to check read operation is locked.
+  @param[in]   HobFlushComplete     Address to bool to check flush hob is completed.
+
+  @return      EFI_SUCCESS
+  @return      EFI_UNSUPPORTED      Runtime variable cache isn't supported
+  @return      Others               Errors
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibInitCache (
+  IN  VARIABLE_STORE_HEADER  *HobCache,
+  IN  VARIABLE_STORE_HEADER  *VolatileCache,
+  IN  VARIABLE_STORE_HEADER  *NvCache,
+  IN  BOOLEAN                *PendingUpdate,
+  IN  BOOLEAN                *ReadLock,
+  IN  BOOLEAN                *HobFlushComplete
+  )
+{
+  return mVariableStorage->InitCache (
+                             HobCache,
+                             VolatileCache,
+                             NvCache,
+                             PendingUpdate,
+                             ReadLock,
+                             HobFlushComplete
+                             );
+}
+
+/**
+  Copies any pending updates to runtime variable caches.
+
+  @retval EFI_SUCCESS             The cache store was updated successfully.
+  @retval EFI_UNSUPPORTED         The cache store to be updated is not initialized properly.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibSyncCache (
+  VOID
+  )
+{
+  return mVariableStorage->SyncCache ();
+}
+
+/**
+  Get runtime variable caches info.
+
+  @param[out]    HobCacheSize                  Cache size of variables in Hob list.
+  @param[out]    VolatileCacheSize             Cache size of variables in volatile memory.
+  @param[out]    NvCacheSize                   Cache size of variables in non-volatile memory.
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibGetCacheInfo (
+  OUT UINTN  *HobCacheSize,
+  OUT UINTN  *VolatileCacheSize,
+  OUT UINTN  *NvCacheSize
+  )
+{
+  return mVariableStorage->GetCacheInfo (
+                             HobCacheSize,
+                             VolatileCacheSize,
+                             NvCacheSize
+                             );
+}
+
+/**
+  Initialise Variable Write Service.
+  This function should install gSmmVariableWriteGuid or register notifier to install
+
+  @param[in] WriteReadyNotify   Notifier to be called when varaibles are
+                                writable.
+
+  @return EFI_SUCCESS
+  @return Others                Failed to initialise write service.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterLibInitWriteService (
+  IN WRITE_READY_NOTIFY_FN  WriteReadyNotify
+  )
+{
+  return mVariableStorage->InitWriteService (
+                             WriteReadyNotify
+                             );
+}

--- a/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseLib.uni
+++ b/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseLib.uni
@@ -1,0 +1,12 @@
+// /** @file
+// Variable Storage Router Base Library.
+//
+// Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Variable Storage Router Base Library."
+#string STR_MODULE_DESCRIPTION          #language en-US "Variable Storage Router Base Library."

--- a/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.c
+++ b/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.c
@@ -1,0 +1,37 @@
+/** @file
+  Variable Storage Router Base Library
+
+Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/MmServicesTableLib.h>
+
+#include <Protocol/VariableStorage.h>
+
+extern EDKII_VARIABLE_STORAGE_PROTOCOL  *mVariableStorage;
+
+/**
+  The constructor function for VariableStorageRouterLib.
+
+  @param  ImageHandle     The firmware allocated handle for the EFI image.
+  @param  MmSystemTable   A pointer to the MM System Table.
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterBaseLibConstructor (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
+  )
+{
+  return gMmst->MmLocateProtocol (
+                  &gEdkiiVariableStorageProtocolGuid,
+                  NULL,
+                  (VOID **)&mVariableStorage
+                  );
+}

--- a/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.inf
@@ -1,0 +1,45 @@
+## @file
+#  Variable Storage Base Library which uses FVB.
+#
+#  Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = VariableStorageRouterBaseLib
+  MODULE_UNI_FILE                = VariableStorageRouterBaseLib.uni
+  FILE_GUID                      = 5481529a-380d-11f1-8961-ab5d0e6d80c1
+  MODULE_TYPE                    = MM_STANDALONE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = VariableStorageLib|MM_STANDALONE
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  CONSTRUCTOR                    = VariableStorageRouterBaseLibConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  VariableStorageRouterBase.c
+  VariableStorageRouterBaseStandaloneMmLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MmServicesTableLib
+
+[Protocols]
+  gEdkiiVariableStorageProtocolGuid            ## COUNSUMES
+
+[Depex]
+  gEdkiiVariableStorageProtocolGuid

--- a/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.c
+++ b/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.c
@@ -1,0 +1,37 @@
+/** @file
+  Variable Storage Router Base Library
+
+Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/MmServicesTableLib.h>
+
+#include <Protocol/VariableStorage.h>
+
+extern EDKII_VARIABLE_STORAGE_PROTOCOL  *mVariableStorage;
+
+/**
+  The constructor function for VariableStorageRouterLib.
+
+  @param  ImageHandle     The firmware allocated handle for the EFI image.
+  @param[in] SystemTable  A pointer to the EFI system table
+
+  @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageRouterBaseLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return gMmst->MmLocateProtocol (
+                  &gEdkiiVariableStorageProtocolGuid,
+                  NULL,
+                  (VOID **)&mVariableStorage
+                  );
+}

--- a/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.inf
+++ b/MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.inf
@@ -1,0 +1,45 @@
+## @file
+#  Variable Storage Base Library which uses FVB.
+#
+#  Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = VariableStorageRouterBaseLib
+  MODULE_UNI_FILE                = VariableStorageRouterBaseLib.uni
+  FILE_GUID                      = 20d30b70-85e5-11f1-b3c9-f3f75f24066e
+  MODULE_TYPE                    = DXE_SMM_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = VariableStorageLib|DXE_SMM_DRIVER
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  CONSTRUCTOR                    = VariableStorageRouterBaseLibConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  VariableStorageRouterBase.c
+  VariableStorageRouterBaseTraditionalMmLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MmServicesTableLib
+
+[Protocols]
+  gEdkiiVariableStorageProtocolGuid            ## COUNSUMES
+
+[Depex]
+  gEdkiiVariableStorageProtocolGuid

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -11,6 +11,7 @@
 # Copyright (c) Microsoft Corporation.<BR>
 # Copyright (C) 2024 - 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. All rights reserved.<BR>
+# Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -761,6 +762,9 @@
 
   ## Include/Protocol/CxlIo.h
   gEdkiiCxlIoProtocolGuid = { 0x8FAC60B2, 0xBBC1, 0x41DE, {0xA7, 0x97, 0x98, 0x75, 0xCD, 0xD3, 0xA8, 0xF8 } }
+
+  ## Include/Protocol/VariableStorage.h
+  gEdkiiVariableStorageProtocolGuid = { 0xf9aff246, 0x81f3, 0x11f1, { 0x99, 0x1c, 0xaf, 0xf9, 0xcc, 0x08, 0x41, 0x35 } }
 
 [PcdsFeatureFlag]
   ## Indicates if the platform can support update capsule across a system reset.<BR><BR>

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -187,6 +187,10 @@
   #
   HobPrintLib|Include/Library/HobPrintLib.h
 
+  ##  @libraryclass   Provides a services to communicate Variable Storage
+  #
+  VariableStorageRouterLib|Include/Library/VariableStorageRouterLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -5,6 +5,7 @@
 # Copyright (c) 2007 - 2024, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
 # Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.<BR>
+# Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 #
 #    SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -472,6 +473,12 @@
   }
 
 !if $(TOOL_CHAIN_TAG) != "XCODE5"
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf {
+    <LibraryClasses>
+      DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
+      NULL|MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLibStandaloneMm.inf
+      NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
+  }
   MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
 !endif
@@ -481,13 +488,14 @@
   MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.inf
   MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf
   MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
-  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf {
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf {
     <LibraryClasses>
       NULL|MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.inf
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf
       NULL|MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLib.inf
       NULL|MdeModulePkg/Library/VarCheckPcdLib/VarCheckPcdLib.inf
   }
+  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf {
     <LibraryClasses>
       NULL|MdeModulePkg/Library/VarCheckUefiLib/VarCheckUefiLib.inf

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -160,6 +160,7 @@
   SmmServicesTableLib|MdePkg/Library/SmmServicesTableLib/SmmServicesTableLib.inf
   LockBoxLib|MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxSmmLib.inf
   SmmMemLib|MdePkg/Library/SmmMemLib/SmmMemLib.inf
+  VariableStorageRouterLib|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.inf
 
 [LibraryClasses.common.UEFI_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -182,6 +183,7 @@
   MemLib|StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
   VarCheckHiiLibMmDependency|MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibMmDependency.inf
   VarCheckHiiLib|MdeModulePkg/Library/VarCheckHiiLib/VarCheckHiiLibStandaloneMm.inf
+  VariableStorageRouterLib|MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.inf
 
 [LibraryClasses.AARCH64]
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf
@@ -473,6 +475,7 @@
   }
 
 !if $(TOOL_CHAIN_TAG) != "XCODE5"
+  MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseStandaloneMmLib.inf
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf {
     <LibraryClasses>
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf
@@ -488,6 +491,7 @@
   MdeModulePkg/Application/SmiHandlerProfileInfo/SmiHandlerProfileInfo.inf
   MdeModulePkg/Core/PiSmmCore/PiSmmIpl.inf
   MdeModulePkg/Core/PiSmmCore/PiSmmCore.inf
+  MdeModulePkg/Library/VariableStorageRouterBaseLib/VariableStorageRouterBaseTraditionalMmLib.inf
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf {
     <LibraryClasses>
       NULL|MdeModulePkg/Library/VarCheckPolicyLib/VarCheckPolicyLib.inf

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/PrivilegePolymorphic.h
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/PrivilegePolymorphic.h
@@ -8,6 +8,7 @@
 
   Copyright (c) 2017, Red Hat, Inc.<BR>
   Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -163,4 +164,19 @@ VariableSmmIsNonPrimaryBufferValid (
 BOOLEAN
 VariableIsMorVariableLegitimate (
   VOID
+  );
+
+/**
+  Initailize Variable Stoarge.
+
+  @param  [in]  ImageHandle      The firmware allocated handle for the EFI image
+
+  @retval EFI_SUCCESS            Success
+  @retval Others                 Error
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbInitialize (
+  IN EFI_HANDLE  ImageHandle
   );

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
@@ -16,45 +16,54 @@
 
 Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
+Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
-
 #include <Protocol/SmmVariable.h>
-#include <Protocol/SmmFirmwareVolumeBlock.h>
-#include <Protocol/SmmFaultTolerantWrite.h>
-#include <Protocol/MmEndOfDxe.h>
-#include <Protocol/SmmVarCheck.h>
+#include <Protocol/VariableStorage.h>
 
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
 #include <Library/MmServicesTableLib.h>
-#include <Library/VariablePolicyLib.h>
 
 #include <Guid/SmmVariableCommon.h>
-#include "Variable.h"
-#include "VariableParsing.h"
-#include "VariableRuntimeCache.h"
+#include "PrivilegePolymorphic.h"
 
 extern VARIABLE_STORE_HEADER  *mNvVariableCache;
 
-BOOLEAN  mAtRuntime              = FALSE;
-UINT8    *mVariableBufferPayload = NULL;
-UINTN    mVariableBufferPayloadSize;
+STATIC BOOLEAN  mAtRuntime              = FALSE;
+STATIC BOOLEAN  mEndOfDxe               = FALSE;
+STATIC UINT8    *mVariableBufferPayload = NULL;
+STATIC UINTN    mVariableBufferPayloadSize;
+
+STATIC EDKII_VARIABLE_STORAGE_PROTOCOL  *mVariableStorage;
 
 /**
-  SecureBoot Hook for SetVariable.
+  This code gets the size of variable header.
 
-  @param[in] VariableName                 Name of Variable to be found.
-  @param[in] VendorGuid                   Variable vendor GUID.
+  @return Size of variable header in bytes in type UINTN.
 
 **/
-VOID
+STATIC
+UINTN
 EFIAPI
-SecureBootHook (
-  IN CHAR16    *VariableName,
-  IN EFI_GUID  *VendorGuid
+GetVariableHeaderSize (
+  VOID
   )
 {
-  return;
+  UINTN    Value;
+  BOOLEAN  AuthFormat;
+
+  AuthFormat = mVariableStorage->CheckAuthFormat ();
+
+  if (AuthFormat) {
+    Value = sizeof (AUTHENTICATED_VARIABLE_HEADER);
+  } else {
+    Value = sizeof (VARIABLE_HEADER);
+  }
+
+  return Value;
 }
 
 /**
@@ -75,9 +84,10 @@ SecureBootHook (
   @return EFI_WRITE_PROTECTED             Variable is read-only.
 
 **/
+STATIC
 EFI_STATUS
 EFIAPI
-SmmVariableSetVariable (
+VariableStorageFvbSetVariable (
   IN CHAR16    *VariableName,
   IN EFI_GUID  *VendorGuid,
   IN UINT32    Attributes,
@@ -85,344 +95,156 @@ SmmVariableSetVariable (
   IN VOID      *Data
   )
 {
-  EFI_STATUS  Status;
+  return mVariableStorage->SetVariable (
+                             VariableName,
+                             VendorGuid,
+                             Attributes,
+                             DataSize,
+                             Data,
+                             TRUE
+                             );
+}
 
-  //
-  // Disable write protection when the calling SetVariable() through EFI_SMM_VARIABLE_PROTOCOL.
-  //
-  mRequestSource = VarCheckFromTrusted;
-  Status         = VariableServiceSetVariable (
-                     VariableName,
-                     VendorGuid,
-                     Attributes,
-                     DataSize,
-                     Data
-                     );
-  mRequestSource = VarCheckFromUntrusted;
-  return Status;
+/**
+  Returns the value of a variable.
+
+  @param[in]       VariableName  A Null-terminated string that is the name of the vendor's
+                                 variable.
+  @param[in]       VendorGuid    A unique identifier for the vendor.
+  @param[out]      Attributes    If not NULL, a pointer to the memory location to return the
+                                 attributes bitmask for the variable.
+  @param[in, out]  DataSize      On input, the size in bytes of the return Data buffer.
+                                 On output the size of data returned in Data.
+  @param[out]      Data          The buffer to return the contents of the variable. May be NULL
+                                 with a zero DataSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS            The function completed successfully.
+  @retval EFI_NOT_FOUND          The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL   The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER  VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER  VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER  DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER  The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR       The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED        After ExitBootServices() has been called, this return code may be returned
+                                 if no variable storage is supported. The platform should describe this
+                                 runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                 configuration table.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+VariableStorageFvbGetVariable (
+  IN     CHAR16    *VariableName,
+  IN     EFI_GUID  *VendorGuid,
+  OUT    UINT32    *Attributes     OPTIONAL,
+  IN OUT UINTN     *DataSize,
+  OUT    VOID      *Data           OPTIONAL
+  )
+{
+  return mVariableStorage->GetVariable (
+                             VariableName,
+                             VendorGuid,
+                             Attributes,
+                             DataSize,
+                             Data
+                             );
+}
+
+/**
+  Enumerates the current variable names.
+
+  @param[in, out]  VariableNameSize The size of the VariableName buffer. The size must be large
+                                    enough to fit input string supplied in VariableName buffer.
+  @param[in, out]  VariableName     On input, supplies the last VariableName that was returned
+                                    by GetNextVariableName(). On output, returns the Nullterminated
+                                    string of the current variable.
+  @param[in, out]  VendorGuid       On input, supplies the last VendorGuid that was returned by
+                                    GetNextVariableName(). On output, returns the
+                                    VendorGuid of the current variable.
+
+  @retval EFI_SUCCESS           The function completed successfully.
+  @retval EFI_NOT_FOUND         The next variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL  The VariableNameSize is too small for the result.
+                                VariableNameSize has been updated with the size needed to complete the request.
+  @retval EFI_INVALID_PARAMETER VariableNameSize is NULL.
+  @retval EFI_INVALID_PARAMETER VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER The input values of VariableName and VendorGuid are not a name and
+                                GUID of an existing variable.
+  @retval EFI_INVALID_PARAMETER Null-terminator is not found in the first VariableNameSize bytes of
+                                the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR      The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED       After ExitBootServices() has been called, this return code may be returned
+                                if no variable storage is supported. The platform should describe this
+                                runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                configuration table.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+VariableStorageFvbGetNextVariableName (
+  IN OUT UINTN     *VariableNameSize,
+  IN OUT CHAR16    *VariableName,
+  IN OUT EFI_GUID  *VendorGuid
+  )
+{
+  return mVariableStorage->GetNextVariableName (
+                             VariableNameSize,
+                             VariableName,
+                             VendorGuid
+                             );
+}
+
+/**
+  Returns information about the EFI variables.
+
+  @param[in]   Attributes                   Attributes bitmask to specify the type of variables on
+                                            which to return information.
+  @param[out]  MaximumVariableStorageSize   On output the maximum size of the storage space
+                                            available for the EFI variables associated with the
+                                            attributes specified.
+  @param[out]  RemainingVariableStorageSize Returns the remaining size of the storage space
+                                            available for the EFI variables associated with the
+                                            attributes specified.
+  @param[out]  MaximumVariableSize          Returns the maximum size of the individual EFI
+                                            variables associated with the attributes specified.
+
+  @retval EFI_SUCCESS                  Valid answer returned.
+  @retval EFI_INVALID_PARAMETER        An invalid combination of attribute bits was supplied
+  @retval EFI_UNSUPPORTED              The attribute is not supported on this platform, and the
+                                       MaximumVariableStorageSize,
+                                       RemainingVariableStorageSize, MaximumVariableSize
+                                       are undefined.
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+VariableStorageFvbQueryVariableInfo (
+  IN  UINT32  Attributes,
+  OUT UINT64  *MaximumVariableStorageSize,
+  OUT UINT64  *RemainingVariableStorageSize,
+  OUT UINT64  *MaximumVariableSize
+  )
+{
+  return mVariableStorage->QueryVariableInfo (
+                             Attributes,
+                             MaximumVariableStorageSize,
+                             RemainingVariableStorageSize,
+                             MaximumVariableSize
+                             );
 }
 
 EFI_SMM_VARIABLE_PROTOCOL  gSmmVariable = {
-  VariableServiceGetVariable,
-  VariableServiceGetNextVariableName,
-  SmmVariableSetVariable,
-  VariableServiceQueryVariableInfo
+  VariableStorageFvbGetVariable,
+  VariableStorageFvbGetNextVariableName,
+  VariableStorageFvbSetVariable,
+  VariableStorageFvbQueryVariableInfo
 };
-
-EDKII_SMM_VAR_CHECK_PROTOCOL  mSmmVarCheck = {
-  VarCheckRegisterSetVariableCheckHandler,
-  VarCheckVariablePropertySet,
-  VarCheckVariablePropertyGet
-};
-
-/**
-  Return TRUE if ExitBootServices () has been called.
-
-  @retval TRUE If ExitBootServices () has been called.
-**/
-BOOLEAN
-AtRuntime (
-  VOID
-  )
-{
-  return mAtRuntime;
-}
-
-/**
-  Initializes a basic mutual exclusion lock.
-
-  This function initializes a basic mutual exclusion lock to the released state
-  and returns the lock.  Each lock provides mutual exclusion access at its task
-  priority level.  Since there is no preemption or multiprocessor support in EFI,
-  acquiring the lock only consists of raising to the locks TPL.
-  If Lock is NULL, then ASSERT().
-  If Priority is not a valid TPL value, then ASSERT().
-
-  @param  Lock       A pointer to the lock data structure to initialize.
-  @param  Priority   EFI TPL is associated with the lock.
-
-  @return The lock.
-
-**/
-EFI_LOCK *
-InitializeLock (
-  IN OUT EFI_LOCK  *Lock,
-  IN EFI_TPL       Priority
-  )
-{
-  return Lock;
-}
-
-/**
-  Acquires lock only at boot time. Simply returns at runtime.
-
-  This is a temperary function that will be removed when
-  EfiAcquireLock() in UefiLib can handle the call in UEFI
-  Runtimer driver in RT phase.
-  It calls EfiAcquireLock() at boot time, and simply returns
-  at runtime.
-
-  @param  Lock         A pointer to the lock to acquire.
-
-**/
-VOID
-AcquireLockOnlyAtBootTime (
-  IN EFI_LOCK  *Lock
-  )
-{
-}
-
-/**
-  Releases lock only at boot time. Simply returns at runtime.
-
-  This is a temperary function which will be removed when
-  EfiReleaseLock() in UefiLib can handle the call in UEFI
-  Runtimer driver in RT phase.
-  It calls EfiReleaseLock() at boot time and simply returns
-  at runtime.
-
-  @param  Lock         A pointer to the lock to release.
-
-**/
-VOID
-ReleaseLockOnlyAtBootTime (
-  IN EFI_LOCK  *Lock
-  )
-{
-}
-
-/**
-  Retrieve the SMM Fault Tolerent Write protocol interface.
-
-  @param[out] FtwProtocol       The interface of SMM Ftw protocol
-
-  @retval EFI_SUCCESS           The SMM FTW protocol instance was found and returned in FtwProtocol.
-  @retval EFI_NOT_FOUND         The SMM FTW protocol instance was not found.
-  @retval EFI_INVALID_PARAMETER SarProtocol is NULL.
-
-**/
-EFI_STATUS
-GetFtwProtocol (
-  OUT VOID  **FtwProtocol
-  )
-{
-  EFI_STATUS  Status;
-
-  //
-  // Locate Smm Fault Tolerent Write protocol
-  //
-  Status = gMmst->MmLocateProtocol (
-                    &gEfiSmmFaultTolerantWriteProtocolGuid,
-                    NULL,
-                    FtwProtocol
-                    );
-  return Status;
-}
-
-/**
-  Retrieve the SMM FVB protocol interface by HANDLE.
-
-  @param[in]  FvBlockHandle     The handle of SMM FVB protocol that provides services for
-                                reading, writing, and erasing the target block.
-  @param[out] FvBlock           The interface of SMM FVB protocol
-
-  @retval EFI_SUCCESS           The interface information for the specified protocol was returned.
-  @retval EFI_UNSUPPORTED       The device does not support the SMM FVB protocol.
-  @retval EFI_INVALID_PARAMETER FvBlockHandle is not a valid EFI_HANDLE or FvBlock is NULL.
-
-**/
-EFI_STATUS
-GetFvbByHandle (
-  IN  EFI_HANDLE                          FvBlockHandle,
-  OUT EFI_FIRMWARE_VOLUME_BLOCK_PROTOCOL  **FvBlock
-  )
-{
-  //
-  // To get the SMM FVB protocol interface on the handle
-  //
-  return gMmst->MmHandleProtocol (
-                  FvBlockHandle,
-                  &gEfiSmmFirmwareVolumeBlockProtocolGuid,
-                  (VOID **)FvBlock
-                  );
-}
-
-/**
-  Function returns an array of handles that support the SMM FVB protocol
-  in a buffer allocated from pool.
-
-  @param[out]  NumberHandles    The number of handles returned in Buffer.
-  @param[out]  Buffer           A pointer to the buffer to return the requested
-                                array of  handles that support SMM FVB protocol.
-
-  @retval EFI_SUCCESS           The array of handles was returned in Buffer, and the number of
-                                handles in Buffer was returned in NumberHandles.
-  @retval EFI_NOT_FOUND         No SMM FVB handle was found.
-  @retval EFI_OUT_OF_RESOURCES  There is not enough pool memory to store the matching results.
-  @retval EFI_INVALID_PARAMETER NumberHandles is NULL or Buffer is NULL.
-
-**/
-EFI_STATUS
-GetFvbCountAndBuffer (
-  OUT UINTN       *NumberHandles,
-  OUT EFI_HANDLE  **Buffer
-  )
-{
-  EFI_STATUS  Status;
-  UINTN       BufferSize;
-
-  if ((NumberHandles == NULL) || (Buffer == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  BufferSize     = 0;
-  *NumberHandles = 0;
-  *Buffer        = NULL;
-  Status         = gMmst->MmLocateHandle (
-                            ByProtocol,
-                            &gEfiSmmFirmwareVolumeBlockProtocolGuid,
-                            NULL,
-                            &BufferSize,
-                            *Buffer
-                            );
-  if (EFI_ERROR (Status) && (Status != EFI_BUFFER_TOO_SMALL)) {
-    return EFI_NOT_FOUND;
-  }
-
-  *Buffer = AllocatePool (BufferSize);
-  if (*Buffer == NULL) {
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  Status = gMmst->MmLocateHandle (
-                    ByProtocol,
-                    &gEfiSmmFirmwareVolumeBlockProtocolGuid,
-                    NULL,
-                    &BufferSize,
-                    *Buffer
-                    );
-
-  *NumberHandles = BufferSize / sizeof (EFI_HANDLE);
-  if (EFI_ERROR (Status)) {
-    *NumberHandles = 0;
-    FreePool (*Buffer);
-    *Buffer = NULL;
-  }
-
-  return Status;
-}
-
-/**
-  Get the variable statistics information from the information buffer pointed by gVariableInfo.
-
-  Caution: This function may be invoked at SMM runtime.
-  InfoEntry and InfoSize are external input. Care must be taken to make sure not security issue at runtime.
-
-  @param[in, out]  InfoEntry    A pointer to the buffer of variable information entry.
-                                On input, point to the variable information returned last time. if
-                                InfoEntry->VendorGuid is zero, return the first information.
-                                On output, point to the next variable information.
-  @param[in, out]  InfoSize     On input, the size of the variable information buffer.
-                                On output, the returned variable information size.
-
-  @retval EFI_SUCCESS           The variable information is found and returned successfully.
-  @retval EFI_UNSUPPORTED       No variable inoformation exists in variable driver. The
-                                PcdVariableCollectStatistics should be set TRUE to support it.
-  @retval EFI_BUFFER_TOO_SMALL  The buffer is too small to hold the next variable information.
-  @retval EFI_INVALID_PARAMETER Input parameter is invalid.
-
-**/
-EFI_STATUS
-SmmVariableGetStatistics (
-  IN OUT VARIABLE_INFO_ENTRY  *InfoEntry,
-  IN OUT UINTN                *InfoSize
-  )
-{
-  VARIABLE_INFO_ENTRY  *VariableInfo;
-  UINTN                NameSize;
-  UINTN                StatisticsInfoSize;
-  CHAR16               *InfoName;
-  UINTN                InfoNameMaxSize;
-  EFI_GUID             VendorGuid;
-
-  if (InfoEntry == NULL) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  VariableInfo = gVariableInfo;
-  if (VariableInfo == NULL) {
-    return EFI_UNSUPPORTED;
-  }
-
-  StatisticsInfoSize = sizeof (VARIABLE_INFO_ENTRY);
-  if (*InfoSize < StatisticsInfoSize) {
-    *InfoSize = StatisticsInfoSize;
-    return EFI_BUFFER_TOO_SMALL;
-  }
-
-  InfoName        = (CHAR16 *)(InfoEntry + 1);
-  InfoNameMaxSize = (*InfoSize - sizeof (VARIABLE_INFO_ENTRY));
-
-  CopyGuid (&VendorGuid, &InfoEntry->VendorGuid);
-
-  if (IsZeroGuid (&VendorGuid)) {
-    //
-    // Return the first variable info
-    //
-    NameSize           = StrSize (VariableInfo->Name);
-    StatisticsInfoSize = sizeof (VARIABLE_INFO_ENTRY) + NameSize;
-    if (*InfoSize < StatisticsInfoSize) {
-      *InfoSize = StatisticsInfoSize;
-      return EFI_BUFFER_TOO_SMALL;
-    }
-
-    CopyMem (InfoEntry, VariableInfo, sizeof (VARIABLE_INFO_ENTRY));
-    CopyMem (InfoName, VariableInfo->Name, NameSize);
-    *InfoSize = StatisticsInfoSize;
-    return EFI_SUCCESS;
-  }
-
-  //
-  // Get the next variable info
-  //
-  while (VariableInfo != NULL) {
-    if (CompareGuid (&VariableInfo->VendorGuid, &VendorGuid)) {
-      NameSize = StrSize (VariableInfo->Name);
-      if (NameSize <= InfoNameMaxSize) {
-        if (CompareMem (VariableInfo->Name, InfoName, NameSize) == 0) {
-          //
-          // Find the match one
-          //
-          VariableInfo = VariableInfo->Next;
-          break;
-        }
-      }
-    }
-
-    VariableInfo = VariableInfo->Next;
-  }
-
-  if (VariableInfo == NULL) {
-    *InfoSize = 0;
-    return EFI_SUCCESS;
-  }
-
-  //
-  // Output the new variable info
-  //
-  NameSize           = StrSize (VariableInfo->Name);
-  StatisticsInfoSize = sizeof (VARIABLE_INFO_ENTRY) + NameSize;
-  if (*InfoSize < StatisticsInfoSize) {
-    *InfoSize = StatisticsInfoSize;
-    return EFI_BUFFER_TOO_SMALL;
-  }
-
-  CopyMem (InfoEntry, VariableInfo, sizeof (VARIABLE_INFO_ENTRY));
-  CopyMem (InfoName, VariableInfo->Name, NameSize);
-  *InfoSize = StatisticsInfoSize;
-
-  return EFI_SUCCESS;
-}
 
 /**
   Communication service SMI Handler entry.
@@ -470,8 +292,6 @@ SmmVariableHandler (
   SMM_VARIABLE_COMMUNICATE_LOCK_VARIABLE                   *VariableToLock;
   SMM_VARIABLE_COMMUNICATE_VAR_CHECK_VARIABLE_PROPERTY     *CommVariableProperty;
   VARIABLE_INFO_ENTRY                                      *VariableInfo;
-  VARIABLE_RUNTIME_CACHE_CONTEXT                           *VariableCacheContext;
-  VARIABLE_STORE_HEADER                                    *VariableCache;
   UINTN                                                    InfoSize;
   UINTN                                                    NameBufferSize;
   UINTN                                                    CommBufferPayloadSize;
@@ -551,7 +371,7 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = VariableServiceGetVariable (
+      Status = VariableStorageFvbGetVariable (
                  SmmVariableHeader->Name,
                  &SmmVariableHeader->Guid,
                  &SmmVariableHeader->Attributes,
@@ -600,7 +420,7 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = VariableServiceGetNextVariableName (
+      Status = VariableStorageFvbGetNextVariableName (
                  &GetNextVariableName->NameSize,
                  GetNextVariableName->Name,
                  &GetNextVariableName->Guid
@@ -656,13 +476,14 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = VariableServiceSetVariable (
-                 SmmVariableHeader->Name,
-                 &SmmVariableHeader->Guid,
-                 SmmVariableHeader->Attributes,
-                 SmmVariableHeader->DataSize,
-                 (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize
-                 );
+      Status = mVariableStorage->SetVariable (
+                                   SmmVariableHeader->Name,
+                                   &SmmVariableHeader->Guid,
+                                   SmmVariableHeader->Attributes,
+                                   SmmVariableHeader->DataSize,
+                                   (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize,
+                                   FALSE
+                                   );
       break;
 
     case SMM_VARIABLE_FUNCTION_QUERY_VARIABLE_INFO:
@@ -673,7 +494,7 @@ SmmVariableHandler (
 
       QueryVariableInfo = (SMM_VARIABLE_COMMUNICATE_QUERY_VARIABLE_INFO *)SmmVariableFunctionHeader->Data;
 
-      Status = VariableServiceQueryVariableInfo (
+      Status = VariableStorageFvbQueryVariableInfo (
                  QueryVariableInfo->Attributes,
                  &QueryVariableInfo->MaximumVariableStorageSize,
                  &QueryVariableInfo->RemainingVariableStorageSize,
@@ -693,30 +514,22 @@ SmmVariableHandler (
       break;
 
     case SMM_VARIABLE_FUNCTION_READY_TO_BOOT:
-      if (AtRuntime ()) {
+      if (mAtRuntime) {
         Status = EFI_UNSUPPORTED;
         break;
       }
 
       if (!mEndOfDxe) {
-        MorLockInitAtEndOfDxe ();
-        Status = LockVariablePolicy ();
-        ASSERT_EFI_ERROR (Status);
-        mEndOfDxe = TRUE;
-        VarCheckLibInitializeAtEndOfDxe (NULL);
-        //
-        // The initialization for variable quota.
-        //
-        InitializeVariableQuota ();
+        Status = mVariableStorage->ReadyToBoot ();
+      } else {
+        Status = EFI_SUCCESS;
       }
 
-      ReclaimForOS ();
-      Status = EFI_SUCCESS;
       break;
 
     case SMM_VARIABLE_FUNCTION_EXIT_BOOT_SERVICE:
       mAtRuntime = TRUE;
-      Status     = EFI_SUCCESS;
+      Status     = mVariableStorage->ExitBootService ();
       break;
 
     case SMM_VARIABLE_FUNCTION_GET_STATISTICS:
@@ -733,7 +546,7 @@ SmmVariableHandler (
       // that was used by SMM core to cache CommSize from SmmCommunication protocol.
       //
 
-      Status          = SmmVariableGetStatistics (VariableInfo, &InfoSize);
+      Status          = mVariableStorage->GetStatics (VariableInfo, &InfoSize);
       *CommBufferSize = InfoSize + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE;
       break;
 
@@ -742,27 +555,28 @@ SmmVariableHandler (
         Status = EFI_ACCESS_DENIED;
       } else {
         VariableToLock = (SMM_VARIABLE_COMMUNICATE_LOCK_VARIABLE *)SmmVariableFunctionHeader->Data;
-        Status         = VariableLockRequestToLock (
-                           NULL,
-                           VariableToLock->Name,
-                           &VariableToLock->Guid
-                           );
+        Status         = mVariableStorage->RequestToLock (
+                                             VariableToLock->Name,
+                                             &VariableToLock->Guid
+                                             );
       }
 
       break;
+
     case SMM_VARIABLE_FUNCTION_VAR_CHECK_VARIABLE_PROPERTY_SET:
       if (mEndOfDxe) {
         Status = EFI_ACCESS_DENIED;
       } else {
         CommVariableProperty = (SMM_VARIABLE_COMMUNICATE_VAR_CHECK_VARIABLE_PROPERTY *)SmmVariableFunctionHeader->Data;
-        Status               = VarCheckVariablePropertySet (
-                                 CommVariableProperty->Name,
-                                 &CommVariableProperty->Guid,
-                                 &CommVariableProperty->VariableProperty
-                                 );
+        Status               = mVariableStorage->PropertySet (
+                                                   CommVariableProperty->Name,
+                                                   &CommVariableProperty->Guid,
+                                                   &CommVariableProperty->VariableProperty
+                                                   );
       }
 
       break;
+
     case SMM_VARIABLE_FUNCTION_VAR_CHECK_VARIABLE_PROPERTY_GET:
       if (CommBufferPayloadSize < OFFSET_OF (SMM_VARIABLE_COMMUNICATE_VAR_CHECK_VARIABLE_PROPERTY, Name)) {
         DEBUG ((DEBUG_ERROR, "VarCheckVariablePropertyGet: SMM communication buffer size invalid!\n"));
@@ -807,13 +621,14 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = VarCheckVariablePropertyGet (
-                 CommVariableProperty->Name,
-                 &CommVariableProperty->Guid,
-                 &CommVariableProperty->VariableProperty
-                 );
+      Status = mVariableStorage->PropertyGet (
+                                   CommVariableProperty->Name,
+                                   &CommVariableProperty->Guid,
+                                   &CommVariableProperty->VariableProperty
+                                   );
       CopyMem (SmmVariableFunctionHeader->Data, mVariableBufferPayload, CommBufferPayloadSize);
       break;
+
     case SMM_VARIABLE_FUNCTION_INIT_RUNTIME_VARIABLE_CACHE_CONTEXT:
       if (CommBufferPayloadSize < sizeof (SMM_VARIABLE_COMMUNICATE_RUNTIME_VARIABLE_CACHE_CONTEXT)) {
         DEBUG ((DEBUG_ERROR, "InitRuntimeVariableCacheContext: SMM communication buffer size invalid!\n"));
@@ -924,44 +739,20 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      VariableCacheContext                                     = &mVariableModuleGlobal->VariableGlobal.VariableRuntimeCacheContext;
-      VariableCacheContext->VariableRuntimeHobCache.Store      = RuntimeVariableCacheContext->RuntimeHobCache;
-      VariableCacheContext->VariableRuntimeVolatileCache.Store = RuntimeVariableCacheContext->RuntimeVolatileCache;
-      VariableCacheContext->VariableRuntimeNvCache.Store       = RuntimeVariableCacheContext->RuntimeNvCache;
-      VariableCacheContext->PendingUpdate                      = RuntimeVariableCacheContext->PendingUpdate;
-      VariableCacheContext->ReadLock                           = RuntimeVariableCacheContext->ReadLock;
-      VariableCacheContext->HobFlushComplete                   = RuntimeVariableCacheContext->HobFlushComplete;
-
-      // Set up the intial pending request since the RT cache needs to be in sync with SMM cache
-      VariableCacheContext->VariableRuntimeHobCache.PendingUpdateOffset = 0;
-      VariableCacheContext->VariableRuntimeHobCache.PendingUpdateLength = 0;
-      if ((mVariableModuleGlobal->VariableGlobal.HobVariableBase > 0) &&
-          (VariableCacheContext->VariableRuntimeHobCache.Store != NULL))
-      {
-        VariableCache                                                     = (VARIABLE_STORE_HEADER *)(UINTN)mVariableModuleGlobal->VariableGlobal.HobVariableBase;
-        VariableCacheContext->VariableRuntimeHobCache.PendingUpdateLength = (UINT32)((UINTN)GetEndPointer (VariableCache) - (UINTN)VariableCache);
-        CopyGuid (&(VariableCacheContext->VariableRuntimeHobCache.Store->Signature), &(VariableCache->Signature));
-      }
-
-      VariableCache                                                          = (VARIABLE_STORE_HEADER  *)(UINTN)mVariableModuleGlobal->VariableGlobal.VolatileVariableBase;
-      VariableCacheContext->VariableRuntimeVolatileCache.PendingUpdateOffset = 0;
-      VariableCacheContext->VariableRuntimeVolatileCache.PendingUpdateLength = (UINT32)((UINTN)GetEndPointer (VariableCache) - (UINTN)VariableCache);
-      CopyGuid (&(VariableCacheContext->VariableRuntimeVolatileCache.Store->Signature), &(VariableCache->Signature));
-
-      VariableCache                                                    = (VARIABLE_STORE_HEADER  *)(UINTN)mNvVariableCache;
-      VariableCacheContext->VariableRuntimeNvCache.PendingUpdateOffset = 0;
-      VariableCacheContext->VariableRuntimeNvCache.PendingUpdateLength = (UINT32)((UINTN)GetEndPointer (VariableCache) - (UINTN)VariableCache);
-      CopyGuid (&(VariableCacheContext->VariableRuntimeNvCache.Store->Signature), &(VariableCache->Signature));
-
-      *(VariableCacheContext->PendingUpdate)    = TRUE;
-      *(VariableCacheContext->ReadLock)         = FALSE;
-      *(VariableCacheContext->HobFlushComplete) = FALSE;
-
-      Status = EFI_SUCCESS;
+      Status = mVariableStorage->InitCache (
+                                   RuntimeVariableCacheContext->RuntimeHobCache,
+                                   RuntimeVariableCacheContext->RuntimeVolatileCache,
+                                   RuntimeVariableCacheContext->RuntimeNvCache,
+                                   RuntimeVariableCacheContext->PendingUpdate,
+                                   RuntimeVariableCacheContext->ReadLock,
+                                   RuntimeVariableCacheContext->HobFlushComplete
+                                   );
       break;
+
     case SMM_VARIABLE_FUNCTION_SYNC_RUNTIME_CACHE:
-      Status = FlushPendingRuntimeVariableCacheUpdates ();
+      Status = mVariableStorage->SyncCache ();
       break;
+
     case SMM_VARIABLE_FUNCTION_GET_RUNTIME_CACHE_INFO:
       if (CommBufferPayloadSize < sizeof (SMM_VARIABLE_COMMUNICATE_GET_RUNTIME_CACHE_INFO)) {
         DEBUG ((DEBUG_ERROR, "GetRuntimeCacheInfo: SMM communication buffer size invalid!\n"));
@@ -970,20 +761,13 @@ SmmVariableHandler (
 
       GetRuntimeCacheInfo = (SMM_VARIABLE_COMMUNICATE_GET_RUNTIME_CACHE_INFO *)SmmVariableFunctionHeader->Data;
 
-      if (mVariableModuleGlobal->VariableGlobal.HobVariableBase > 0) {
-        VariableCache                            = (VARIABLE_STORE_HEADER *)(UINTN)mVariableModuleGlobal->VariableGlobal.HobVariableBase;
-        GetRuntimeCacheInfo->TotalHobStorageSize = VariableCache->Size;
-      } else {
-        GetRuntimeCacheInfo->TotalHobStorageSize = 0;
-      }
+      GetRuntimeCacheInfo->AuthenticatedVariableUsage = mVariableStorage->CheckAuthFormat ();
 
-      VariableCache                                   = (VARIABLE_STORE_HEADER  *)(UINTN)mVariableModuleGlobal->VariableGlobal.VolatileVariableBase;
-      GetRuntimeCacheInfo->TotalVolatileStorageSize   = VariableCache->Size;
-      VariableCache                                   = (VARIABLE_STORE_HEADER  *)(UINTN)mNvVariableCache;
-      GetRuntimeCacheInfo->TotalNvStorageSize         = (UINTN)VariableCache->Size;
-      GetRuntimeCacheInfo->AuthenticatedVariableUsage = mVariableModuleGlobal->VariableGlobal.AuthFormat;
-
-      Status = EFI_SUCCESS;
+      Status = mVariableStorage->GetCacheInfo (
+                                   &GetRuntimeCacheInfo->TotalHobStorageSize,
+                                   &GetRuntimeCacheInfo->TotalVolatileStorageSize,
+                                   &GetRuntimeCacheInfo->TotalNvStorageSize
+                                   );
       break;
 
     default:
@@ -1015,124 +799,12 @@ SmmEndOfDxeCallback (
   IN EFI_HANDLE      Handle
   )
 {
-  EFI_STATUS  Status;
-
   DEBUG ((DEBUG_INFO, "[Variable]SMM_END_OF_DXE is signaled\n"));
-  MorLockInitAtEndOfDxe ();
-  Status = LockVariablePolicy ();
-  ASSERT_EFI_ERROR (Status);
-  mEndOfDxe = TRUE;
-  VarCheckLibInitializeAtEndOfDxe (NULL);
-  //
-  // The initialization for variable quota.
-  //
-  InitializeVariableQuota ();
-  if (PcdGetBool (PcdReclaimVariableSpaceAtEndOfDxe)) {
-    ReclaimForOS ();
+
+  if (!mEndOfDxe) {
+    mEndOfDxe = TRUE;
+    return mVariableStorage->EndOfDxe ();
   }
-
-  return EFI_SUCCESS;
-}
-
-/**
-  Initializes variable write service for SMM.
-
-**/
-VOID
-VariableWriteServiceInitializeSmm (
-  VOID
-  )
-{
-  EFI_STATUS  Status;
-
-  Status = VariableWriteServiceInitialize ();
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Variable write service initialization failed. Status = %r\n", Status));
-  }
-
-  //
-  // Notify the variable wrapper driver the variable write service is ready
-  //
-  VariableNotifySmmWriteReady ();
-}
-
-/**
-  SMM Fault Tolerant Write protocol notification event handler.
-
-  Non-Volatile variable write may needs FTW protocol to reclaim when
-  writting variable.
-
-  @param  Protocol   Points to the protocol's unique identifier
-  @param  Interface  Points to the interface instance
-  @param  Handle     The handle on which the interface was installed
-
-  @retval EFI_SUCCESS   SmmEventCallback runs successfully
-  @retval EFI_NOT_FOUND The Fvb protocol for variable is not found.
-
- **/
-EFI_STATUS
-EFIAPI
-SmmFtwNotificationEvent (
-  IN CONST EFI_GUID  *Protocol,
-  IN VOID            *Interface,
-  IN EFI_HANDLE      Handle
-  )
-{
-  EFI_STATUS                              Status;
-  EFI_PHYSICAL_ADDRESS                    VariableStoreBase;
-  EFI_SMM_FIRMWARE_VOLUME_BLOCK_PROTOCOL  *FvbProtocol;
-  EFI_SMM_FAULT_TOLERANT_WRITE_PROTOCOL   *FtwProtocol;
-  EFI_PHYSICAL_ADDRESS                    NvStorageVariableBase;
-  UINTN                                   FtwMaxBlockSize;
-  UINT32                                  NvStorageVariableSize;
-  UINT64                                  NvStorageVariableSize64;
-
-  if (mVariableModuleGlobal->FvbInstance != NULL) {
-    return EFI_SUCCESS;
-  }
-
-  //
-  // Ensure SMM FTW protocol is installed.
-  //
-  Status = GetFtwProtocol ((VOID **)&FtwProtocol);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  Status = GetVariableFlashNvStorageInfo (&NvStorageVariableBase, &NvStorageVariableSize64);
-  ASSERT_EFI_ERROR (Status);
-
-  Status = SafeUint64ToUint32 (NvStorageVariableSize64, &NvStorageVariableSize);
-  // This driver currently assumes the size will be UINT32 so assert the value is safe for now.
-  ASSERT_EFI_ERROR (Status);
-
-  ASSERT (NvStorageVariableBase != 0);
-  VariableStoreBase = NvStorageVariableBase + mNvFvHeaderCache->HeaderLength;
-
-  Status = FtwProtocol->GetMaxBlockSize (FtwProtocol, &FtwMaxBlockSize);
-  if (!EFI_ERROR (Status)) {
-    ASSERT (NvStorageVariableSize <= FtwMaxBlockSize);
-  }
-
-  //
-  // Let NonVolatileVariableBase point to flash variable store base directly after FTW ready.
-  //
-  mVariableModuleGlobal->VariableGlobal.NonVolatileVariableBase = VariableStoreBase;
-
-  //
-  // Find the proper FVB protocol for variable.
-  //
-  Status = GetFvbInfoByAddress (NvStorageVariableBase, NULL, &FvbProtocol);
-  if (EFI_ERROR (Status)) {
-    return EFI_NOT_FOUND;
-  }
-
-  mVariableModuleGlobal->FvbInstance = FvbProtocol;
-
-  //
-  // Initializes variable write service after FTW was ready.
-  //
-  VariableWriteServiceInitializeSmm ();
 
   return EFI_SUCCESS;
 }
@@ -1154,13 +826,13 @@ MmVariableServiceInitialize (
 {
   EFI_STATUS  Status;
   EFI_HANDLE  VariableHandle;
-  VOID        *SmmFtwRegistration;
   VOID        *SmmEndOfDxeRegistration;
 
-  //
-  // Variable initialize.
-  //
-  Status = VariableCommonInitialize ();
+  Status = gMmst->MmLocateProtocol (
+                    &gEdkiiVariableStorageProtocolGuid,
+                    NULL,
+                    (VOID **)&mVariableStorage
+                    );
   ASSERT_EFI_ERROR (Status);
 
   //
@@ -1175,17 +847,9 @@ MmVariableServiceInitialize (
                             );
   ASSERT_EFI_ERROR (Status);
 
-  Status = gMmst->MmInstallProtocolInterface (
-                    &VariableHandle,
-                    &gEdkiiSmmVarCheckProtocolGuid,
-                    EFI_NATIVE_INTERFACE,
-                    &mSmmVarCheck
-                    );
-  ASSERT_EFI_ERROR (Status);
-
-  mVariableBufferPayloadSize =  GetMaxVariableSize () +
+  mVariableBufferPayloadSize = mVariableStorage->GetMaxVariableSize () +
                                OFFSET_OF (SMM_VARIABLE_COMMUNICATE_VAR_CHECK_VARIABLE_PROPERTY, Name) -
-                               GetVariableHeaderSize (mVariableModuleGlobal->VariableGlobal.AuthFormat);
+                               GetVariableHeaderSize ();
 
   Status = gMmst->MmAllocatePool (
                     EfiRuntimeServicesData,
@@ -1216,24 +880,11 @@ MmVariableServiceInitialize (
                     );
   ASSERT_EFI_ERROR (Status);
 
-  if (!PcdGetBool (PcdEmuVariableNvModeEnable)) {
-    //
-    // Register FtwNotificationEvent () notify function.
-    //
-    Status = gMmst->MmRegisterProtocolNotify (
-                      &gEfiSmmFaultTolerantWriteProtocolGuid,
-                      SmmFtwNotificationEvent,
-                      &SmmFtwRegistration
-                      );
-    ASSERT_EFI_ERROR (Status);
-
-    SmmFtwNotificationEvent (NULL, NULL, NULL);
-  } else {
-    //
-    // Emulated non-volatile variable mode does not depend on FVB and FTW.
-    //
-    VariableWriteServiceInitializeSmm ();
-  }
+  //
+  // Notify the variable wrapper driver the variable service is ready
+  //
+  Status = mVariableStorage->InitWriteService (VariableNotifySmmWriteReady);
+  ASSERT_EFI_ERROR (Status);
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
@@ -21,11 +21,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 #include <Protocol/SmmVariable.h>
-#include <Protocol/VariableStorage.h>
 
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MmServicesTableLib.h>
+#include <Library/VariableStorageRouterLib.h>
 
 #include <Guid/SmmVariableCommon.h>
 #include "PrivilegePolymorphic.h"
@@ -36,8 +36,6 @@ STATIC BOOLEAN  mAtRuntime              = FALSE;
 STATIC BOOLEAN  mEndOfDxe               = FALSE;
 STATIC UINT8    *mVariableBufferPayload = NULL;
 STATIC UINTN    mVariableBufferPayloadSize;
-
-STATIC EDKII_VARIABLE_STORAGE_PROTOCOL  *mVariableStorage;
 
 /**
   This code gets the size of variable header.
@@ -55,7 +53,7 @@ GetVariableHeaderSize (
   UINTN    Value;
   BOOLEAN  AuthFormat;
 
-  AuthFormat = mVariableStorage->CheckAuthFormat ();
+  AuthFormat = VariableStorageRouterLibCheckAuthFormat ();
 
   if (AuthFormat) {
     Value = sizeof (AUTHENTICATED_VARIABLE_HEADER);
@@ -87,7 +85,7 @@ GetVariableHeaderSize (
 STATIC
 EFI_STATUS
 EFIAPI
-VariableStorageFvbSetVariable (
+SmmVariableSetVariable (
   IN CHAR16    *VariableName,
   IN EFI_GUID  *VendorGuid,
   IN UINT32    Attributes,
@@ -95,155 +93,21 @@ VariableStorageFvbSetVariable (
   IN VOID      *Data
   )
 {
-  return mVariableStorage->SetVariable (
-                             VariableName,
-                             VendorGuid,
-                             Attributes,
-                             DataSize,
-                             Data,
-                             TRUE
-                             );
-}
-
-/**
-  Returns the value of a variable.
-
-  @param[in]       VariableName  A Null-terminated string that is the name of the vendor's
-                                 variable.
-  @param[in]       VendorGuid    A unique identifier for the vendor.
-  @param[out]      Attributes    If not NULL, a pointer to the memory location to return the
-                                 attributes bitmask for the variable.
-  @param[in, out]  DataSize      On input, the size in bytes of the return Data buffer.
-                                 On output the size of data returned in Data.
-  @param[out]      Data          The buffer to return the contents of the variable. May be NULL
-                                 with a zero DataSize in order to determine the size buffer needed.
-
-  @retval EFI_SUCCESS            The function completed successfully.
-  @retval EFI_NOT_FOUND          The variable was not found.
-  @retval EFI_BUFFER_TOO_SMALL   The DataSize is too small for the result.
-  @retval EFI_INVALID_PARAMETER  VariableName is NULL.
-  @retval EFI_INVALID_PARAMETER  VendorGuid is NULL.
-  @retval EFI_INVALID_PARAMETER  DataSize is NULL.
-  @retval EFI_INVALID_PARAMETER  The DataSize is not too small and Data is NULL.
-  @retval EFI_DEVICE_ERROR       The variable could not be retrieved due to a hardware error.
-  @retval EFI_SECURITY_VIOLATION The variable could not be retrieved due to an authentication failure.
-  @retval EFI_UNSUPPORTED        After ExitBootServices() has been called, this return code may be returned
-                                 if no variable storage is supported. The platform should describe this
-                                 runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
-                                 configuration table.
-
-**/
-STATIC
-EFI_STATUS
-EFIAPI
-VariableStorageFvbGetVariable (
-  IN     CHAR16    *VariableName,
-  IN     EFI_GUID  *VendorGuid,
-  OUT    UINT32    *Attributes     OPTIONAL,
-  IN OUT UINTN     *DataSize,
-  OUT    VOID      *Data           OPTIONAL
-  )
-{
-  return mVariableStorage->GetVariable (
-                             VariableName,
-                             VendorGuid,
-                             Attributes,
-                             DataSize,
-                             Data
-                             );
-}
-
-/**
-  Enumerates the current variable names.
-
-  @param[in, out]  VariableNameSize The size of the VariableName buffer. The size must be large
-                                    enough to fit input string supplied in VariableName buffer.
-  @param[in, out]  VariableName     On input, supplies the last VariableName that was returned
-                                    by GetNextVariableName(). On output, returns the Nullterminated
-                                    string of the current variable.
-  @param[in, out]  VendorGuid       On input, supplies the last VendorGuid that was returned by
-                                    GetNextVariableName(). On output, returns the
-                                    VendorGuid of the current variable.
-
-  @retval EFI_SUCCESS           The function completed successfully.
-  @retval EFI_NOT_FOUND         The next variable was not found.
-  @retval EFI_BUFFER_TOO_SMALL  The VariableNameSize is too small for the result.
-                                VariableNameSize has been updated with the size needed to complete the request.
-  @retval EFI_INVALID_PARAMETER VariableNameSize is NULL.
-  @retval EFI_INVALID_PARAMETER VariableName is NULL.
-  @retval EFI_INVALID_PARAMETER VendorGuid is NULL.
-  @retval EFI_INVALID_PARAMETER The input values of VariableName and VendorGuid are not a name and
-                                GUID of an existing variable.
-  @retval EFI_INVALID_PARAMETER Null-terminator is not found in the first VariableNameSize bytes of
-                                the input VariableName buffer.
-  @retval EFI_DEVICE_ERROR      The variable could not be retrieved due to a hardware error.
-  @retval EFI_UNSUPPORTED       After ExitBootServices() has been called, this return code may be returned
-                                if no variable storage is supported. The platform should describe this
-                                runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
-                                configuration table.
-
-**/
-STATIC
-EFI_STATUS
-EFIAPI
-VariableStorageFvbGetNextVariableName (
-  IN OUT UINTN     *VariableNameSize,
-  IN OUT CHAR16    *VariableName,
-  IN OUT EFI_GUID  *VendorGuid
-  )
-{
-  return mVariableStorage->GetNextVariableName (
-                             VariableNameSize,
-                             VariableName,
-                             VendorGuid
-                             );
-}
-
-/**
-  Returns information about the EFI variables.
-
-  @param[in]   Attributes                   Attributes bitmask to specify the type of variables on
-                                            which to return information.
-  @param[out]  MaximumVariableStorageSize   On output the maximum size of the storage space
-                                            available for the EFI variables associated with the
-                                            attributes specified.
-  @param[out]  RemainingVariableStorageSize Returns the remaining size of the storage space
-                                            available for the EFI variables associated with the
-                                            attributes specified.
-  @param[out]  MaximumVariableSize          Returns the maximum size of the individual EFI
-                                            variables associated with the attributes specified.
-
-  @retval EFI_SUCCESS                  Valid answer returned.
-  @retval EFI_INVALID_PARAMETER        An invalid combination of attribute bits was supplied
-  @retval EFI_UNSUPPORTED              The attribute is not supported on this platform, and the
-                                       MaximumVariableStorageSize,
-                                       RemainingVariableStorageSize, MaximumVariableSize
-                                       are undefined.
-
-**/
-STATIC
-EFI_STATUS
-EFIAPI
-VariableStorageFvbQueryVariableInfo (
-  IN  UINT32  Attributes,
-  OUT UINT64  *MaximumVariableStorageSize,
-  OUT UINT64  *RemainingVariableStorageSize,
-  OUT UINT64  *MaximumVariableSize
-  )
-{
-  return mVariableStorage->QueryVariableInfo (
-                             Attributes,
-                             MaximumVariableStorageSize,
-                             RemainingVariableStorageSize,
-                             MaximumVariableSize
-                             );
+  return VariableStorageRouterLibSetVariable (
+           VariableName,
+           VendorGuid,
+           Attributes,
+           DataSize,
+           Data,
+           TRUE
+           );
 }
 
 EFI_SMM_VARIABLE_PROTOCOL  gSmmVariable = {
-  VariableStorageFvbGetVariable,
-  VariableStorageFvbGetNextVariableName,
-  VariableStorageFvbSetVariable,
-  VariableStorageFvbQueryVariableInfo
+  VariableStorageRouterLibGetVariable,
+  VariableStorageRouterLibGetNextVariableName,
+  SmmVariableSetVariable,
+  VariableStorageRouterLibQueryVariableInfo
 };
 
 /**
@@ -371,7 +235,7 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = VariableStorageFvbGetVariable (
+      Status = VariableStorageRouterLibGetVariable (
                  SmmVariableHeader->Name,
                  &SmmVariableHeader->Guid,
                  &SmmVariableHeader->Attributes,
@@ -420,7 +284,7 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = VariableStorageFvbGetNextVariableName (
+      Status = VariableStorageRouterLibGetNextVariableName (
                  &GetNextVariableName->NameSize,
                  GetNextVariableName->Name,
                  &GetNextVariableName->Guid
@@ -476,14 +340,14 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = mVariableStorage->SetVariable (
-                                   SmmVariableHeader->Name,
-                                   &SmmVariableHeader->Guid,
-                                   SmmVariableHeader->Attributes,
-                                   SmmVariableHeader->DataSize,
-                                   (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize,
-                                   FALSE
-                                   );
+      Status = VariableStorageRouterLibSetVariable (
+                 SmmVariableHeader->Name,
+                 &SmmVariableHeader->Guid,
+                 SmmVariableHeader->Attributes,
+                 SmmVariableHeader->DataSize,
+                 (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize,
+                 FALSE
+                 );
       break;
 
     case SMM_VARIABLE_FUNCTION_QUERY_VARIABLE_INFO:
@@ -494,7 +358,7 @@ SmmVariableHandler (
 
       QueryVariableInfo = (SMM_VARIABLE_COMMUNICATE_QUERY_VARIABLE_INFO *)SmmVariableFunctionHeader->Data;
 
-      Status = VariableStorageFvbQueryVariableInfo (
+      Status = VariableStorageRouterLibQueryVariableInfo (
                  QueryVariableInfo->Attributes,
                  &QueryVariableInfo->MaximumVariableStorageSize,
                  &QueryVariableInfo->RemainingVariableStorageSize,
@@ -520,7 +384,7 @@ SmmVariableHandler (
       }
 
       if (!mEndOfDxe) {
-        Status = mVariableStorage->ReadyToBoot ();
+        Status = VariableStorageRouterLibReadyToBoot ();
       } else {
         Status = EFI_SUCCESS;
       }
@@ -529,7 +393,7 @@ SmmVariableHandler (
 
     case SMM_VARIABLE_FUNCTION_EXIT_BOOT_SERVICE:
       mAtRuntime = TRUE;
-      Status     = mVariableStorage->ExitBootService ();
+      Status     = VariableStorageRouterLibExitBootService ();
       break;
 
     case SMM_VARIABLE_FUNCTION_GET_STATISTICS:
@@ -546,7 +410,7 @@ SmmVariableHandler (
       // that was used by SMM core to cache CommSize from SmmCommunication protocol.
       //
 
-      Status          = mVariableStorage->GetStatics (VariableInfo, &InfoSize);
+      Status          = VariableStorageRouterLibGetStatics (VariableInfo, &InfoSize);
       *CommBufferSize = InfoSize + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE;
       break;
 
@@ -555,10 +419,10 @@ SmmVariableHandler (
         Status = EFI_ACCESS_DENIED;
       } else {
         VariableToLock = (SMM_VARIABLE_COMMUNICATE_LOCK_VARIABLE *)SmmVariableFunctionHeader->Data;
-        Status         = mVariableStorage->RequestToLock (
-                                             VariableToLock->Name,
-                                             &VariableToLock->Guid
-                                             );
+        Status         = VariableStorageRouterLibRequestToLock (
+                           VariableToLock->Name,
+                           &VariableToLock->Guid
+                           );
       }
 
       break;
@@ -568,11 +432,11 @@ SmmVariableHandler (
         Status = EFI_ACCESS_DENIED;
       } else {
         CommVariableProperty = (SMM_VARIABLE_COMMUNICATE_VAR_CHECK_VARIABLE_PROPERTY *)SmmVariableFunctionHeader->Data;
-        Status               = mVariableStorage->PropertySet (
-                                                   CommVariableProperty->Name,
-                                                   &CommVariableProperty->Guid,
-                                                   &CommVariableProperty->VariableProperty
-                                                   );
+        Status               = VariableStorageRouterLibPropertySet (
+                                 CommVariableProperty->Name,
+                                 &CommVariableProperty->Guid,
+                                 &CommVariableProperty->VariableProperty
+                                 );
       }
 
       break;
@@ -621,11 +485,11 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = mVariableStorage->PropertyGet (
-                                   CommVariableProperty->Name,
-                                   &CommVariableProperty->Guid,
-                                   &CommVariableProperty->VariableProperty
-                                   );
+      Status = VariableStorageRouterLibPropertyGet (
+                 CommVariableProperty->Name,
+                 &CommVariableProperty->Guid,
+                 &CommVariableProperty->VariableProperty
+                 );
       CopyMem (SmmVariableFunctionHeader->Data, mVariableBufferPayload, CommBufferPayloadSize);
       break;
 
@@ -739,18 +603,18 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = mVariableStorage->InitCache (
-                                   RuntimeVariableCacheContext->RuntimeHobCache,
-                                   RuntimeVariableCacheContext->RuntimeVolatileCache,
-                                   RuntimeVariableCacheContext->RuntimeNvCache,
-                                   RuntimeVariableCacheContext->PendingUpdate,
-                                   RuntimeVariableCacheContext->ReadLock,
-                                   RuntimeVariableCacheContext->HobFlushComplete
-                                   );
+      Status = VariableStorageRouterLibInitCache (
+                 RuntimeVariableCacheContext->RuntimeHobCache,
+                 RuntimeVariableCacheContext->RuntimeVolatileCache,
+                 RuntimeVariableCacheContext->RuntimeNvCache,
+                 RuntimeVariableCacheContext->PendingUpdate,
+                 RuntimeVariableCacheContext->ReadLock,
+                 RuntimeVariableCacheContext->HobFlushComplete
+                 );
       break;
 
     case SMM_VARIABLE_FUNCTION_SYNC_RUNTIME_CACHE:
-      Status = mVariableStorage->SyncCache ();
+      Status = VariableStorageRouterLibSyncCache ();
       break;
 
     case SMM_VARIABLE_FUNCTION_GET_RUNTIME_CACHE_INFO:
@@ -761,13 +625,13 @@ SmmVariableHandler (
 
       GetRuntimeCacheInfo = (SMM_VARIABLE_COMMUNICATE_GET_RUNTIME_CACHE_INFO *)SmmVariableFunctionHeader->Data;
 
-      GetRuntimeCacheInfo->AuthenticatedVariableUsage = mVariableStorage->CheckAuthFormat ();
+      GetRuntimeCacheInfo->AuthenticatedVariableUsage = VariableStorageRouterLibCheckAuthFormat ();
 
-      Status = mVariableStorage->GetCacheInfo (
-                                   &GetRuntimeCacheInfo->TotalHobStorageSize,
-                                   &GetRuntimeCacheInfo->TotalVolatileStorageSize,
-                                   &GetRuntimeCacheInfo->TotalNvStorageSize
-                                   );
+      Status = VariableStorageRouterLibGetCacheInfo (
+                 &GetRuntimeCacheInfo->TotalHobStorageSize,
+                 &GetRuntimeCacheInfo->TotalVolatileStorageSize,
+                 &GetRuntimeCacheInfo->TotalNvStorageSize
+                 );
       break;
 
     default:
@@ -803,7 +667,7 @@ SmmEndOfDxeCallback (
 
   if (!mEndOfDxe) {
     mEndOfDxe = TRUE;
-    return mVariableStorage->EndOfDxe ();
+    return VariableStorageRouterLibEndOfDxe ();
   }
 
   return EFI_SUCCESS;
@@ -828,13 +692,6 @@ MmVariableServiceInitialize (
   EFI_HANDLE  VariableHandle;
   VOID        *SmmEndOfDxeRegistration;
 
-  Status = gMmst->MmLocateProtocol (
-                    &gEdkiiVariableStorageProtocolGuid,
-                    NULL,
-                    (VOID **)&mVariableStorage
-                    );
-  ASSERT_EFI_ERROR (Status);
-
   //
   // Install the Smm Variable Protocol on a new handle.
   //
@@ -847,7 +704,7 @@ MmVariableServiceInitialize (
                             );
   ASSERT_EFI_ERROR (Status);
 
-  mVariableBufferPayloadSize = mVariableStorage->GetMaxVariableSize () +
+  mVariableBufferPayloadSize = VariableStorageRouterLibGetMaxVariableSize () +
                                OFFSET_OF (SMM_VARIABLE_COMMUNICATE_VAR_CHECK_VARIABLE_PROPERTY, Name) -
                                GetVariableHeaderSize ();
 
@@ -883,7 +740,7 @@ MmVariableServiceInitialize (
   //
   // Notify the variable wrapper driver the variable service is ready
   //
-  Status = mVariableStorage->InitWriteService (VariableNotifySmmWriteReady);
+  Status = VariableStorageRouterLibInitWriteService (VariableNotifySmmWriteReady);
   ASSERT_EFI_ERROR (Status);
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
@@ -20,6 +20,7 @@
 #
 # Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
+# Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -42,111 +43,40 @@
 
 
 [Sources]
-  Reclaim.c
-  Variable.c
-  VariableTraditionalMm.c
-  VariableSmm.c
-  VariableNonVolatile.c
-  VariableNonVolatile.h
-  VariableParsing.c
-  VariableParsing.h
-  VariableRuntimeCache.c
-  VariableRuntimeCache.h
-  VarCheck.c
-  Variable.h
   PrivilegePolymorphic.h
-  VariableExLib.c
-  TcgMorLockSmm.c
   SpeculationBarrierSmm.c
-  VariableLockRequestToLock.c
+  VariableSmm.c
+  VariableTraditionalMm.c
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
 
 [LibraryClasses]
-  UefiDriverEntryPoint
-  MemoryAllocationLib
   BaseLib
-  SynchronizationLib
-  UefiLib
-  MmServicesTableLib
   BaseMemoryLib
   DebugLib
   DxeServicesTableLib
-  HobLib
-  PcdLib
-  SmmMemLib
-  AuthVariableLib
-  VarCheckLib
+  MemoryAllocationLib
+  MmServicesTableLib
   UefiBootServicesTableLib
-  VariableFlashInfoLib
-  VariablePolicyLib
-  VariablePolicyHelperLib
+  UefiDriverEntryPoint
+  UefiLib
   SafeIntLib
+  SmmMemLib
 
 [Protocols]
-  gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES
-  ## CONSUMES
-  ## NOTIFY
-  gEfiSmmFaultTolerantWriteProtocolGuid
   ## PRODUCES
   ## UNDEFINED # SmiHandlerRegister
   gEfiSmmVariableProtocolGuid
   gEfiMmEndOfDxeProtocolGuid                    ## NOTIFY
-  gEdkiiSmmVarCheckProtocolGuid                 ## PRODUCES
-  gEfiTcgProtocolGuid                           ## SOMETIMES_CONSUMES
-  gEfiTcg2ProtocolGuid                          ## SOMETIMES_CONSUMES
+  gEdkiiVariableStorageProtocolGuid             ## COUNSUMES
 
 [Guids]
-  ## SOMETIMES_CONSUMES   ## GUID # Signature of Variable store header
-  ## SOMETIMES_PRODUCES   ## GUID # Signature of Variable store header
-  ## SOMETIMES_CONSUMES   ## HOB
-  ## SOMETIMES_PRODUCES   ## SystemTable
-  gEfiAuthenticatedVariableGuid
-
-  ## SOMETIMES_CONSUMES   ## GUID # Signature of Variable store header
-  ## SOMETIMES_PRODUCES   ## GUID # Signature of Variable store header
-  ## SOMETIMES_CONSUMES   ## HOB
-  ## SOMETIMES_PRODUCES   ## SystemTable
-  gEfiVariableGuid
-
-  ## SOMETIMES_CONSUMES   ## Variable:L"PlatformLang"
-  ## SOMETIMES_PRODUCES   ## Variable:L"PlatformLang"
-  ## SOMETIMES_CONSUMES   ## Variable:L"Lang"
-  ## SOMETIMES_PRODUCES   ## Variable:L"Lang"
-  gEfiGlobalVariableGuid
-
-  gEfiMemoryOverwriteControlDataGuid            ## SOMETIMES_CONSUMES   ## Variable:L"MemoryOverwriteRequestControl"
-  gEfiMemoryOverwriteRequestControlLockGuid     ## SOMETIMES_PRODUCES   ## Variable:L"MemoryOverwriteRequestControlLock"
-
-  gSmmVariableWriteGuid                         ## PRODUCES             ## GUID # Install protocol
-  gEfiSystemNvDataFvGuid                        ## CONSUMES             ## GUID
-  gEdkiiFaultTolerantWriteGuid                  ## SOMETIMES_CONSUMES   ## HOB
-
-  ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
-  ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"
-  gEdkiiVarErrorFlagGuid
-
-[Pcd]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize                  ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxAuthVariableSize              ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVolatileVariableSize          ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxHardwareErrorVariableSize     ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize                ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHwErrStorageSize                 ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxUserNvVariableSpaceSize           ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdBoottimeReservedNvVariableSpaceSize  ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdReclaimVariableSpaceAtEndOfDxe   ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable          ## SOMETIMES_CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved       ## SOMETIMES_CONSUMES
-
-[FeaturePcd]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableCollectStatistics        ## CONSUMES  # statistic the information of variable.
-  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLangDeprecate       ## CONSUMES  # Auto update PlatformLang/Lang
+  gSmmVariableWriteGuid                        ## PRODUCES             ## GUID # Install protocol
 
 [Depex]
-  TRUE
+  gEdkiiVariableStorageProtocolGuid
 
 [UserExtensions.TianoCore."ExtraFiles"]
   VariableSmmExtra.uni

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
@@ -64,6 +64,7 @@
   UefiLib
   SafeIntLib
   SmmMemLib
+  VariableStorageRouterLib
 
 [Protocols]
   ## PRODUCES
@@ -76,7 +77,7 @@
   gSmmVariableWriteGuid                        ## PRODUCES             ## GUID # Install protocol
 
 [Depex]
-  gEdkiiVariableStorageProtocolGuid
+  TRUE
 
 [UserExtensions.TianoCore."ExtraFiles"]
   VariableSmmExtra.uni

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.c
@@ -4,6 +4,7 @@
 
 Copyright (c) 2011 - 2024, Intel Corporation. All rights reserved. <BR>
 Copyright (c) 2018, Linaro, Ltd. All rights reserved. <BR>
+Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -99,18 +100,4 @@ VariableServiceInitialize (
   )
 {
   return MmVariableServiceInitialize ();
-}
-
-/**
-  Whether the MOR variable is legitimate or not.
-
-  @retval TRUE  MOR Variable is legitimate.
-  @retval FALSE MOR Variable in not legitimate.
-**/
-BOOLEAN
-VariableIsMorVariableLegitimate (
-  VOID
-  )
-{
-  return TRUE;
 }

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -21,6 +21,7 @@
 # Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
 # Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.
+# Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -35,23 +36,10 @@
   ENTRY_POINT                    = VariableServiceInitialize
 
 [Sources]
-  Reclaim.c
-  Variable.c
+  PrivilegePolymorphic.h
+  SpeculationBarrierSmm.c
   VariableSmm.c
   VariableStandaloneMm.c
-  VariableNonVolatile.c
-  VariableNonVolatile.h
-  VariableParsing.c
-  VariableParsing.h
-  VariableRuntimeCache.c
-  VariableRuntimeCache.h
-  VarCheck.c
-  Variable.h
-  PrivilegePolymorphic.h
-  VariableExLib.c
-  TcgMorLockSmm.c
-  SpeculationBarrierSmm.c
-  VariableLockRequestToLock.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -59,79 +47,25 @@
   StandaloneMmPkg/StandaloneMmPkg.dec
 
 [LibraryClasses]
-  AuthVariableLib
   BaseLib
   BaseMemoryLib
   DebugLib
-  HobLib
   MemLib
   MemoryAllocationLib
   MmServicesTableLib
   SafeIntLib
   StandaloneMmDriverEntryPoint
   SynchronizationLib
-  VarCheckLib
-  VariableFlashInfoLib
-  VariablePolicyLib
-  VariablePolicyHelperLib
 
 [Protocols]
-  gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES
-  ## CONSUMES
-  ## NOTIFY
-  gEfiSmmFaultTolerantWriteProtocolGuid
   ## PRODUCES
   ## UNDEFINED # SmiHandlerRegister
   gEfiSmmVariableProtocolGuid
   gEfiMmEndOfDxeProtocolGuid                   ## NOTIFY
-  gEdkiiSmmVarCheckProtocolGuid                ## PRODUCES
+  gEdkiiVariableStorageProtocolGuid            ## COUNSUMES
 
 [Guids]
-  ## SOMETIMES_CONSUMES   ## GUID # Signature of Variable store header
-  ## SOMETIMES_PRODUCES   ## GUID # Signature of Variable store header
-  ## SOMETIMES_CONSUMES   ## HOB
-  ## SOMETIMES_PRODUCES   ## SystemTable
-  gEfiAuthenticatedVariableGuid
-
-  ## SOMETIMES_CONSUMES   ## GUID # Signature of Variable store header
-  ## SOMETIMES_PRODUCES   ## GUID # Signature of Variable store header
-  ## SOMETIMES_CONSUMES   ## HOB
-  ## SOMETIMES_PRODUCES   ## SystemTable
-  gEfiVariableGuid
-
-  ## SOMETIMES_CONSUMES   ## Variable:L"PlatformLang"
-  ## SOMETIMES_PRODUCES   ## Variable:L"PlatformLang"
-  ## SOMETIMES_CONSUMES   ## Variable:L"Lang"
-  ## SOMETIMES_PRODUCES   ## Variable:L"Lang"
-  gEfiGlobalVariableGuid
-
-  gEfiMemoryOverwriteControlDataGuid            ## SOMETIMES_CONSUMES   ## Variable:L"MemoryOverwriteRequestControl"
-  gEfiMemoryOverwriteRequestControlLockGuid     ## SOMETIMES_PRODUCES   ## Variable:L"MemoryOverwriteRequestControlLock"
-
-  gSmmVariableWriteGuid                         ## PRODUCES             ## GUID # Install protocol
-  gEfiSystemNvDataFvGuid                        ## CONSUMES             ## GUID
-  gEdkiiFaultTolerantWriteGuid                  ## SOMETIMES_CONSUMES   ## HOB
-
-  ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
-  ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"
-  gEdkiiVarErrorFlagGuid
-
-[Pcd]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize                  ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxAuthVariableSize              ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVolatileVariableSize          ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxHardwareErrorVariableSize     ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize                ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHwErrStorageSize                 ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxUserNvVariableSpaceSize           ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdBoottimeReservedNvVariableSpaceSize  ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdReclaimVariableSpaceAtEndOfDxe   ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable          ## SOMETIMES_CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved       ## SOMETIMES_CONSUMES
-
-[FeaturePcd]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableCollectStatistics        ## CONSUMES  # statistic the information of variable.
-  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLangDeprecate       ## CONSUMES  # Auto update PlatformLang/Lang
+  gSmmVariableWriteGuid                        ## PRODUCES             ## GUID # Install protocol
 
 [Depex]
-  TRUE
+  gEdkiiVariableStorageProtocolGuid

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -56,16 +56,16 @@
   SafeIntLib
   StandaloneMmDriverEntryPoint
   SynchronizationLib
+  VariableStorageRouterLib
 
 [Protocols]
   ## PRODUCES
   ## UNDEFINED # SmiHandlerRegister
   gEfiSmmVariableProtocolGuid
   gEfiMmEndOfDxeProtocolGuid                   ## NOTIFY
-  gEdkiiVariableStorageProtocolGuid            ## COUNSUMES
 
 [Guids]
   gSmmVariableWriteGuid                        ## PRODUCES             ## GUID # Install protocol
 
 [Depex]
-  gEdkiiVariableStorageProtocolGuid
+  TRUE

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbSmm.c
@@ -1,0 +1,1148 @@
+/** @file
+  Base Variable Storage Lib for Smm.
+
+
+Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
+Copyright (c) 2026, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Protocol/SmmFirmwareVolumeBlock.h>
+#include <Protocol/SmmFaultTolerantWrite.h>
+#include <Protocol/MmEndOfDxe.h>
+#include <Protocol/SmmVarCheck.h>
+#include <Protocol/VariableStorage.h>
+
+#include <Library/MmServicesTableLib.h>
+#include <Library/VariablePolicyLib.h>
+
+#include "Variable.h"
+#include "VariableParsing.h"
+#include "VariableRuntimeCache.h"
+
+STATIC BOOLEAN                mAtRuntime                = FALSE;
+STATIC BOOLEAN                mVariablePolicyLocked     = FALSE;
+STATIC WRITE_READY_NOTIFY_FN  mVariableWriteReadyNotify = NULL;
+
+STATIC EDKII_SMM_VAR_CHECK_PROTOCOL  mSmmVarCheck = {
+  VarCheckRegisterSetVariableCheckHandler,
+  VarCheckVariablePropertySet,
+  VarCheckVariablePropertyGet
+};
+
+/**
+  Return TRUE if ExitBootServices () has been called.
+
+  @retval TRUE If ExitBootServices () has been called.
+**/
+BOOLEAN
+AtRuntime (
+  VOID
+  )
+{
+  return mAtRuntime;
+}
+
+/**
+  SecureBoot Hook for SetVariable.
+
+  @param[in] VariableName                 Name of Variable to be found.
+  @param[in] VendorGuid                   Variable vendor GUID.
+
+**/
+VOID
+EFIAPI
+SecureBootHook (
+  IN CHAR16    *VariableName,
+  IN EFI_GUID  *VendorGuid
+  )
+{
+  return;
+}
+
+/**
+  Initializes variable write service for SMM.
+
+**/
+STATIC
+VOID
+EFIAPI
+VariableWriteServiceInitializeSmm (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = VariableWriteServiceInitialize ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Variable write service initialization failed. Status = %r\n", Status));
+  }
+
+  //
+  // Notify the variable wrapper driver the variable write service is ready
+  //
+  if (mVariableWriteReadyNotify != NULL) {
+    mVariableWriteReadyNotify ();
+  }
+}
+
+/**
+  Lock Variable Policy and Reclaim Variable.
+
+  @param[in] EndOfDxe        This function is called at EndOfDxe phase.
+
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+VariableLockPolicyAndReclaimVariable (
+  BOOLEAN  EndOfDxe
+  )
+{
+  EFI_STATUS  Status;
+
+  if (!mVariablePolicyLocked) {
+    MorLockInitAtEndOfDxe ();
+    Status = LockVariablePolicy ();
+    if (EFI_ERROR (Status)) {
+      ASSERT_EFI_ERROR (Status);
+      return Status;
+    }
+
+    mVariablePolicyLocked = TRUE;
+    VarCheckLibInitializeAtEndOfDxe (NULL);
+    //
+    // The initialization for variable quota.
+    //
+    InitializeVariableQuota ();
+  }
+
+  if (!EndOfDxe || PcdGetBool (PcdReclaimVariableSpaceAtEndOfDxe)) {
+    ReclaimForOS ();
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Notification handler after gEfiSmmVariableProtocolGuid is installed.
+
+  @param  Protocol   Points to the protocol's unique identifier
+  @param  Interface  Points to the interface instance
+  @param  Handle     The handle on which the interface was installed
+
+  @retval EFI_SUCCESS
+  @retval Others     Errors
+
+ **/
+STATIC
+EFI_STATUS
+EFIAPI
+VariableProtocolInstallNotify (
+  IN CONST EFI_GUID  *Protocol,
+  IN VOID            *Interface,
+  IN EFI_HANDLE      Handle
+  )
+{
+  return gMmst->MmInstallProtocolInterface (
+                  &Handle,
+                  &gEdkiiSmmVarCheckProtocolGuid,
+                  EFI_NATIVE_INTERFACE,
+                  &mSmmVarCheck
+                  );
+}
+
+/**
+  Retrieve the SMM FVB protocol interface by HANDLE.
+
+  @param[in]  FvBlockHandle     The handle of SMM FVB protocol that provides services for
+                                reading, writing, and erasing the target block.
+  @param[out] FvBlock           The interface of SMM FVB protocol
+
+  @retval EFI_SUCCESS           The interface information for the specified protocol was returned.
+  @retval EFI_UNSUPPORTED       The device does not support the SMM FVB protocol.
+  @retval EFI_INVALID_PARAMETER FvBlockHandle is not a valid EFI_HANDLE or FvBlock is NULL.
+
+**/
+EFI_STATUS
+GetFvbByHandle (
+  IN  EFI_HANDLE                          FvBlockHandle,
+  OUT EFI_FIRMWARE_VOLUME_BLOCK_PROTOCOL  **FvBlock
+  )
+{
+  //
+  // To get the SMM FVB protocol interface on the handle
+  //
+  return gMmst->MmHandleProtocol (
+                  FvBlockHandle,
+                  &gEfiSmmFirmwareVolumeBlockProtocolGuid,
+                  (VOID **)FvBlock
+                  );
+}
+
+/**
+  Retrieve the SMM Fault Tolerant Write protocol interface.
+
+  @param[out] FtwProtocol       The interface of SMM Ftw protocol
+
+  @retval EFI_SUCCESS           The SMM FTW protocol instance was found and returned in FtwProtocol.
+  @retval EFI_NOT_FOUND         The SMM FTW protocol instance was not found.
+  @retval EFI_INVALID_PARAMETER SarProtocol is NULL.
+
+**/
+EFI_STATUS
+GetFtwProtocol (
+  OUT VOID  **FtwProtocol
+  )
+{
+  EFI_STATUS  Status;
+
+  //
+  // Locate Smm Fault Tolerant Write protocol
+  //
+  Status = gMmst->MmLocateProtocol (
+                    &gEfiSmmFaultTolerantWriteProtocolGuid,
+                    NULL,
+                    FtwProtocol
+                    );
+  return Status;
+}
+
+/**
+  SMM Fault Tolerant Write protocol notification event handler.
+
+  Non-Volatile variable write may needs FTW protocol to reclaim when
+  writing variable.
+
+  @param  Protocol   Points to the protocol's unique identifier
+  @param  Interface  Points to the interface instance
+  @param  Handle     The handle on which the interface was installed
+
+  @retval EFI_SUCCESS   SmmEventCallback runs successfully
+  @retval EFI_NOT_FOUND The Fvb protocol for variable is not found.
+
+ **/
+EFI_STATUS
+EFIAPI
+SmmFtwNotificationEvent (
+  IN CONST EFI_GUID  *Protocol,
+  IN VOID            *Interface,
+  IN EFI_HANDLE      Handle
+  )
+{
+  EFI_STATUS                              Status;
+  EFI_PHYSICAL_ADDRESS                    VariableStoreBase;
+  EFI_SMM_FIRMWARE_VOLUME_BLOCK_PROTOCOL  *FvbProtocol;
+  EFI_SMM_FAULT_TOLERANT_WRITE_PROTOCOL   *FtwProtocol;
+  EFI_PHYSICAL_ADDRESS                    NvStorageVariableBase;
+  UINTN                                   FtwMaxBlockSize;
+  UINT32                                  NvStorageVariableSize;
+  UINT64                                  NvStorageVariableSize64;
+
+  if (mVariableModuleGlobal->FvbInstance != NULL) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Ensure SMM FTW protocol is installed.
+  //
+  Status = GetFtwProtocol ((VOID **)&FtwProtocol);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = GetVariableFlashNvStorageInfo (&NvStorageVariableBase, &NvStorageVariableSize64);
+  ASSERT_EFI_ERROR (Status);
+
+  Status = SafeUint64ToUint32 (NvStorageVariableSize64, &NvStorageVariableSize);
+  // This driver currently assumes the size will be UINT32 so assert the value is safe for now.
+  ASSERT_EFI_ERROR (Status);
+
+  ASSERT (NvStorageVariableBase != 0);
+  VariableStoreBase = NvStorageVariableBase + mNvFvHeaderCache->HeaderLength;
+
+  Status = FtwProtocol->GetMaxBlockSize (FtwProtocol, &FtwMaxBlockSize);
+  if (!EFI_ERROR (Status)) {
+    ASSERT (NvStorageVariableSize <= FtwMaxBlockSize);
+  }
+
+  //
+  // Let NonVolatileVariableBase point to flash variable store base directly after FTW ready.
+  //
+  mVariableModuleGlobal->VariableGlobal.NonVolatileVariableBase = VariableStoreBase;
+
+  //
+  // Find the proper FVB protocol for variable.
+  //
+  Status = GetFvbInfoByAddress (NvStorageVariableBase, NULL, &FvbProtocol);
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_FOUND;
+  }
+
+  mVariableModuleGlobal->FvbInstance = FvbProtocol;
+
+  //
+  // Initializes variable write service after FTW was ready.
+  //
+  VariableWriteServiceInitializeSmm ();
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Initializes a basic mutual exclusion lock.
+
+  This function initializes a basic mutual exclusion lock to the released state
+  and returns the lock.  Each lock provides mutual exclusion access at its task
+  priority level.  Since there is no preemption or multiprocessor support in EFI,
+  acquiring the lock only consists of raising to the locks TPL.
+  If Lock is NULL, then ASSERT().
+  If Priority is not a valid TPL value, then ASSERT().
+
+  @param  Lock       A pointer to the lock data structure to initialize.
+  @param  Priority   EFI TPL is associated with the lock.
+
+  @return The lock.
+
+**/
+EFI_LOCK *
+InitializeLock (
+  IN OUT EFI_LOCK  *Lock,
+  IN EFI_TPL       Priority
+  )
+{
+  return Lock;
+}
+
+/**
+  Acquires lock only at boot time. Simply returns at runtime.
+
+  This is a temporary function that will be removed when
+  EfiAcquireLock() in UefiLib can handle the call in UEFI
+  Runtime driver in RT phase.
+  It calls EfiAcquireLock() at boot time, and simply returns
+  at runtime.
+
+  @param  Lock         A pointer to the lock to acquire.
+
+**/
+VOID
+AcquireLockOnlyAtBootTime (
+  IN EFI_LOCK  *Lock
+  )
+{
+}
+
+/**
+  Releases lock only at boot time. Simply returns at runtime.
+
+  This is a temporary function which will be removed when
+  EfiReleaseLock() in UefiLib can handle the call in UEFI
+  Runtime driver in RT phase.
+  It calls EfiReleaseLock() at boot time and simply returns
+  at runtime.
+
+  @param  Lock         A pointer to the lock to release.
+
+**/
+VOID
+ReleaseLockOnlyAtBootTime (
+  IN EFI_LOCK  *Lock
+  )
+{
+}
+
+/**
+  Function returns an array of handles that support the SMM FVB protocol
+  in a buffer allocated from pool.
+
+  @param[out]  NumberHandles    The number of handles returned in Buffer.
+  @param[out]  Buffer           A pointer to the buffer to return the requested
+                                array of  handles that support SMM FVB protocol.
+
+  @retval EFI_SUCCESS           The array of handles was returned in Buffer, and the number of
+                                handles in Buffer was returned in NumberHandles.
+  @retval EFI_NOT_FOUND         No SMM FVB handle was found.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough pool memory to store the matching results.
+  @retval EFI_INVALID_PARAMETER NumberHandles is NULL or Buffer is NULL.
+
+**/
+EFI_STATUS
+GetFvbCountAndBuffer (
+  OUT UINTN       *NumberHandles,
+  OUT EFI_HANDLE  **Buffer
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       BufferSize;
+
+  if ((NumberHandles == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  BufferSize     = 0;
+  *NumberHandles = 0;
+  *Buffer        = NULL;
+  Status         = gMmst->MmLocateHandle (
+                            ByProtocol,
+                            &gEfiSmmFirmwareVolumeBlockProtocolGuid,
+                            NULL,
+                            &BufferSize,
+                            *Buffer
+                            );
+  if (EFI_ERROR (Status) && (Status != EFI_BUFFER_TOO_SMALL)) {
+    return EFI_NOT_FOUND;
+  }
+
+  *Buffer = AllocatePool (BufferSize);
+  if (*Buffer == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = gMmst->MmLocateHandle (
+                    ByProtocol,
+                    &gEfiSmmFirmwareVolumeBlockProtocolGuid,
+                    NULL,
+                    &BufferSize,
+                    *Buffer
+                    );
+
+  *NumberHandles = BufferSize / sizeof (EFI_HANDLE);
+  if (EFI_ERROR (Status)) {
+    *NumberHandles = 0;
+    FreePool (*Buffer);
+    *Buffer = NULL;
+  }
+
+  return Status;
+}
+
+/**
+  Check whether Variable storage use Auth Format.
+
+  @return TRUE    Use Auth format.
+  @return FALSE   Not use Auth format.
+
+**/
+BOOLEAN
+EFIAPI
+VariableStorageFvbCheckAuthFormat (
+  VOID
+  )
+{
+  return mVariableModuleGlobal->VariableGlobal.AuthFormat;
+}
+
+/**
+  Get maximum variable size, covering both non-volatile and volatile variables.
+
+  @return Maximum variable size.
+
+**/
+UINTN
+EFIAPI
+VariableStorageFvbGetMaxVariableSize (
+  VOID
+  )
+{
+  return GetMaxVariableSize ();
+}
+
+/**
+
+  This code finds variable in storage blocks (Volatile or Non-Volatile).
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize is external input.
+  This function will do basic validation, before parse the data.
+
+  @param VariableName               Name of Variable to be found.
+  @param VendorGuid                 Variable vendor GUID.
+  @param Attributes                 Attribute value of the variable found.
+  @param DataSize                   Size of Data found. If size is less than the
+                                    data, this value contains the required size.
+  @param Data                       The buffer to return the contents of the variable. May be NULL
+                                    with a zero DataSize in order to determine the size buffer needed.
+
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER     The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION    The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbGetVariable (
+  IN      CHAR16    *VariableName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINT32    *Attributes OPTIONAL,
+  IN OUT  UINTN     *DataSize,
+  OUT     VOID      *Data OPTIONAL
+  )
+{
+  return VariableServiceGetVariable (
+           VariableName,
+           VendorGuid,
+           Attributes,
+           DataSize,
+           Data
+           );
+}
+
+/**
+
+  This code Finds the Next available variable.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode. This function will do basic validation, before parse the data.
+
+  @param VariableNameSize           The size of the VariableName buffer. The size must be large
+                                    enough to fit input string supplied in VariableName buffer.
+  @param VariableName               Pointer to variable name.
+  @param VendorGuid                 Variable Vendor Guid.
+
+  @retval EFI_SUCCESS               The function completed successfully.
+  @retval EFI_NOT_FOUND             The next variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL      The VariableNameSize is too small for the result.
+                                    VariableNameSize has been updated with the size needed to complete the request.
+  @retval EFI_INVALID_PARAMETER     VariableNameSize is NULL.
+  @retval EFI_INVALID_PARAMETER     VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER     VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER     The input values of VariableName and VendorGuid are not a name and
+                                    GUID of an existing variable.
+  @retval EFI_INVALID_PARAMETER     Null-terminator is not found in the first VariableNameSize bytes of
+                                    the input VariableName buffer.
+  @retval EFI_DEVICE_ERROR          The variable could not be retrieved due to a hardware error.
+  @retval EFI_UNSUPPORTED           After ExitBootServices() has been called, this return code may be returned
+                                    if no variable storage is supported. The platform should describe this
+                                    runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                    configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbGetNextVariableName (
+  IN OUT  UINTN     *VariableNameSize,
+  IN OUT  CHAR16    *VariableName,
+  IN OUT  EFI_GUID  *VendorGuid
+  )
+{
+  return VariableServiceGetNextVariableName (
+           VariableNameSize,
+           VariableName,
+           VendorGuid
+           );
+}
+
+/**
+
+  This code sets variable in storage blocks (Volatile or Non-Volatile).
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize and data are external input.
+  This function will do basic validation, before parse the data.
+  This function will parse the authentication carefully to avoid security issues, like
+  buffer overflow, integer overflow.
+  This function will check attribute carefully to avoid authentication bypass.
+
+  @param VariableName                     Name of Variable to be found.
+  @param VendorGuid                       Variable vendor GUID.
+  @param Attributes                       Attribute value of the variable found
+  @param DataSize                         Size of Data found. If size is less than the
+                                          data, this value contains the required size.
+  @param Data                             Data pointer.
+  @param FromTrusted                      Whether request comes from trusted.
+
+  @retval EFI_SUCCESS                     The function completed successfully.
+  @retval EFI_NOT_FOUND                   The variable was not found.
+  @retval EFI_BUFFER_TOO_SMALL            The DataSize is too small for the result.
+  @retval EFI_INVALID_PARAMETER           VariableName is NULL.
+  @retval EFI_INVALID_PARAMETER           VendorGuid is NULL.
+  @retval EFI_INVALID_PARAMETER           DataSize is NULL.
+  @retval EFI_INVALID_PARAMETER           The DataSize is not too small and Data is NULL.
+  @retval EFI_DEVICE_ERROR                The variable could not be retrieved due to a hardware error.
+  @retval EFI_SECURITY_VIOLATION          The variable could not be retrieved due to an authentication failure.
+  @retval EFI_UNSUPPORTED                 After ExitBootServices() has been called, this return code may be returned
+                                          if no variable storage is supported. The platform should describe this
+                                          runtime service as unsupported at runtime via an EFI_RT_PROPERTIES_TABLE
+                                          configuration table.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbSetVariable (
+  IN CHAR16    *VariableName,
+  IN EFI_GUID  *VendorGuid,
+  IN UINT32    Attributes,
+  IN UINTN     DataSize,
+  IN VOID      *Data,
+  IN BOOLEAN   FromTrusted
+  )
+{
+  EFI_STATUS  Status;
+
+  //
+  // Disable write protection when the calling SetVariable() through EFI_SMM_VARIABLE_PROTOCOL.
+  //
+  if (FromTrusted) {
+    mRequestSource = VarCheckFromTrusted;
+  }
+
+  Status = VariableServiceSetVariable (
+             VariableName,
+             VendorGuid,
+             Attributes,
+             DataSize,
+             Data
+             );
+
+  if (FromTrusted) {
+    mRequestSource = VarCheckFromUntrusted;
+  }
+
+  return Status;
+}
+
+/**
+  This code returns information about the EFI variables.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode. This function will do basic validation, before parse the data.
+
+  @param Attributes                     Attributes bitmask to specify the type of variables
+                                        on which to return information.
+  @param MaximumVariableStorageSize     Pointer to the maximum size of the storage space available
+                                        for the EFI variables associated with the attributes specified.
+  @param RemainingVariableStorageSize   Pointer to the remaining size of the storage space available
+                                        for EFI variables associated with the attributes specified.
+  @param MaximumVariableSize            Pointer to the maximum size of an individual EFI variables
+                                        associated with the attributes specified.
+
+  @return EFI_INVALID_PARAMETER         An invalid combination of attribute bits was supplied.
+  @return EFI_SUCCESS                   Query successfully.
+  @return EFI_UNSUPPORTED               The attribute is not supported on this platform.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbQueryVariableInfo (
+  IN  UINT32  Attributes,
+  OUT UINT64  *MaximumVariableStorageSize,
+  OUT UINT64  *RemainingVariableStorageSize,
+  OUT UINT64  *MaximumVariableSize
+  )
+{
+  return VariableServiceQueryVariableInfo (
+           Attributes,
+           MaximumVariableStorageSize,
+           RemainingVariableStorageSize,
+           MaximumVariableSize
+           );
+}
+
+/**
+  Callback function at End of DXE phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbEndOfDxe (
+  IN VOID
+  )
+{
+  mEndOfDxe = TRUE;
+  return VariableLockPolicyAndReclaimVariable (TRUE);
+}
+
+/**
+  Callback function at READY_TO_BOOT phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbReadyToBoot (
+  IN VOID
+  )
+{
+  if (mAtRuntime) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (!mEndOfDxe) {
+    mEndOfDxe = TRUE;
+  }
+
+  return VariableLockPolicyAndReclaimVariable (FALSE);
+}
+
+/**
+  Callback function for EXIT_BOOT phase notification.
+
+  @return EFI_SUCCESS
+  @return Others                   ERROR.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbExitBootService (
+  IN VOID
+  )
+{
+  mAtRuntime = TRUE;
+  return EFI_SUCCESS;
+}
+
+/**
+  Get the variable statistics information from the information buffer pointed by gVariableInfo.
+
+  Caution: This function may be invoked at SMM runtime.
+  InfoEntry and InfoSize are external input. Care must be taken to make sure not security issue at runtime.
+
+  @param[in, out]  InfoEntry    A pointer to the buffer of variable information entry.
+                                On input, point to the variable information returned last time. if
+                                InfoEntry->VendorGuid is zero, return the first information.
+                                On output, point to the next variable information.
+  @param[in, out]  InfoSize     On input, the size of the variable information buffer.
+                                On output, the returned variable information size.
+
+  @retval EFI_SUCCESS           The variable information is found and returned successfully.
+  @retval EFI_UNSUPPORTED       No variable information exists in variable driver.
+  @retval EFI_BUFFER_TOO_SMALL  The buffer is too small to hold the next variable information.
+  @retval EFI_INVALID_PARAMETER Input parameter is invalid.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbGetStatics (
+  IN OUT VARIABLE_INFO_ENTRY  *InfoEntry,
+  IN OUT UINTN                *InfoSize
+  )
+{
+  VARIABLE_INFO_ENTRY  *VariableInfo;
+  UINTN                NameSize;
+  UINTN                StatisticsInfoSize;
+  CHAR16               *InfoName;
+  UINTN                InfoNameMaxSize;
+  EFI_GUID             VendorGuid;
+
+  if (InfoEntry == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  VariableInfo = gVariableInfo;
+  if (VariableInfo == NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  StatisticsInfoSize = sizeof (VARIABLE_INFO_ENTRY);
+  if (*InfoSize < StatisticsInfoSize) {
+    *InfoSize = StatisticsInfoSize;
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  InfoName        = (CHAR16 *)(InfoEntry + 1);
+  InfoNameMaxSize = (*InfoSize - sizeof (VARIABLE_INFO_ENTRY));
+
+  CopyGuid (&VendorGuid, &InfoEntry->VendorGuid);
+
+  if (IsZeroGuid (&VendorGuid)) {
+    //
+    // Return the first variable info
+    //
+    NameSize           = StrSize (VariableInfo->Name);
+    StatisticsInfoSize = sizeof (VARIABLE_INFO_ENTRY) + NameSize;
+    if (*InfoSize < StatisticsInfoSize) {
+      *InfoSize = StatisticsInfoSize;
+      return EFI_BUFFER_TOO_SMALL;
+    }
+
+    CopyMem (InfoEntry, VariableInfo, sizeof (VARIABLE_INFO_ENTRY));
+    CopyMem (InfoName, VariableInfo->Name, NameSize);
+    *InfoSize = StatisticsInfoSize;
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Get the next variable info
+  //
+  while (VariableInfo != NULL) {
+    if (CompareGuid (&VariableInfo->VendorGuid, &VendorGuid)) {
+      NameSize = StrSize (VariableInfo->Name);
+      if (NameSize <= InfoNameMaxSize) {
+        if (CompareMem (VariableInfo->Name, InfoName, NameSize) == 0) {
+          //
+          // Find the match one
+          //
+          VariableInfo = VariableInfo->Next;
+          break;
+        }
+      }
+    }
+
+    VariableInfo = VariableInfo->Next;
+  }
+
+  if (VariableInfo == NULL) {
+    *InfoSize = 0;
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Output the new variable info
+  //
+  NameSize           = StrSize (VariableInfo->Name);
+  StatisticsInfoSize = sizeof (VARIABLE_INFO_ENTRY) + NameSize;
+  if (*InfoSize < StatisticsInfoSize) {
+    *InfoSize = StatisticsInfoSize;
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  CopyMem (InfoEntry, VariableInfo, sizeof (VARIABLE_INFO_ENTRY));
+  CopyMem (InfoName, VariableInfo->Name, NameSize);
+  *InfoSize = StatisticsInfoSize;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Mark a variable that will become read-only after leaving the DXE phase of execution.
+
+  @param[in] VariableName  A pointer to the variable name that will be made read-only subsequently.
+  @param[in] VendorGuid    A pointer to the vendor GUID that will be made read-only subsequently.
+
+  @retval EFI_SUCCESS           The variable specified by the VariableName and the VendorGuid was marked
+                                as pending to be read-only.
+  @retval EFI_INVALID_PARAMETER VariableName or VendorGuid is NULL.
+                                Or VariableName is an empty string.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource to hold the lock request.
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbRequestToLock (
+  IN       CHAR16    *VariableName,
+  IN       EFI_GUID  *VendorGuid
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mEndOfDxe) {
+    Status = EFI_ACCESS_DENIED;
+  } else {
+    Status = VariableLockRequestToLock (
+               NULL,
+               VariableName,
+               VendorGuid
+               );
+  }
+
+  return Status;
+}
+
+/**
+  Variable property set.
+
+  @param[in] Name               Pointer to the variable name.
+  @param[in] Guid               Pointer to the vendor GUID.
+  @param[in] VariableProperty   Pointer to the input variable property.
+
+  @retval EFI_SUCCESS           The property of variable specified by the Name and Guid was set successfully.
+  @retval EFI_INVALID_PARAMETER Name, Guid or VariableProperty is NULL, or Name is an empty string,
+                                or the fields of VariableProperty are not valid.
+  @retval EFI_ACCESS_DENIED     EFI_END_OF_DXE_EVENT_GROUP_GUID or EFI_EVENT_GROUP_READY_TO_BOOT has
+                                already been signaled.
+  @retval EFI_OUT_OF_RESOURCES  There is not enough resource for the variable property set request.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbPropertySet (
+  IN CHAR16                       *Name,
+  IN EFI_GUID                     *Guid,
+  IN VAR_CHECK_VARIABLE_PROPERTY  *VariableProperty
+  )
+{
+  return VarCheckVariablePropertySet (
+           Name,
+           Guid,
+           VariableProperty
+           );
+}
+
+/**
+  Variable property get.
+
+  @param[in]  Name              Pointer to the variable name.
+  @param[in]  Guid              Pointer to the vendor GUID.
+  @param[out] VariableProperty  Pointer to the output variable property.
+
+  @retval EFI_SUCCESS           The property of variable specified by the Name and Guid was got successfully.
+  @retval EFI_INVALID_PARAMETER Name, Guid or VariableProperty is NULL, or Name is an empty string.
+  @retval EFI_NOT_FOUND         The property of variable specified by the Name and Guid was not found.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbPropertyGet (
+  IN CHAR16                        *Name,
+  IN EFI_GUID                      *Guid,
+  OUT VAR_CHECK_VARIABLE_PROPERTY  *VariableProperty
+  )
+{
+  return VarCheckVariablePropertyGet (
+           Name,
+           Guid,
+           VariableProperty
+           );
+}
+
+/**
+  Initialise Variable Runtime Cache.
+
+  @param[in]   HobCache             Address of cache for variables in HobList.
+  @param[in]   VolatileCache        Address of cache for variables in  volatile memory.
+  @param[in]   NvCache              Address of cache for variables in  in non-volatile memory.
+  @param[in]   PendingUpdate        Address to bool to check pending update.
+  @param[in]   ReadLock             Address to bool to check read operation is locked.
+  @param[in]   HobFlushComplete     Address to bool to check flush hob is completed.
+
+  @return      EFI_SUCCESS
+  @return      EFI_UNSUPPORTED      Runtime variable cache isn't supported
+  @return      Others               Errors
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbInitCache (
+  IN  VARIABLE_STORE_HEADER  *HobCache,
+  IN  VARIABLE_STORE_HEADER  *VolatileCache,
+  IN  VARIABLE_STORE_HEADER  *NvCache,
+  IN  BOOLEAN                *PendingUpdate,
+  IN  BOOLEAN                *ReadLock,
+  IN  BOOLEAN                *HobFlushComplete
+  )
+{
+  VARIABLE_STORE_HEADER           *VariableCache;
+  VARIABLE_RUNTIME_CACHE_CONTEXT  *VariableCacheContext;
+
+  VariableCacheContext = &mVariableModuleGlobal->VariableGlobal.VariableRuntimeCacheContext;
+
+  VariableCacheContext->VariableRuntimeHobCache.Store      = HobCache;
+  VariableCacheContext->VariableRuntimeVolatileCache.Store = VolatileCache;
+  VariableCacheContext->VariableRuntimeNvCache.Store       = NvCache;
+  VariableCacheContext->PendingUpdate                      = PendingUpdate;
+  VariableCacheContext->ReadLock                           = ReadLock;
+  VariableCacheContext->HobFlushComplete                   = HobFlushComplete;
+
+  // Set up the initial pending request since the RT cache needs to be in sync with SMM cache
+  VariableCacheContext->VariableRuntimeHobCache.PendingUpdateOffset = 0;
+  VariableCacheContext->VariableRuntimeHobCache.PendingUpdateLength = 0;
+
+  if ((mVariableModuleGlobal->VariableGlobal.HobVariableBase > 0) &&
+      (VariableCacheContext->VariableRuntimeHobCache.Store != NULL))
+  {
+    VariableCache                                                     = (VARIABLE_STORE_HEADER *)(UINTN)mVariableModuleGlobal->VariableGlobal.HobVariableBase;
+    VariableCacheContext->VariableRuntimeHobCache.PendingUpdateLength = (UINT32)((UINTN)GetEndPointer (VariableCache) - (UINTN)VariableCache);
+    CopyGuid (&(VariableCacheContext->VariableRuntimeHobCache.Store->Signature), &(VariableCache->Signature));
+  }
+
+  VariableCache                                                          = (VARIABLE_STORE_HEADER  *)(UINTN)mVariableModuleGlobal->VariableGlobal.VolatileVariableBase;
+  VariableCacheContext->VariableRuntimeVolatileCache.PendingUpdateOffset = 0;
+  VariableCacheContext->VariableRuntimeVolatileCache.PendingUpdateLength = (UINT32)((UINTN)GetEndPointer (VariableCache) - (UINTN)VariableCache);
+  CopyGuid (&(VariableCacheContext->VariableRuntimeVolatileCache.Store->Signature), &(VariableCache->Signature));
+
+  VariableCache                                                    = (VARIABLE_STORE_HEADER  *)(UINTN)mNvVariableCache;
+  VariableCacheContext->VariableRuntimeNvCache.PendingUpdateOffset = 0;
+  VariableCacheContext->VariableRuntimeNvCache.PendingUpdateLength = (UINT32)((UINTN)GetEndPointer (VariableCache) - (UINTN)VariableCache);
+  CopyGuid (&(VariableCacheContext->VariableRuntimeNvCache.Store->Signature), &(VariableCache->Signature));
+
+  *(VariableCacheContext->PendingUpdate)    = TRUE;
+  *(VariableCacheContext->ReadLock)         = FALSE;
+  *(VariableCacheContext->HobFlushComplete) = FALSE;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Copies any pending updates to runtime variable caches.
+
+  @retval EFI_SUCCESS             The cache store was updated successfully.
+  @retval EFI_UNSUPPORTED         The cache store to be updated is not initialized properly.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbSyncCache (
+  VOID
+  )
+{
+  return FlushPendingRuntimeVariableCacheUpdates ();
+}
+
+/**
+  Get runtime variable caches info.
+
+  @param[out]    HobCacheSize                  Cache size of variables in Hob list.
+  @param[out]    VolatileCacheSize             Cache size of variables in volatile memory.
+  @param[out]    NvCacheSize                   Cache size of variables in non-volatile memory.
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbGetCacheInfo (
+  OUT UINTN  *HobCacheSize,
+  OUT UINTN  *VolatileCacheSize,
+  OUT UINTN  *NvCacheSize
+  )
+{
+  VARIABLE_STORE_HEADER  *VariableCache;
+
+  if (mVariableModuleGlobal->VariableGlobal.HobVariableBase > 0) {
+    VariableCache = (VARIABLE_STORE_HEADER *)(UINTN)mVariableModuleGlobal->VariableGlobal.HobVariableBase;
+    *HobCacheSize = VariableCache->Size;
+  } else {
+    *HobCacheSize = 0;
+  }
+
+  VariableCache      = (VARIABLE_STORE_HEADER  *)(UINTN)mVariableModuleGlobal->VariableGlobal.VolatileVariableBase;
+  *VolatileCacheSize = VariableCache->Size;
+
+  VariableCache = (VARIABLE_STORE_HEADER  *)(UINTN)mNvVariableCache;
+  *NvCacheSize  = (UINTN)VariableCache->Size;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Initialise Variable Write Service.
+  This function should install gSmmVariableWriteGuid or register notifier to install
+
+  @param[in] WriteReadyNotify   Notifier to be called when variables are
+                                writable.
+
+  @return EFI_SUCCESS
+  @return Others                Failed to initialise write service.
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbInitWriteService (
+  IN WRITE_READY_NOTIFY_FN  WriteReadyNotify
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *SmmFtwRegistration;
+
+  mVariableWriteReadyNotify = WriteReadyNotify;
+
+  if (!PcdGetBool (PcdEmuVariableNvModeEnable)) {
+    //
+    // Register FtwNotificationEvent () notify function.
+    //
+    Status = gMmst->MmRegisterProtocolNotify (
+                      &gEfiSmmFaultTolerantWriteProtocolGuid,
+                      SmmFtwNotificationEvent,
+                      &SmmFtwRegistration
+                      );
+    ASSERT_EFI_ERROR (Status);
+
+    SmmFtwNotificationEvent (NULL, NULL, NULL);
+  } else {
+    //
+    // Emulated non-volatile variable mode does not depend on FVB and FTW.
+    //
+    VariableWriteServiceInitializeSmm ();
+    Status = EFI_SUCCESS;
+  }
+
+  return Status;
+}
+
+STATIC EDKII_VARIABLE_STORAGE_PROTOCOL  mSmmVariableStorageFvb = {
+  VariableStorageFvbCheckAuthFormat,
+  VariableStorageFvbGetMaxVariableSize,
+  VariableStorageFvbGetVariable,
+  VariableStorageFvbGetNextVariableName,
+  VariableStorageFvbSetVariable,
+  VariableStorageFvbQueryVariableInfo,
+  VariableStorageFvbEndOfDxe,
+  VariableStorageFvbReadyToBoot,
+  VariableStorageFvbExitBootService,
+  VariableStorageFvbGetStatics,
+  VariableStorageFvbRequestToLock,
+  VariableStorageFvbPropertySet,
+  VariableStorageFvbPropertyGet,
+  VariableStorageFvbInitCache,
+  VariableStorageFvbSyncCache,
+  VariableStorageFvbGetCacheInfo,
+  VariableStorageFvbInitWriteService,
+};
+
+/**
+  Initailize Variable Stoarge.
+
+  @param  [in]  ImageHandle      The firmware allocated handle for the EFI image
+
+  @retval EFI_SUCCESS            Success
+  @retval Others                 Error
+
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbInitialize (
+  IN EFI_HANDLE  ImageHandle
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Registration;
+
+  //
+  // Variable initialize.
+  //
+  Status = VariableCommonInitialize ();
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Install Notification for gEfiSmmVariableProtocolGuid,
+  //
+  Status = gMmst->MmRegisterProtocolNotify (
+                    &gEfiSmmVariableProtocolGuid,
+                    VariableProtocolInstallNotify,
+                    &Registration
+                    );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Install Variable Storage Protocol.
+  //
+  Status = gMmst->MmInstallProtocolInterface (
+                    &ImageHandle,
+                    &gEdkiiVariableStorageProtocolGuid,
+                    EFI_NATIVE_INTERFACE,
+                    &mSmmVariableStorageFvb
+                    );
+  ASSERT_EFI_ERROR (Status);
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.c
@@ -1,0 +1,47 @@
+/** @file
+
+  Parts of the SMM/MM implementation that are specific to standalone MM
+
+Copyright (c) 2011 - 2024, Intel Corporation. All rights reserved. <BR>
+Copyright (c) 2018, Linaro, Ltd. All rights reserved. <BR>
+Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/MmServicesTableLib.h>
+#include <Library/StandaloneMmMemLib.h>
+#include "Variable.h"
+
+/**
+  Whether the MOR variable is legitimate or not.
+
+  @retval TRUE  MOR Variable is legitimate.
+  @retval FALSE MOR Variable in not legitimate.
+**/
+BOOLEAN
+VariableIsMorVariableLegitimate (
+  VOID
+  )
+{
+  return TRUE;
+}
+
+/**
+  Variable Storage FVB MM driver entry point.
+
+  @param[in] ImageHandle    A handle for the image that is initializing this
+                            driver
+  @param[in] MmSystemTable  A pointer to the MM system table
+
+  @retval EFI_SUCCESS       Variable storage successfully initialized.
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbSmmEntry (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
+  )
+{
+  return VariableStorageFvbInitialize (ImageHandle);
+}

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbStandaloneMm.inf
@@ -1,0 +1,135 @@
+## @file
+#  Provides SMM variable service.
+#
+#  This module installs SMM variable protocol into SMM protocol database,
+#  which can be used by SMM driver, and installs SMM variable protocol
+#  into BS protocol database, which can be used to notify the SMM Runtime
+#  Dxe driver that the SMM variable service is ready.
+#  This module should be used with SMM Runtime DXE module together. The
+#  SMM Runtime DXE module would install variable arch protocol and variable
+#  write arch protocol based on SMM variable module.
+#
+#  Caution: This module requires additional review when modified.
+#  This driver will have external input - variable data and communicate buffer in SMM mode.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#    The whole SMM authentication variable design relies on the integrity of flash part and SMM.
+#  which is assumed to be protected by platform.  All variable code and metadata in flash/SMM Memory
+#  may not be modified without authorization. If platform fails to protect these resources,
+#  the authentication service provided in this driver will be broken, and the behavior is undefined.
+#
+# Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.
+# Copyright (c) 2026, ARM Limited. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = VariableStorageFvbStandaloneMm
+  FILE_GUID                      = 6c88f500-3781-11f1-b248-231b4ad90f6e
+  MODULE_TYPE                    = MM_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  ENTRY_POINT                    = VariableStorageFvbSmmEntry
+
+[Sources]
+  PrivilegePolymorphic.h
+  SpeculationBarrierSmm.c
+  Reclaim.c
+  TcgMorLockSmm.c
+  VarCheck.c
+  Variable.c
+  Variable.h
+  VariableExLib.c
+  VariableLockRequestToLock.c
+  VariableNonVolatile.c
+  VariableNonVolatile.h
+  VariableParsing.c
+  VariableParsing.h
+  VariableRuntimeCache.c
+  VariableRuntimeCache.h
+  VariableStorageFvbSmm.c
+  VariableStorageFvbStandaloneMm.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+
+[LibraryClasses]
+  AuthVariableLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HobLib
+  MemLib
+  MemoryAllocationLib
+  MmServicesTableLib
+  SafeIntLib
+  StandaloneMmDriverEntryPoint
+  SynchronizationLib
+  VarCheckLib
+  VariableFlashInfoLib
+  VariablePolicyLib
+  VariablePolicyHelperLib
+
+[Protocols]
+  gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES
+  ## CONSUMES
+  ## NOTIFY
+  gEfiSmmFaultTolerantWriteProtocolGuid
+  gEfiSmmVariableProtocolGuid                  ## NOTIFY
+  gEdkiiSmmVarCheckProtocolGuid                ## PRODUCES
+  gEdkiiVariableStorageProtocolGuid            ## PRODUCES
+
+[Guids]
+  ## SOMETIMES_CONSUMES   ## GUID # Signature of Variable store header
+  ## SOMETIMES_PRODUCES   ## GUID # Signature of Variable store header
+  ## SOMETIMES_CONSUMES   ## HOB
+  ## SOMETIMES_PRODUCES   ## SystemTable
+  gEfiAuthenticatedVariableGuid
+
+  ## SOMETIMES_CONSUMES   ## GUID # Signature of Variable store header
+  ## SOMETIMES_PRODUCES   ## GUID # Signature of Variable store header
+  ## SOMETIMES_CONSUMES   ## HOB
+  ## SOMETIMES_PRODUCES   ## SystemTable
+  gEfiVariableGuid
+
+  ## SOMETIMES_CONSUMES   ## Variable:L"PlatformLang"
+  ## SOMETIMES_PRODUCES   ## Variable:L"PlatformLang"
+  ## SOMETIMES_CONSUMES   ## Variable:L"Lang"
+  ## SOMETIMES_PRODUCES   ## Variable:L"Lang"
+  gEfiGlobalVariableGuid
+
+  gEfiMemoryOverwriteControlDataGuid            ## SOMETIMES_CONSUMES   ## Variable:L"MemoryOverwriteRequestControl"
+  gEfiMemoryOverwriteRequestControlLockGuid     ## SOMETIMES_PRODUCES   ## Variable:L"MemoryOverwriteRequestControlLock"
+
+  gEfiSystemNvDataFvGuid                        ## CONSUMES             ## GUID
+  gEdkiiFaultTolerantWriteGuid                  ## SOMETIMES_CONSUMES   ## HOB
+
+  ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
+  ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"
+  gEdkiiVarErrorFlagGuid
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize                  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxAuthVariableSize              ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVolatileVariableSize          ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxHardwareErrorVariableSize     ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize                ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHwErrStorageSize                 ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxUserNvVariableSpaceSize           ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdBoottimeReservedNvVariableSpaceSize  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdReclaimVariableSpaceAtEndOfDxe   ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable          ## SOMETIMES_CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved       ## SOMETIMES_CONSUMES
+
+[FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableCollectStatistics        ## CONSUMES  # statistic the information of variable.
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLangDeprecate       ## CONSUMES  # Auto update PlatformLang/Lang
+
+[Depex]
+  TRUE

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.c
@@ -1,0 +1,68 @@
+/** @file
+
+  Parts of the SMM/MM implementation that are specific to traditional MM
+
+Copyright (c) 2011 - 2024, Intel Corporation. All rights reserved. <BR>
+Copyright (c) 2018, Linaro, Ltd. All rights reserved. <BR>
+Copyright (c) 2026, Arm Limited. All rights reserved.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/SmmMemLib.h>
+#include "Variable.h"
+
+/**
+  Whether the TCG or TCG2 protocols are installed in the UEFI protocol database.
+  This information is used by the MorLock code to infer whether an existing
+  MOR variable is legitimate or not.
+
+  @retval TRUE  Either the TCG or TCG2 protocol is installed in the UEFI
+                protocol database. MOR variable is legitimate.
+  @retval FALSE Neither the TCG nor the TCG2 protocol is installed in the UEFI
+                protocol database. MOR variable is not legitimate.
+**/
+BOOLEAN
+VariableIsMorVariableLegitimate (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Interface;
+
+  Status = gBS->LocateProtocol (
+                  &gEfiTcg2ProtocolGuid,
+                  NULL,                     // Registration
+                  &Interface
+                  );
+  if (!EFI_ERROR (Status)) {
+    return TRUE;
+  }
+
+  Status = gBS->LocateProtocol (
+                  &gEfiTcgProtocolGuid,
+                  NULL,                     // Registration
+                  &Interface
+                  );
+  return !EFI_ERROR (Status);
+}
+
+/**
+  Variable Storage FVB MM driver entry point.
+
+  @param[in] ImageHandle    A handle for the image that is initializing this
+                            driver
+  @param[in] SystemTable    A pointer to the EFI system table
+
+  @retval EFI_SUCCESS       Variable storage successfully initialized.
+**/
+EFI_STATUS
+EFIAPI
+VariableStorageFvbSmmEntry (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return VariableStorageFvbInitialize (ImageHandle);
+}

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStorageFvbTraditionalMm.inf
@@ -1,0 +1,149 @@
+## @file
+#  Provides SMM variable service.
+#
+#  This module installs SMM variable protocol into SMM protocol database,
+#  which can be used by SMM driver, and installs SMM variable protocol
+#  into BS protocol database, which can be used to notify the SMM Runtime
+#  Dxe driver that the SMM variable service is ready.
+#  This module should be used with SMM Runtime DXE module together. The
+#  SMM Runtime DXE module would install variable arch protocol and variable
+#  write arch protocol based on SMM variable module.
+#
+#  Caution: This module requires additional review when modified.
+#  This driver will have external input - variable data and communicate buffer in SMM mode.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#    The whole SMM authentication variable design relies on the integrity of flash part and SMM.
+#  which is assumed to be protected by platform.  All variable code and metadata in flash/SMM Memory
+#  may not be modified without authorization. If platform fails to protect these resources,
+#  the authentication service provided in this driver will be broken, and the behavior is undefined.
+#
+# Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.
+# Copyright (c) 2026, Arm Limited. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = VariableStorageFvbTraditionalMm
+  FILE_GUID                      = 705b50fe-3800-11f1-b819-27dac9deecba
+  MODULE_TYPE                    = DXE_SMM_DRIVER
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x0001000A
+  ENTRY_POINT                    = VariableStorageFvbSmmEntry
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+
+[Sources]
+  PrivilegePolymorphic.h
+  SpeculationBarrierSmm.c
+  TcgMorLockSmm.c
+  Reclaim.c
+  VarCheck.c
+  Variable.c
+  Variable.h
+  VariableExLib.c
+  VariableLockRequestToLock.c
+  VariableNonVolatile.c
+  VariableNonVolatile.h
+  VariableParsing.c
+  VariableParsing.h
+  VariableRuntimeCache.c
+  VariableRuntimeCache.h
+  VariableStorageFvbSmm.c
+  VariableStorageFvbTraditionalMm.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  AuthVariableLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HobLib
+  MemoryAllocationLib
+  MmServicesTableLib
+  SafeIntLib
+  SynchronizationLib
+  UefiLib
+  DxeServicesTableLib
+  PcdLib
+  SmmMemLib
+  VarCheckLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  VariableFlashInfoLib
+  VariablePolicyLib
+  VariablePolicyHelperLib
+
+[Protocols]
+  gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES
+  ## CONSUMES
+  ## NOTIFY
+  gEfiSmmFaultTolerantWriteProtocolGuid
+  ## PRODUCES
+  ## UNDEFINED # SmiHandlerRegister
+  gEfiSmmVariableProtocolGuid
+  gEfiMmEndOfDxeProtocolGuid                    ## NOTIFY
+  gEdkiiSmmVarCheckProtocolGuid                 ## PRODUCES
+  gEfiTcgProtocolGuid                           ## SOMETIMES_CONSUMES
+  gEfiTcg2ProtocolGuid                          ## SOMETIMES_CONSUMES
+  gEdkiiVariableStorageProtocolGuid            ## PRODUCES
+
+[Guids]
+  ## SOMETIMES_CONSUMES   ## GUID # Signature of Variable store header
+  ## SOMETIMES_PRODUCES   ## GUID # Signature of Variable store header
+  ## SOMETIMES_CONSUMES   ## HOB
+  ## SOMETIMES_PRODUCES   ## SystemTable
+  gEfiAuthenticatedVariableGuid
+
+  ## SOMETIMES_CONSUMES   ## GUID # Signature of Variable store header
+  ## SOMETIMES_PRODUCES   ## GUID # Signature of Variable store header
+  ## SOMETIMES_CONSUMES   ## HOB
+  ## SOMETIMES_PRODUCES   ## SystemTable
+  gEfiVariableGuid
+
+  ## SOMETIMES_CONSUMES   ## Variable:L"PlatformLang"
+  ## SOMETIMES_PRODUCES   ## Variable:L"PlatformLang"
+  ## SOMETIMES_CONSUMES   ## Variable:L"Lang"
+  ## SOMETIMES_PRODUCES   ## Variable:L"Lang"
+  gEfiGlobalVariableGuid
+
+  gEfiMemoryOverwriteControlDataGuid            ## SOMETIMES_CONSUMES   ## Variable:L"MemoryOverwriteRequestControl"
+  gEfiMemoryOverwriteRequestControlLockGuid     ## SOMETIMES_PRODUCES   ## Variable:L"MemoryOverwriteRequestControlLock"
+
+  gEfiSystemNvDataFvGuid                        ## CONSUMES             ## GUID
+  gEdkiiFaultTolerantWriteGuid                  ## SOMETIMES_CONSUMES   ## HOB
+
+  ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
+  ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"
+  gEdkiiVarErrorFlagGuid
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize                  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxAuthVariableSize              ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVolatileVariableSize          ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxHardwareErrorVariableSize     ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize                ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHwErrStorageSize                 ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxUserNvVariableSpaceSize           ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdBoottimeReservedNvVariableSpaceSize  ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdReclaimVariableSpaceAtEndOfDxe   ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable          ## SOMETIMES_CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved       ## SOMETIMES_CONSUMES
+
+[FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdVariableCollectStatistics        ## CONSUMES  # statistic the information of variable.
+  gEfiMdePkgTokenSpaceGuid.PcdUefiVariableDefaultLangDeprecate       ## CONSUMES  # Auto update PlatformLang/Lang
+
+[Depex]
+  TRUE

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableTraditionalMm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableTraditionalMm.c
@@ -4,6 +4,7 @@
 
 Copyright (c) 2011 - 2024, Intel Corporation. All rights reserved. <BR>
 Copyright (c) 2018, Linaro, Ltd. All rights reserved. <BR>
+Copyright (c) 2026, ARM Limited. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -110,39 +111,4 @@ VariableServiceInitialize (
   )
 {
   return MmVariableServiceInitialize ();
-}
-
-/**
-  Whether the TCG or TCG2 protocols are installed in the UEFI protocol database.
-  This information is used by the MorLock code to infer whether an existing
-  MOR variable is legitimate or not.
-
-  @retval TRUE  Either the TCG or TCG2 protocol is installed in the UEFI
-                protocol database. MOR variable is legitimate.
-  @retval FALSE Neither the TCG nor the TCG2 protocol is installed in the UEFI
-                protocol database. MOR variable is not legitimate.
-**/
-BOOLEAN
-VariableIsMorVariableLegitimate (
-  VOID
-  )
-{
-  EFI_STATUS  Status;
-  VOID        *Interface;
-
-  Status = gBS->LocateProtocol (
-                  &gEfiTcg2ProtocolGuid,
-                  NULL,                     // Registration
-                  &Interface
-                  );
-  if (!EFI_ERROR (Status)) {
-    return TRUE;
-  }
-
-  Status = gBS->LocateProtocol (
-                  &gEfiTcgProtocolGuid,
-                  NULL,                     // Registration
-                  &Interface
-                  );
-  return !EFI_ERROR (Status);
 }


### PR DESCRIPTION
# Description

Deploying VariableService in StandaloneMm provides stronger protection for 
UEFI variables by isolating variable processing from the normal execution  
environment.                                                               
                                                                           
Typical use cases include:                                                 
  1. Protection of Secure Boot variables:                                  
      Secure Boot variables such as PK, KEK, db, dbx, SecureBoot, and      
      SetupMode must not be modified by the operating system or untrusted DXE drivers.
                                                                           
  2. Integration with secure storage:                                      
      Some platforms provide secure storage mechanisms, such as eMMC RPMB  
      (Replay Protected Memory Block) or other platform-specific secure    
      storage solutions. These backends provide protection against         
      unauthorized modification while preserving the integrity of          
      security-critical variables.                                         
                                                                           
Although VariableService can already run in StandaloneMm, its persistence  
layer remains tightly coupled to the Firmware Volume Block (FVB)           
abstraction. The current implementation assumes an FVB/FTW-based storage                                                                                                                                                                                                             
model, with variable persistence and fault-tolerant writes implemented     
around that design.                                                        
                                                                           
This assumption does not hold on all platforms. Some platforms store       
firmware variables through a dedicated storage management controller that  
is not directly accessible from the application processor. Communication   
with such storage is transactional rather than block based, making the     
existing FVB abstraction unsuitable.                                       
                                                                           
In these environments, StandaloneMm should act as a proxy that forwards    
variable operations to the underlying storage implementation instead of    
managing persistence through FVB.                                          
                                                                           
This patchset proposes introducing a VariableStorage Protocol together with     
VariableStorageRouterLib for StandaloneMm. This separates VariableService  
from the underlying storage implementation while preserving the existing   
VariableService semantics.                                                 
                                                                           
Existing platforms can continue using the current FVB-based storage model  
without modification, while new platforms may provide alternative storage  
implementations through VariableStorageRouterLib and the VariableStorage Protocol.

For a detail, Please see the RFC doc [0].

- [X] Breaking change?
  - Each platform where use the VariableStandaloneMm and VariableSmm driver should use 
    VariableStorageFvbStandaloneMm, VariableStorageFvbTraditionalMm and VariableStorageRouterBaseLib properly in their
    .dsc and .fdf file.
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Boot and check the VariableStorage operation.

## Integration Instructions

N/A

## Reference
Link: [0] https://github.com/tianocore/tianocore-wiki.github.io/pull/44
Link: [1] https://github.com/tianocore/edk2-platforms/pull/1032