### PR TITLE
UefiCpuPkg/CpuDxeRiscV64: Read hardware interrupt state in GetInterruptState

### DIFF
--- a/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxeRiscV64/CpuDxe.c
@@ -13,8 +13,7 @@
 //
 // Global Variables
 //
-STATIC BOOLEAN           mInterruptState = FALSE;
-STATIC EFI_HANDLE        mCpuHandle      = NULL;
+STATIC EFI_HANDLE        mCpuHandle = NULL;
 STATIC UINTN             mBootHartId;
 RISCV_EFI_BOOT_PROTOCOL  gRiscvBootProtocol;
 
@@ -123,7 +122,6 @@ CpuEnableInterrupt (
   )
 {
   EnableInterrupts ();
-  mInterruptState = TRUE;
   return EFI_SUCCESS;
 }
 
@@ -143,7 +141,6 @@ CpuDisableInterrupt (
   )
 {
   DisableInterrupts ();
-  mInterruptState = FALSE;
   return EFI_SUCCESS;
 }
 
@@ -168,7 +165,7 @@ CpuGetInterruptState (
     return EFI_INVALID_PARAMETER;
   }
 
-  *State = mInterruptState;
+  *State = GetInterruptState ();
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
# Description

Fix CpuGetInterruptState() to read the actual hardware interrupt flag (sstatus.SIE) via BaseLib's GetInterruptState() instead of returning a cached boolean variable. The cached variable becomes stale in interrupt context where hardware disables interrupts without going through the protocol's DisableInterrupt() call.

Update the cache after reading hardware for backward compatibility with any code that may depend on the cached value being current.

This is a PI Spec conformance fix: EFI_CPU_ARCH_PROTOCOL.GetInterruptState() is specified to return the current processor interrupt state.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested


## Integration Instructions

N/A
