### PR TITLE
OvmfPkg/LoongArchVirt: Add NOOPT as valid build target

### DIFF
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc
@@ -19,7 +19,7 @@
   DSC_SPECIFICATION              = 1.29
   OUTPUT_DIRECTORY               = Build/$(PLATFORM_NAME)
   SUPPORTED_ARCHITECTURES        = LOONGARCH64
-  BUILD_TARGETS                  = DEBUG|RELEASE
+  BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
   FLASH_DEFINITION               = OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
 


### PR DESCRIPTION
# Description

Add NOOPT as valid build target for LOONGARCH64 virtual machine platform.

## How This Was Tested

Run command `build -a X64 -t GCC -D NOOPT -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc`, the build process can successfully run.

## Integration Instructions

N/A
