### PR TITLE
OvmfPkg/RiscVVirt: Add Hash2DxeCrypto for TcpDxe

### DIFF
--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -457,6 +457,11 @@
   OvmfPkg/VirtioRngDxe/VirtioRng.inf
 
   #
+  # Hash2 protocol, needed to dispatch TcpDxe
+  #
+  SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
+
+  #
   # FAT filesystem + GPT/MBR partitioning + UDF filesystem + virtio-fs
   #
   MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
@@ -154,6 +154,11 @@ INF  OvmfPkg/VirtioNetDxe/VirtioNet.inf
 INF  OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
 INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 
+#
+# Hash2 protocol, needed to dispatch TcpDxe
+#
+INF  SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
+
 !include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
 
 #


### PR DESCRIPTION
# Description

add Hash2DxeCrypto to RiscVVirt, which is required for enabling TCP.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

qemu-system-riscv64 -M virt -cpu rv64 -device virtio-rng-pci, GCC/RELEASE.

before: SimpleNetwork 1 handle, MNP/ARP/IP4/DHCP4/UDP4/TCP4 all 0. after:
SimpleNetwork 2, all six at 1. adding only -device virtio-rng-pci to the
unpatched build gets everything but TCP4, which pins Hash2 as separate.

PXE over QEMU's built-in TFTP downloads and runs a payload.

## Integration Instructions

n/a

