### PR TITLE
Adding Posix based `TimerLib` for host based unit tests to onboard more AArch64 tests

### DIFF
--- a/CryptoPkg/Test/CryptoPkgHostUnitTest.dsc
+++ b/CryptoPkg/Test/CryptoPkgHostUnitTest.dsc
@@ -13,7 +13,7 @@
   PLATFORM_VERSION        = 0.1
   DSC_SPECIFICATION       = 0x00010005
   OUTPUT_DIRECTORY        = Build/CryptoPkg/HostTest
-  SUPPORTED_ARCHITECTURES = IA32|X64
+  SUPPORTED_ARCHITECTURES = IA32|X64|AARCH64
   BUILD_TARGETS           = NOOPT
   SKUID_IDENTIFIER        = DEFAULT
 
@@ -34,10 +34,8 @@
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
   MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
-  TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
-
-[LibraryClasses.X64, LibraryClasses.IA32]
-  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
+  TimerLib|UnitTestFrameworkPkg/Library/Posix/TimerLibPosix/TimerLibPosix.inf
+  RngLib|MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
 
 [Components]
   #

--- a/CryptoPkg/Test/Mock/Include/GoogleTest/Library/MockBaseCryptLib.h
+++ b/CryptoPkg/Test/Mock/Include/GoogleTest/Library/MockBaseCryptLib.h
@@ -5,8 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#ifndef MOCK_BASE_CRYPT_LIB_H_
-#define MOCK_BASE_CRYPT_LIB_H_
+#pragma once
 
 #include <Library/GoogleTestLib.h>
 #include <Library/FunctionMockLib.h>
@@ -1750,5 +1749,3 @@ struct MockBaseCryptLib {
     )
     );
 };
-
-#endif

--- a/MdePkg/Include/Library/ArmFfaMemMgmtLib.h
+++ b/MdePkg/Include/Library/ArmFfaMemMgmtLib.h
@@ -12,8 +12,8 @@
 #include <Uefi.h>
 
 /**
-  @brief      Starts a transaction to transfer of ownership of a memory region
-              from a Sender endpoint to a Receiver endpoint.
+  Starts a transaction to transfer of ownership of a memory region from a Sender
+  endpoint to a Receiver endpoint.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -39,8 +39,8 @@ ArmFfaMemLibDonate (
   );
 
 /**
-  @brief      Starts a transaction to transfer of ownership of a memory region
-              from a Sender endpoint to a Receiver endpoint.
+  Starts a transaction to transfer of ownership of a memory region from a Sender
+  endpoint to a Receiver endpoint.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -60,8 +60,8 @@ ArmFfaMemLibDonateRxTx (
   );
 
 /**
-  @brief      Starts a transaction to transfer an Owner's access to a memory
-              region and  grant access to it to one or more Borrowers.
+  Starts a transaction to transfer an Owner's access to a memory region and grant
+  access to it to one or more Borrowers.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -88,9 +88,8 @@ ArmFfaMemLibLend (
   );
 
 /**
-  @brief      Starts a transaction to transfer an Owner's access to a memory
-              region and  grant access to it to one or more Borrowers through
-              Rx/Tx buffer.
+  Starts a transaction to transfer an Owner's access to a memory region and grant
+  access to it to one or more Borrowers through Rx/Tx buffer.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -110,8 +109,7 @@ ArmFfaMemLibLendRxTx (
   );
 
 /**
-  @brief      Starts a transaction to grant access to a memory region to one or
-              more Borrowers.
+  Starts a transaction to grant access to a memory region to one or more Borrowers.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -137,8 +135,8 @@ ArmFfaMemLibShare (
   );
 
 /**
-  @brief      Starts a transaction to grant access to a memory region to one or
-              more Borrowers through Rx/Tx buffer.
+  Starts a transaction to grant access to a memory region to one or more Borrowers
+  through Rx/Tx buffer.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -158,8 +156,7 @@ ArmFfaMemLibShareRxTx (
   );
 
 /**
-  @brief      Requests completion of a donate, lend or share memory management
-              transaction.
+  Requests completion of a donate, lend or share memory management transaction.
 
   @param[in]  TotalLength         Total length of the memory transaction descriptor
                                   in bytes
@@ -188,8 +185,8 @@ ArmFfaMemLibRetrieveReq (
   );
 
 /**
-  @brief      Requests completion of a donate, lend or share memory management
-              transaction through Rx/Tx buffer.
+  Requests completion of a donate, lend or share memory management transaction
+  through Rx/Tx buffer.
 
   @param[in]  TotalLength         Total length of the memory transaction descriptor
                                   in bytes
@@ -212,8 +209,8 @@ ArmFfaMemLibRetrieveReqRxTx (
   );
 
 /**
-  @brief      Starts a transaction to transfer access to a shared or lent
-              memory region from a Borrower back to its Owner.
+  Starts a transaction to transfer access to a shared or lent memory region from
+  a Borrower back to its Owner.
 
   @retval     The translated FF-A error status code
 **/
@@ -224,7 +221,7 @@ ArmFfaMemLibRelinquish (
   );
 
 /**
-  @brief      Restores exclusive access to a memory region back to its Owner.
+  Restores exclusive access to a memory region back to its Owner.
 
   @param[in]  Handle  Globally unique Handle to identify the memory region
   @param[in]  Flags   Flags for modifying the reclaim behavior
@@ -239,10 +236,9 @@ ArmFfaMemLibReclaim (
   );
 
 /**
-  @brief       Queries the memory attributes of a memory region. This function
-               can only access the regions of the SP's own translation regine.
-               Moreover this interface is only available in the boot phase,
-               i.e. before invoking FFA_MSG_WAIT interface.
+  Queries the memory attributes of a memory region. This function can only access
+  the regions of the SP's own translation regine. Moreover this interface is only
+  available in the boot phase, i.e. before invoking FFA_MSG_WAIT interface.
 
   @param[in]   BaseAddr     Base VA of a translation granule whose
                             permission attributes must be returned.
@@ -262,10 +258,9 @@ ArmFfaMemLibPermGet (
   );
 
 /**
-  @brief       Sets the memory attributes of a memory regions. This function
-               can only access the regions of the SP's own translation regine.
-               Moreover this interface is only available in the boot phase,
-               i.e. before invoking FFA_MSG_WAIT interface.
+  Sets the memory attributes of a memory regions. This function can only access
+  the regions of the SP's own translation regine. Moreover this interface is only
+  available in the boot phase, i.e. before invoking FFA_MSG_WAIT interface.
 
   @param[in]   BaseAddr     Base VA of a memory region whose permission
                             attributes must be set.

--- a/MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.c
+++ b/MdePkg/Library/ArmFfaMemMgmtLib/ArmFfaMemMgmtLib.c
@@ -25,8 +25,8 @@
 #include <Library/BaseMemoryLib.h>
 
 /**
-  @brief      Starts a transaction to transfer of ownership of a memory region
-              from a Sender endpoint to a Receiver endpoint.
+  Starts a transaction to transfer of ownership of a memory region from a Sender
+  endpoint to a Receiver endpoint.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -95,8 +95,8 @@ ArmFfaMemLibDonate (
 }
 
 /**
-  @brief      Starts a transaction to transfer of ownership of a memory region
-              from a Sender endpoint to a Receiver endpoint.
+  Starts a transaction to transfer of ownership of a memory region from a Sender
+  endpoint to a Receiver endpoint.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -119,8 +119,8 @@ ArmFfaMemLibDonateRxTx (
 }
 
 /**
-  @brief      Starts a transaction to transfer an Owner's access to a memory
-              region and  grant access to it to one or more Borrowers.
+  Starts a transaction to transfer an Owner's access to a memory region and grant
+  access to it to one or more Borrowers.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -190,9 +190,8 @@ ArmFfaMemLibLend (
 }
 
 /**
-  @brief      Starts a transaction to transfer an Owner's access to a memory
-              region and  grant access to it to one or more Borrowers through
-              Rx/Tx buffer.
+  Starts a transaction to transfer an Owner's access to a memory region and grant
+  access to it to one or more Borrowers through Rx/Tx buffer.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -215,8 +214,7 @@ ArmFfaMemLibLendRxTx (
 }
 
 /**
-  @brief      Starts a transaction to grant access to a memory region to one or
-              more Borrowers.
+  Starts a transaction to grant access to a memory region to one or more Borrowers.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -286,8 +284,8 @@ ArmFfaMemLibShare (
 }
 
 /**
-  @brief      Starts a transaction to grant access to a memory region to one or
-              more Borrowers through Rx/Tx buffer.
+  Starts a transaction to grant access to a memory region to one or more Borrowers
+  through Rx/Tx buffer.
 
   @param[in]  TotalLength     Total length of the memory transaction descriptor
                               in bytes
@@ -310,8 +308,7 @@ ArmFfaMemLibShareRxTx (
 }
 
 /**
-  @brief      Requests completion of a donate, lend or share memory management
-              transaction.
+  Requests completion of a donate, lend or share memory management transaction.
 
   @param[in]  TotalLength         Total length of the memory transaction descriptor
                                   in bytes
@@ -382,8 +379,8 @@ ArmFfaMemLibRetrieveReq (
 }
 
 /**
-  @brief      Requests completion of a donate, lend or share memory management
-              transaction through Rx/Tx buffer.
+  Requests completion of a donate, lend or share memory management transaction
+  through Rx/Tx buffer.
 
   @param[in]  TotalLength         Total length of the memory transaction descriptor
                                   in bytes
@@ -416,8 +413,8 @@ ArmFfaMemLibRetrieveReqRxTx (
 }
 
 /**
-  @brief      Starts a transaction to transfer access to a shared or lent
-              memory region from a Borrower back to its Owner.
+  Starts a transaction to transfer access to a shared or lent memory region from
+  a Borrower back to its Owner.
 
   @retval     The translated FF-A error status code
 **/
@@ -454,7 +451,7 @@ ArmFfaMemLibRelinquish (
 }
 
 /**
-  @brief      Restores exclusive access to a memory region back to its Owner.
+  Restores exclusive access to a memory region back to its Owner.
 
   @param[in]  Handle  Globally unique Handle to identify the memory region
   @param[in]  Flags   Flags for modifying the reclaim behavior
@@ -504,10 +501,9 @@ ArmFfaMemLibReclaim (
 }
 
 /**
-  @brief       Queries the memory attributes of a memory region. This function
-               can only access the regions of the SP's own translation regine.
-               Moreover this interface is only available in the boot phase,
-               i.e. before invoking FFA_MSG_WAIT interface.
+  Queries the memory attributes of a memory region. This function can only access
+  the regions of the SP's own translation regine. Moreover this interface is only
+  available in the boot phase, i.e. before invoking FFA_MSG_WAIT interface.
 
   @param[in]   BaseAddr     Base VA of a translation granule whose
                             permission attributes must be returned.
@@ -562,10 +558,9 @@ ArmFfaMemLibPermGet (
 }
 
 /**
-  @brief       Sets the memory attributes of a memory regions. This function
-               can only access the regions of the SP's own translation regine.
-               Moreover this interface is only available in the boot phase,
-               i.e. before invoking FFA_MSG_WAIT interface.
+  Sets the memory attributes of a memory regions. This function can only access
+  the regions of the SP's own translation regine. Moreover this interface is only
+  available in the boot phase, i.e. before invoking FFA_MSG_WAIT interface.
 
   @param[in]   BaseAddr     Base VA of a memory region whose permission
                             attributes must be set.

--- a/MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
+++ b/MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
@@ -181,12 +181,16 @@
   AArch64/SetJumpLongJump.S         | GCC
   AArch64/CpuBreakpoint.S           | GCC
   AArch64/SpeculationBarrier.S      | GCC
+  AArch64/ArmReadCntPctReg.S        | GCC
+  AArch64/ArmReadIdAA64Isar0Reg.S   | GCC
 
   AArch64/MemoryFence.asm           | MSFT
   AArch64/SwitchStack.asm           | MSFT
   AArch64/SetJumpLongJump.asm       | MSFT
   AArch64/CpuBreakpoint.asm         | MSFT
   AArch64/SpeculationBarrier.asm    | MSFT
+  AArch64/ArmReadCntPctReg.asm      | MSFT
+  AArch64/ArmReadIdAA64Isar0Reg.asm | MSFT
   AArch64UnitTestHost.c
 
 [Sources.RISCV64]

--- a/SecurityPkg/Test/SecurityPkgHostTest.dsc
+++ b/SecurityPkg/Test/SecurityPkgHostTest.dsc
@@ -20,10 +20,8 @@
 
 [LibraryClasses]
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
-  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
-
-[LibraryClasses.AARCH64]
-  RngLib|MdePkg/Library/BaseRngLibNull/BaseRngLibNull.inf
+  TimerLib|UnitTestFrameworkPkg/Library/Posix/TimerLibPosix/TimerLibPosix.inf
+  RngLib|MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
 
 [Components]
   SecurityPkg/Library/SecureBootVariableLib/UnitTest/MockUefiRuntimeServicesTableLib.inf

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/LoongArch/LoongArch64/ArchExceptionHandler.c
@@ -267,7 +267,7 @@ IpiInterruptHandler (
     //
     do {
       ResumeVector = IoCsrRead32 (LOONGARCH_IOCSR_MBUF0);
-    } while (!ResumeVector);
+    } while (ResumeVector == 0);
 
     //
     // Get the resume vector if populated.
@@ -279,7 +279,8 @@ IpiInterruptHandler (
     //
     do {
       Parameter = IoCsrRead32 (LOONGARCH_IOCSR_MBUF3);
-    } while (!Parameter && --RereadCount);
+      --RereadCount;
+    } while ((Parameter == 0) && (RereadCount != 0));
 
     //
     // Get the parameter if populated.

--- a/UefiCpuPkg/Test/UefiCpuPkgHostTest.dsc
+++ b/UefiCpuPkg/Test/UefiCpuPkgHostTest.dsc
@@ -12,7 +12,7 @@
   PLATFORM_VERSION        = 0.1
   DSC_SPECIFICATION       = 0x00010005
   OUTPUT_DIRECTORY        = Build/UefiCpuPkg/HostTest
-  SUPPORTED_ARCHITECTURES = IA32|X64
+  SUPPORTED_ARCHITECTURES = IA32|X64|AARCH64
   BUILD_TARGETS           = NOOPT
   SKUID_IDENTIFIER        = DEFAULT
 
@@ -23,17 +23,19 @@
   CpuPageTableLib|UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableLib.inf
   OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
   BaseCryptLib|CryptoPkg/Library/BaseCryptLib/UnitTestHostBaseCryptLib.inf
-  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
+  TimerLib|UnitTestFrameworkPkg/Library/Posix/TimerLibPosix/TimerLibPosix.inf
+  RngLib|MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
 
 [PcdsPatchableInModule]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuNumberOfReservedVariableMtrrs|0
 
-[Components]
+[Components.IA32, Components.X64]
   #
   # Build HOST_APPLICATION that tests the MtrrLib
   #
   UefiCpuPkg/Library/MtrrLib/UnitTest/MtrrLibUnitTestHost.inf
 
+[Components]
   #
   # Build HOST_APPLICATION that tests the CpuPageTableLib
   #

--- a/UnitTestFrameworkPkg/Library/Posix/TimerLibPosix/TimerLibPosix.c
+++ b/UnitTestFrameworkPkg/Library/Posix/TimerLibPosix/TimerLibPosix.c
@@ -1,0 +1,193 @@
+/** @file
+  Instance of Timer Library based on the host's standard C library.
+
+  Uses the C11 timespec_get() API to provide a free running performance
+  counter and calibrated delays for host-based unit tests.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <time.h>
+
+#include <Base.h>
+#include <Library/TimerLib.h>
+#include <Library/DebugLib.h>
+
+///
+/// The host performance counter provided by this library counts in
+/// nanoseconds, so its frequency is one billion ticks per second.
+///
+#define TIMER_LIB_POSIX_NANO_SECONDS_PER_SECOND        1000000000ULL
+#define TIMER_LIB_POSIX_NANO_SECONDS_PER_MICRO_SECOND  1000ULL
+
+/**
+  Reads the host's real time clock and returns the current time in nanoseconds.
+
+  @return The current host time in nanoseconds.
+
+**/
+STATIC
+UINT64
+GetHostTimeInNanoSeconds (
+  VOID
+  )
+{
+  struct timespec  Time;
+
+  if (timespec_get (&Time, TIME_UTC) == 0) {
+    //
+    // The host clock could not be read. This is not expected on any
+    // supported host, so assert to surface the failure to the developer.
+    //
+    ASSERT (FALSE);
+    return 0;
+  }
+
+  return ((UINT64)Time.tv_sec * TIMER_LIB_POSIX_NANO_SECONDS_PER_SECOND) +
+         (UINT64)Time.tv_nsec;
+}
+
+/**
+  Stalls the CPU for at least the given number of nanoseconds.
+
+  Stalls the CPU for the number of nanoseconds specified by NanoSeconds.
+
+  @param  NanoSeconds The minimum number of nanoseconds to delay.
+
+  @return The value of NanoSeconds inputted.
+
+**/
+UINTN
+EFIAPI
+NanoSecondDelay (
+  IN      UINTN  NanoSeconds
+  )
+{
+  UINT64  Start;
+
+  Start = GetHostTimeInNanoSeconds ();
+  while ((GetHostTimeInNanoSeconds () - Start) < (UINT64)NanoSeconds) {
+    //
+    // Busy wait until the host clock has advanced by the requested delay.
+    //
+  }
+
+  return NanoSeconds;
+}
+
+/**
+  Stalls the CPU for at least the given number of microseconds.
+
+  Stalls the CPU for the number of microseconds specified by MicroSeconds.
+
+  @param  MicroSeconds  The minimum number of microseconds to delay.
+
+  @return The value of MicroSeconds inputted.
+
+**/
+UINTN
+EFIAPI
+MicroSecondDelay (
+  IN      UINTN  MicroSeconds
+  )
+{
+  UINT64  Start;
+  UINT64  DelayInNanoSeconds;
+
+  DelayInNanoSeconds = (UINT64)MicroSeconds * TIMER_LIB_POSIX_NANO_SECONDS_PER_MICRO_SECOND;
+  Start              = GetHostTimeInNanoSeconds ();
+  while ((GetHostTimeInNanoSeconds () - Start) < DelayInNanoSeconds) {
+    //
+    // Busy wait until the host clock has advanced by the requested delay.
+    //
+  }
+
+  return MicroSeconds;
+}
+
+/**
+  Retrieves the current value of a 64-bit free running performance counter.
+
+  The counter can either count up by 1 or count down by 1. If the physical
+  performance counter counts by a larger increment, then the counter values
+  must be translated. The properties of the counter can be retrieved from
+  GetPerformanceCounterProperties().
+
+  @return The current value of the free running performance counter.
+
+**/
+UINT64
+EFIAPI
+GetPerformanceCounter (
+  VOID
+  )
+{
+  return GetHostTimeInNanoSeconds ();
+}
+
+/**
+  Retrieves the 64-bit frequency in Hz and the range of performance counter
+  values.
+
+  If StartValue is not NULL, then the value that the performance counter starts
+  with immediately after is it rolls over is returned in StartValue. If
+  EndValue is not NULL, then the value that the performance counter end with
+  immediately before it rolls over is returned in EndValue. The 64-bit
+  frequency of the performance counter in Hz is always returned. If StartValue
+  is less than EndValue, then the performance counter counts up. If StartValue
+  is greater than EndValue, then the performance counter counts down. For
+  example, a 64-bit free running counter that counts up would have a StartValue
+  of 0 and an EndValue of 0xFFFFFFFFFFFFFFFF. A 24-bit free running counter
+  that counts down would have a StartValue of 0xFFFFFF and an EndValue of 0.
+
+  @param  StartValue  The value the performance counter starts with when it
+                      rolls over.
+  @param  EndValue    The value that the performance counter ends with before
+                      it rolls over.
+
+  @return The frequency in Hz.
+
+**/
+UINT64
+EFIAPI
+GetPerformanceCounterProperties (
+  OUT      UINT64  *StartValue   OPTIONAL,
+  OUT      UINT64  *EndValue     OPTIONAL
+  )
+{
+  if (StartValue != NULL) {
+    *StartValue = 0;
+  }
+
+  if (EndValue != NULL) {
+    *EndValue = MAX_UINT64;
+  }
+
+  return TIMER_LIB_POSIX_NANO_SECONDS_PER_SECOND;
+}
+
+/**
+  Converts elapsed ticks of performance counter to time in nanoseconds.
+
+  This function converts the elapsed ticks of running performance counter to
+  time value in unit of nanoseconds.
+
+  @param  Ticks     The number of elapsed ticks of running performance counter.
+
+  @return The elapsed time in nanoseconds.
+
+**/
+UINT64
+EFIAPI
+GetTimeInNanoSecond (
+  IN      UINT64  Ticks
+  )
+{
+  //
+  // The performance counter ticks are already in nanoseconds
+  // (frequency is TIMER_LIB_POSIX_NANO_SECONDS_PER_SECOND), so the elapsed
+  // ticks are equal to the elapsed time in nanoseconds.
+  //
+  return Ticks;
+}

--- a/UnitTestFrameworkPkg/Library/Posix/TimerLibPosix/TimerLibPosix.inf
+++ b/UnitTestFrameworkPkg/Library/Posix/TimerLibPosix/TimerLibPosix.inf
@@ -1,0 +1,29 @@
+## @file
+#  Instance of Timer Library based on the host's standard C library.
+#
+#  Uses the C11 timespec_get() API to provide a free running performance
+#  counter and calibrated delays for host-based unit tests.
+#
+#  Do NOT use this on a production system.
+#
+#  Copyright (c) Microsoft Corporation.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION     = 0x0001001B
+  BASE_NAME       = TimerLibPosix
+  FILE_GUID       = 6C3F9A17-9A1B-4E5C-8B7D-2E9F4A6C1D30
+  MODULE_TYPE     = BASE
+  VERSION_STRING  = 1.0
+  LIBRARY_CLASS   = TimerLib|HOST_APPLICATION
+
+[Sources]
+  TimerLibPosix.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  DebugLib

--- a/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTest.dsc
+++ b/UnitTestFrameworkPkg/Test/UnitTestFrameworkPkgHostTest.dsc
@@ -35,6 +35,7 @@
   UnitTestFrameworkPkg/Library/GoogleTestLib/GoogleTestLib.inf
   UnitTestFrameworkPkg/Library/Posix/DebugLibPosix/DebugLibPosix.inf
   UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.inf
+  UnitTestFrameworkPkg/Library/Posix/TimerLibPosix/TimerLibPosix.inf
   UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLibCmocka.inf
   UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
 


### PR DESCRIPTION
# Description

This change is a follow up the previously merge PR #12070.

With the host based units now run on AArch64 systems, we can onboard more unit tests, i.e. SecurityPkg, CryptoPkg and UefiCpuPkg. However, these packages require the `RngLib` to be available.

This PR takes the approach of supplying a host based `TimerLib` to serve as the backend of timer based `RngLib` to support such functionality.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested on AArch64 host systems and all involved packages can run host based unit tests properly.

## Integration Instructions

N/A
