### PR TITLE
DynamicTablesPkg: Support EL2 virtual timer in ArmGenericTimerParser

### DIFF
--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/Arm/GenericTimer/ArmGenericTimerParser.c
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/Arm/GenericTimer/ArmGenericTimerParser.c
@@ -56,7 +56,8 @@ TimerNodeParser (
   UINT32        GicVersion;
   INT32         DataSize;
   INT32         IntCells;
-  BOOLEAN       AlwaysOnTimer;
+  INT32         IntCount;
+  UINT32        AlwaysOnTimerFlag;
 
   if ((Fdt == NULL) ||
       (GenericTimerInfo == NULL))
@@ -67,9 +68,9 @@ TimerNodeParser (
 
   Data = FdtGetProp (Fdt, TimerNode, "always-on", &DataSize);
   if ((Data == NULL) || (DataSize < 0)) {
-    AlwaysOnTimer = FALSE;
+    AlwaysOnTimerFlag = 0;
   } else {
-    AlwaysOnTimer = TRUE;
+    AlwaysOnTimerFlag = BIT2;
   }
 
   // Get the associated interrupt-controller.
@@ -88,8 +89,9 @@ TimerNodeParser (
 
   // Get the number of cells used to encode an interrupt.
   Status = FdtGetInterruptCellsInfo (Fdt, IntcNode, &IntCells);
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR (Status) || (IntCells == 0)) {
     ASSERT (0);
+    ASSERT (IntCells != 0);
     if (Status == EFI_NOT_FOUND) {
       // Should have found the node.
       Status = EFI_ABORTED;
@@ -98,37 +100,65 @@ TimerNodeParser (
     return Status;
   }
 
-  Data = FdtGetProp (Fdt, TimerNode, "interrupts", &DataSize);
+  Data     = FdtGetProp (Fdt, TimerNode, "interrupts", &DataSize);
+  IntCount = DataSize / IntCells / sizeof (UINT32);
   if ((Data == NULL) ||
-      (DataSize != (FdtMaxTimerItem * IntCells * sizeof (UINT32))))
+      (IntCount > FdtMaxTimerItem))
   {
     // If error or not FdtMaxTimerItem interrupts.
     ASSERT (0);
     return EFI_ABORTED;
   }
 
-  GenericTimerInfo->SecurePL1TimerGSIV =
-    FdtGetInterruptId (&Data[FdtSecureTimerIrq * IntCells]);
-  GenericTimerInfo->SecurePL1TimerFlags =
-    FdtGetInterruptFlags (&Data[FdtSecureTimerIrq * IntCells]);
-  GenericTimerInfo->NonSecurePL1TimerGSIV =
-    FdtGetInterruptId (&Data[FdtNonSecureTimerIrq * IntCells]);
-  GenericTimerInfo->NonSecurePL1TimerFlags =
-    FdtGetInterruptFlags (&Data[FdtNonSecureTimerIrq * IntCells]);
-  GenericTimerInfo->VirtualTimerGSIV =
-    FdtGetInterruptId (&Data[FdtVirtualTimerIrq * IntCells]);
-  GenericTimerInfo->VirtualTimerFlags =
-    FdtGetInterruptFlags (&Data[FdtVirtualTimerIrq * IntCells]);
-  GenericTimerInfo->NonSecurePL2TimerGSIV =
-    FdtGetInterruptId (&Data[FdtHypervisorTimerIrq * IntCells]);
-  GenericTimerInfo->NonSecurePL2TimerFlags =
-    FdtGetInterruptFlags (&Data[FdtHypervisorTimerIrq * IntCells]);
+  if ((IntCount > FdtSecureTimerIrq)) {
+    GenericTimerInfo->SecurePL1TimerGSIV =
+      FdtGetInterruptId (&Data[FdtSecureTimerIrq * IntCells]);
+    GenericTimerInfo->SecurePL1TimerFlags =
+      FdtGetInterruptFlags (&Data[FdtSecureTimerIrq * IntCells]) | AlwaysOnTimerFlag;
+  } else {
+    // No timer, no luck
+    ASSERT (0);
+    return EFI_ABORTED;
+  }
 
-  if (AlwaysOnTimer) {
-    GenericTimerInfo->SecurePL1TimerFlags    |= BIT2;
-    GenericTimerInfo->NonSecurePL1TimerFlags |= BIT2;
-    GenericTimerInfo->VirtualTimerFlags      |= BIT2;
-    GenericTimerInfo->NonSecurePL2TimerFlags |= BIT2;
+  if ((IntCount > FdtNonSecureTimerIrq)) {
+    GenericTimerInfo->NonSecurePL1TimerGSIV =
+      FdtGetInterruptId (&Data[FdtNonSecureTimerIrq * IntCells]);
+    GenericTimerInfo->NonSecurePL1TimerFlags =
+      FdtGetInterruptFlags (&Data[FdtNonSecureTimerIrq * IntCells]) | AlwaysOnTimerFlag;
+  } else {
+    GenericTimerInfo->NonSecurePL1TimerGSIV  = 0;
+    GenericTimerInfo->NonSecurePL1TimerFlags = 0;
+  }
+
+  if ((IntCount > FdtVirtualTimerIrq)) {
+    GenericTimerInfo->VirtualTimerGSIV =
+      FdtGetInterruptId (&Data[FdtVirtualTimerIrq * IntCells]);
+    GenericTimerInfo->VirtualTimerFlags =
+      FdtGetInterruptFlags (&Data[FdtVirtualTimerIrq * IntCells]) | AlwaysOnTimerFlag;
+  } else {
+    GenericTimerInfo->VirtualTimerGSIV  = 0;
+    GenericTimerInfo->VirtualTimerFlags = 0;
+  }
+
+  if ((IntCount > FdtHypervisorTimerIrq)) {
+    GenericTimerInfo->NonSecurePL2TimerGSIV =
+      FdtGetInterruptId (&Data[FdtHypervisorTimerIrq * IntCells]);
+    GenericTimerInfo->NonSecurePL2TimerFlags =
+      FdtGetInterruptFlags (&Data[FdtHypervisorTimerIrq * IntCells]) | AlwaysOnTimerFlag;
+  } else {
+    GenericTimerInfo->NonSecurePL2TimerGSIV  = 0;
+    GenericTimerInfo->NonSecurePL2TimerFlags = 0;
+  }
+
+  if ((IntCount > FdtHypervisorVTimerIrq)) {
+    GenericTimerInfo->VirtualPL2TimerGSIV =
+      FdtGetInterruptId (&Data[FdtHypervisorVTimerIrq * IntCells]);
+    GenericTimerInfo->VirtualPL2TimerFlags =
+      FdtGetInterruptFlags (&Data[FdtHypervisorVTimerIrq * IntCells]) | AlwaysOnTimerFlag;
+  } else {
+    GenericTimerInfo->VirtualPL2TimerGSIV  = 0;
+    GenericTimerInfo->VirtualPL2TimerFlags = 0;
   }
 
   // Setup default values
@@ -137,10 +167,6 @@ TimerNodeParser (
   // these to their default value.
   GenericTimerInfo->CounterControlBaseAddress = 0xFFFFFFFFFFFFFFFF;
   GenericTimerInfo->CounterReadBaseAddress    = 0xFFFFFFFFFFFFFFFF;
-
-  // For systems not implementing ARMv8.1 VHE, this field is 0.
-  GenericTimerInfo->VirtualPL2TimerGSIV  = 0;
-  GenericTimerInfo->VirtualPL2TimerFlags = 0;
 
   return EFI_SUCCESS;
 }

--- a/DynamicTablesPkg/Library/FdtHwInfoParserLib/Arm/GenericTimer/ArmGenericTimerParser.h
+++ b/DynamicTablesPkg/Library/FdtHwInfoParserLib/Arm/GenericTimer/ArmGenericTimerParser.h
@@ -17,6 +17,7 @@ typedef enum FdtTimerInterruptItems {
   FdtNonSecureTimerIrq,   ///< Non-secure timer IRQ
   FdtVirtualTimerIrq,     ///< Virtual timer IRQ
   FdtHypervisorTimerIrq,  ///< Hypervisor timer IRQ
+  FdtHypervisorVTimerIrq, ///< Hypervisor virtual timer IRQ
   FdtMaxTimerItem         ///< Max timer item
 } FDT_TIMER_INTERRUPT_ITEMS;
 


### PR DESCRIPTION
## Description

  When edk2 runs as a kvmtool guest with nested virtualization enabled,
  the Arm architectural timer DT node contains five interrupt specifiers.
  The fifth interrupt represents the EL2 virtual timer.

  `ArmGenericTimerParser` currently expects exactly four timer interrupts.
  It therefore asserts while parsing the timer node generated for a nested
  virtualization guest:

  ```text
  ASSERT [ConfigurationManagerDxe] ArmGenericTimerParser.c(106): 0
```

  Update the parser to determine the number of interrupt specifiers present
  in the DT and populate each architectural timer entry only when available.

  Add support for the EL2 virtual timer and use it to populate the
  VirtualPL2TimerGSIV and VirtualPL2TimerFlags fields in the generated
  GTDT information.

  ## Testing

  Tested using:

  - FVP Base RevC AEMvA 11.31.28
  - Linux cc260f9aca04
  - kvmtool ca0ddafa
  - AArch64 DEBUG firmware built from ArmVirtPkg/ArmVirtKvmTool.dsc

  The nested guest was launched with:
```text
  ./lkvm run -c 1 --nested \
    --irqchip=gicv3-its \
    --firmware KVMTOOL_EFI.fd \
    --dump-dtb kvmtool-nested.dtb \
    --console=serial \
    --nodefaults \
    -m 512 \
    --no-pvtime \
    --force-pci \
    --disk disk.img
```

  The generated timer node contained five interrupt specifiers:

```text
  timer {
      compatible = "arm,armv8-timer\0arm,armv7-timer";
      interrupts = <0x01 0x0d 0x08
                             0x01 0x0e 0x08                    
                             0x01 0x0b 0x08
                             0x01 0x0a 0x08
                            0x01 0x0c 0x08>;
      always-on;
  };
```

  Without the patch, firmware asserted in ArmGenericTimerParser and the
  guest did not reach Linux.

  With the patch, the assertion was no longer present and the guest completed
  firmware and Linux boot:

```text
  ACPI: GTDT 0x000000009DC4DC98 000068
  arch_timer: cp15 timer running at 100.00MHz (phys).
  vda: vda1 vda2
  VFS: Mounted root (ext4 filesystem) readonly on device 254:2.
  Run /sbin/init as init process
  Welcome to Buildroot
```