### PR TITLE
NetworkPkg/HttpBootDxe: Accumulate PartialTransferredSize across retries

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootClient.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootClient.c
@@ -1649,7 +1649,7 @@ HttpBootGetBootFile (
             // For EFI_TIMEOUT and EFI_DEVICE_ERROR errors, we may resume the operation.
             // We will not check if server sent Accept-Ranges header, because some back-ends
             // do not report this header, even when supporting it. Know example: CloudFlare CDN Cache.
-            Private->PartialTransferredSize = ReceivedSize;
+            Private->PartialTransferredSize += ReceivedSize;
             DEBUG (
               (
                DEBUG_WARN | DEBUG_INFO,


### PR DESCRIPTION
When an HTTP download fails with EFI_TIMEOUT or EFI_DEVICE_ERROR and is retried, PartialTransferredSize was overwritten with only the bytes received during that attempt instead of accumulating the running total.

This caused the progress percentage to exceed 100%: on each retry the already-transferred bytes were ignored, so the buffer offset calculation started from an incorrect position and data was re-downloaded from an earlier offset.  The cumulative ReceivedSize that feeds the percentage display therefore grew beyond FileSize.

Fix by using += instead of = when updating PartialTransferredSize on a failed transfer so that cumulative progress is maintained across all retry attempts.

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)

Signed-off-by: Abuthahir M [abuthahirm@ami.com](mailto:abuthahirm@ami.com)