### PR TITLE
MdeModulePkg: Skip deleted vars in PeiVariable index table searches

### DIFF
--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -897,6 +897,15 @@ FindVariableEx (
       MaxIndex = (VARIABLE_HEADER *)((UINT8 *)IndexTable->StartPtr + Offset);
       Valid    = GetVariableHeader (StoreInfo, MaxIndex, &VariableHeader);
       if (Valid && (CompareWithValidVariable (StoreInfo, MaxIndex, VariableHeader, VariableName, VendorGuid, PtrTrack) == EFI_SUCCESS)) {
+        //
+        // Skip variables with deleted state (0x3C).
+        // When a variable is deleted, the state becomes 0x3C (VAR_IN_DELETED_TRANSITION & VAR_DELETED & VAR_ADDED).
+        // This check ensures only valid states (0x3F or 0x3E) are processed.
+        //
+        if (VariableHeader->State == (VAR_IN_DELETED_TRANSITION & VAR_DELETED & VAR_ADDED)) {
+          continue;
+        }
+
         if (VariableHeader->State == (VAR_IN_DELETED_TRANSITION & VAR_ADDED)) {
           InDeletedVariable = PtrTrack->CurrPtr;
         } else {


### PR DESCRIPTION
# Description

The Variable PEIM's index table optimization search path incorrectly returns deleted variables instead of valid variables when duplicate variables exist with different states.

This occurs when:

- One variable has deleted state (VAR_IN_DELETED_TRANSITION & VAR_ADDED, value 0x3C)
- One variable has valid state (VAR_ADDED, value 0x3F)
- Both variables have the same name and GUID

The function should prioritize and return the valid variable, but the index table search was returning the first match regardless of state validity.

In the FindVariableEx() index table traversal, the function was not properly validating variable states before returning a match. When CompareWithValidVariable() found a matching variable name and GUID, it would return immediately without checking if the variable state was valid (0x3F) or deleted (0x3C).

This issue only affects the index table optimization search path and does not impact the linear traversal search path. The Variable PEIM has two main search mechanisms:

1. Linear traversal search - Walks through the entire variable store checking each header sequentially. This path has correct state validation logic and is unaffected by this issue.

2. Index table optimization search - Uses a gEfiVariableIndexTableGuid HOB to quickly jump to variable locations. This optimization is only active when the platform produces this HOB. This is the path affected by the issue.

This commit adds explicit state validation in FindVariableEx() to skip variables with deleted state (0x3C).

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Create variables that are deleted and valid in NVRAM.
- Call FindVariableEx() and check the variable address.
- Check that it only returns valid variables.

## Integration Instructions

- N/A