### PR TITLE
UefiCpuPkg/CpuDxe: Read hardware interrupt state in GetInterruptState

### DIFF
--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -13,8 +13,7 @@
 //
 // Global Variables
 //
-BOOLEAN     InterruptState = FALSE;
-EFI_HANDLE  mCpuHandle     = NULL;
+EFI_HANDLE  mCpuHandle = NULL;
 BOOLEAN     mIsFlushingGCD;
 BOOLEAN     mIsAllocatingPageTable = FALSE;
 UINT64      mTimerPeriod           = 0;
@@ -88,7 +87,6 @@ CpuEnableInterrupt (
 {
   EnableInterrupts ();
 
-  InterruptState = TRUE;
   return EFI_SUCCESS;
 }
 
@@ -109,7 +107,6 @@ CpuDisableInterrupt (
 {
   DisableInterrupts ();
 
-  InterruptState = FALSE;
   return EFI_SUCCESS;
 }
 
@@ -134,7 +131,7 @@ CpuGetInterruptState (
     return EFI_INVALID_PARAMETER;
   }
 
-  *State = InterruptState;
+  *State = GetInterruptState ();
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
# Description

Fix CpuGetInterruptState() to read the actual hardware interrupt flag (RFLAGS.IF) via BaseLib's GetInterruptState() instead of returning a cached boolean variable. The cached variable becomes stale in interrupt context where hardware disables interrupts without going through the protocol's DisableInterrupt() call.

Update the cache after reading hardware for backward compatibility with any code that may depend on the cached value being current.

This is a PI Spec conformance fix: EFI_CPU_ARCH_PROTOCOL.GetInterruptState() is specified to return the current processor interrupt state.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Verify no platform regressions with this change.

## Integration Instructions

N/A