### PR TITLE
FatPkg: Skipping dirty caches flush for ESP in pre-ExitBootServices

### DIFF
--- a/FatPkg/EnhancedFatDxe/Fat.h
+++ b/FatPkg/EnhancedFatDxe/Fat.h
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/BlockIo.h>
 #include <Protocol/DiskIo.h>
 #include <Protocol/DiskIo2.h>
+#include <Protocol/PartitionInfo.h>
 #include <Protocol/SimpleFileSystem.h>
 #include <Protocol/UnicodeCollation.h>
 

--- a/FatPkg/EnhancedFatDxe/Fat.inf
+++ b/FatPkg/EnhancedFatDxe/Fat.inf
@@ -78,6 +78,7 @@
   gEfiDiskIoProtocolGuid                ## TO_START
   gEfiDiskIo2ProtocolGuid               ## TO_START
   gEfiBlockIoProtocolGuid               ## TO_START
+  gEfiPartitionInfoProtocolGuid         ## SOMETIMES_CONSUMES
   gEfiSimpleFileSystemProtocolGuid      ## BY_START
   gEfiUnicodeCollation2ProtocolGuid     ## TO_START
 

--- a/FatPkg/EnhancedFatDxe/Misc.c
+++ b/FatPkg/EnhancedFatDxe/Misc.c
@@ -458,6 +458,36 @@ FatFreeDirEnt (
 }
 
 /**
+  Return whether the volume is an EFI System Partition.
+
+  @param Volume - FAT file system volume.
+
+  @retval TRUE  - The volume is identified as an EFI System Partition.
+  @retval FALSE - The volume is not identified as an EFI System Partition.
+
+**/
+STATIC
+BOOLEAN
+FatIsEfiSystemPartition (
+  IN FAT_VOLUME  *Volume
+  )
+{
+  EFI_STATUS                   Status;
+  EFI_PARTITION_INFO_PROTOCOL  *PartitionInfo;
+
+  Status = gBS->HandleProtocol (
+                  Volume->Handle,
+                  &gEfiPartitionInfoProtocolGuid,
+                  (VOID **)&PartitionInfo
+                  );
+  if (EFI_ERROR (Status)) {
+    return FALSE;
+  }
+
+  return (BOOLEAN)(PartitionInfo->System != 0);
+}
+
+/**
   Pre-ExitBootServices notification, signaled once per FAT volume. Context
   is the FAT_VOLUME this event was created for. This routine will flush any
   dirty caches for the volume.
@@ -489,6 +519,18 @@ FatOnBeforeExitBootServices (
   Status = FatAcquireLockOrFail ();
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "%a: FAT lock busy, skipping flush of %p\n", __func__, Volume->Handle));
+    return;
+  }
+
+  if (FatIsEfiSystemPartition (Volume)) {
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: skipping pre-ExitBootServices flush for ESP %p\n",
+      __func__,
+      Volume->Handle
+      ));
+    Volume->CachingDisabled = TRUE;
+    FatReleaseLock ();
     return;
   }
 


### PR DESCRIPTION
The FatPkg change was added to prevent dirty FAT cache loss on ungraceful power-off (data integrity).
If that concern must also be addressed, a targeted fix should limit flushing to non-ESP volumes or preserve pre-flush file timestamps to avoid making FAT directory entries time-dependent — without affecting the TPM measurement chain.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

[HLK]: TPM 2.0 - Supplemental test with dTPM and PTT test case pass

## Integration Instructions

N/A
