### PR TITLE
OvmfPkg/LoongArchVirt: Add Hash2DxeCrypto to satisfy TcpDxe dependency

### DIFF
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -650,6 +650,11 @@
   OvmfPkg/VirtioRngDxe/VirtioRng.inf
 
   #
+  # Hash2 protocol, needed to dispatch TcpDxe
+  #
+  SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
+
+  #
   # FAT filesystem + GPT/MBR partitioning + UDF filesystem + virtio-fs
   #
   MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf

--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
@@ -118,6 +118,11 @@ INF  OvmfPkg/VirtioRngDxe/VirtioRng.inf
 INF  OvmfPkg/VirtioNetDxe/VirtioNet.inf
 
 #
+# Hash2 protocol, needed to dispatch TcpDxe
+#
+INF  SecurityPkg/Hash2DxeCrypto/Hash2DxeCrypto.inf
+
+#
 # Console
 #
 INF  MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf


### PR DESCRIPTION
# Description

This patch is similar with https://github.com/tianocore/edk2/pull/12924.

The TcpDxe driver requires the Hash2 protocol to be available for its dispatch. On the LoongArchVirt QEMU platform, this protocol was not previously included, leading to failures when the network stack attempted to initialize.

Add SecurityPkg/Hash2DxeCrypto to both the DSC and FDF files, ensuring that the Hash2 protocol is installed and can be consumed by TcpDxe.

## How This Was Tested

Run command: `qemu-system-loongarch64 -m 4G -M virt -smp 2 -cpu la464 -bios Build/LoongArchVirtQemu/DEBUG_GCC/FV/QEMU_EFI.fd -nographic -D NETWORK_ENABLE=TRUE -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0`, enter UEFI Shell, and run `drivers` command, the output contains:

> 82 0000000A D - -  1  - TCP Network Service Driver          TcpDxe                                                                                                                      
> 83 0000000A ? - -  -  - TCP Network Service Driver          TcpDxe

## Integration Instructions

N/A
