### PR TITLE
Dxe core add interrupt enable nesting guard

### DIFF
--- a/MdeModulePkg/Core/Dxe/Event/Tpl.c
+++ b/MdeModulePkg/Core/Dxe/Event/Tpl.c
@@ -9,6 +9,21 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "DxeMain.h"
 #include "Event.h"
 
+//
+// Maximum interrupt nesting depth allowed by the UEFI/PI specifications.
+// Comprised of 3 software TPL levels (TPL_APPLICATION, TPL_CALLBACK,
+// TPL_NOTIFY) plus 16 hardware interrupt priority levels (TPL 16..31).
+//
+#define MAX_INTERRUPT_ENABLE_NEST_DEPTH  (3 + 16)
+
+//
+// Counter for tracking interrupt enable recursion depth.
+// Incremented on entry to CoreSetInterruptState(TRUE) and decremented on exit.
+// Prevents stack overflow from infinite interrupt recursion loops.
+// Must not exceed MAX_INTERRUPT_ENABLE_NEST_DEPTH per UEFI/PI specs.
+//
+static volatile UINTN  mInterruptEnableNestDepth = 0;
+
 /**
   Set Interrupt State.
 
@@ -39,7 +54,12 @@ CoreSetInterruptState (
     }
   }
 
+  mInterruptEnableNestDepth++;
+  ASSERT (mInterruptEnableNestDepth < MAX_INTERRUPT_ENABLE_NEST_DEPTH);
+
   gCpu->EnableInterrupt (gCpu);
+
+  mInterruptEnableNestDepth--;
 }
 
 /**

--- a/MdeModulePkg/Core/Dxe/Event/Tpl.c
+++ b/MdeModulePkg/Core/Dxe/Event/Tpl.c
@@ -32,15 +32,14 @@ CoreSetInterruptState (
     return;
   }
 
-  if (gSmmBase2 == NULL) {
-    gCpu->EnableInterrupt (gCpu);
-    return;
+  if (gSmmBase2 != NULL) {
+    Status = gSmmBase2->InSmm (gSmmBase2, &InSmm);
+    if (EFI_ERROR (Status) || InSmm) {
+      return;
+    }
   }
 
-  Status = gSmmBase2->InSmm (gSmmBase2, &InSmm);
-  if (!EFI_ERROR (Status) && !InSmm) {
-    gCpu->EnableInterrupt (gCpu);
-  }
+  gCpu->EnableInterrupt (gCpu);
 }
 
 /**


### PR DESCRIPTION
# Description

Refactor the CoreSetInterruptState(TRUE) flow so EnableInterrupt() is invoked through a single call site.

Add interrupt-enable recursion depth tracking using mInterruptEnableNestDepth and a bounded assertion in CoreSetInterruptState().

This provides early detection for unintended recursive interrupt-enable loops.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Verify no impact to current platforms.

Verify that ASSERT() is triggered on platform with high frequency timer interrupts and a windows where interrupts are unmasked incorrectly.  Previously, this would cause unbonded recursion until stack overflow detected with stack guard page or non-deterministic failure due to stack overflow.

## Integration Instructions

N/A
