### PR TITLE
NetworkPkg/TcpDxe: Use per-service Hash2 child handle instead of global

### DIFF
--- a/NetworkPkg/TcpDxe/TcpDriver.c
+++ b/NetworkPkg/TcpDxe/TcpDriver.c
@@ -83,12 +83,6 @@ EFI_SERVICE_BINDING_PROTOCOL  gTcpServiceBinding = {
   TcpServiceBindingDestroyChild
 };
 
-//
-// This is the handle for the Hash2ServiceBinding Protocol instance this driver produces
-// if the platform does not provide one.
-//
-EFI_HANDLE  mHash2ServiceHandle = NULL;
-
 /**
   Create and start the heartbeat timer for the TCP driver.
 
@@ -265,6 +259,7 @@ TcpCreateService (
   IP_IO_OPEN_DATA               OpenData;
   EFI_SERVICE_BINDING_PROTOCOL  *Hash2ServiceBinding;
   EFI_HASH2_PROTOCOL            *Hash2Protocol;
+  EFI_HANDLE                    Hash2ChildHandle;
 
   if (IpVersion == IP_VERSION_4) {
     IpServiceBindingGuid  = &gEfiIp4ServiceBindingProtocolGuid;
@@ -298,28 +293,27 @@ TcpCreateService (
     return EFI_UNSUPPORTED;
   }
 
-  Status = gBS->LocateProtocol (&gEfiHash2ProtocolGuid, NULL, (VOID **)&Hash2Protocol);
-  if (EFI_ERROR (Status)) {
+  Hash2ChildHandle    = NULL;
+  Hash2ServiceBinding = NULL;
+  Status              = gBS->LocateProtocol (
+                               &gEfiHash2ServiceBindingProtocolGuid,
+                               NULL,
+                               (VOID **)&Hash2ServiceBinding
+                               );
+  if (!EFI_ERROR (Status) && (Hash2ServiceBinding != NULL) && (Hash2ServiceBinding->CreateChild != NULL)) {
     //
-    // If we can't find the Hashing protocol, then we need to create one.
+    // Create a dedicated Hash2 child for this TCP service instance.
     //
-
-    //
-    // Platform is expected to publish the hash service binding protocol to support TCP.
-    //
-    Status = gBS->LocateProtocol (
-                    &gEfiHash2ServiceBindingProtocolGuid,
-                    NULL,
-                    (VOID **)&Hash2ServiceBinding
-                    );
-    if (EFI_ERROR (Status) || (Hash2ServiceBinding == NULL) || (Hash2ServiceBinding->CreateChild == NULL)) {
+    Status = Hash2ServiceBinding->CreateChild (Hash2ServiceBinding, &Hash2ChildHandle);
+    if (EFI_ERROR (Status)) {
       return EFI_UNSUPPORTED;
     }
-
+  } else {
     //
-    // Create an instance of the hash protocol for this controller.
+    // No Hash2ServiceBinding; verify the platform provides Hash2 directly.
     //
-    Status = Hash2ServiceBinding->CreateChild (Hash2ServiceBinding, &mHash2ServiceHandle);
+    Hash2ServiceBinding = NULL;
+    Status              = gBS->LocateProtocol (&gEfiHash2ProtocolGuid, NULL, (VOID **)&Hash2Protocol);
     if (EFI_ERROR (Status)) {
       return EFI_UNSUPPORTED;
     }
@@ -330,8 +324,14 @@ TcpCreateService (
   //
   TcpServiceData = AllocateZeroPool (sizeof (TCP_SERVICE_DATA));
   if (TcpServiceData == NULL) {
+    if ((Hash2ServiceBinding != NULL) && (Hash2ServiceBinding->DestroyChild != NULL)) {
+      Hash2ServiceBinding->DestroyChild (Hash2ServiceBinding, Hash2ChildHandle);
+    }
+
     return EFI_OUT_OF_RESOURCES;
   }
+
+  TcpServiceData->Hash2ServiceHandle = Hash2ChildHandle;
 
   TcpServiceData->Signature           = TCP_DRIVER_SIGNATURE;
   TcpServiceData->ControllerHandle    = Controller;
@@ -394,6 +394,14 @@ TcpCreateService (
   return EFI_SUCCESS;
 
 ON_ERROR:
+
+  if (TcpServiceData->Hash2ServiceHandle != NULL) {
+    if ((Hash2ServiceBinding != NULL) && (Hash2ServiceBinding->DestroyChild != NULL)) {
+      Hash2ServiceBinding->DestroyChild (Hash2ServiceBinding, TcpServiceData->Hash2ServiceHandle);
+    }
+
+    TcpServiceData->Hash2ServiceHandle = NULL;
+  }
 
   if (TcpServiceData->IpIo != NULL) {
     IpIoDestroy (TcpServiceData->IpIo);
@@ -493,30 +501,6 @@ TcpDestroyService (
     return EFI_SUCCESS;
   }
 
-  //
-  // Destroy the Hash2ServiceBinding instance if it is created by Tcp driver.
-  //
-  if (mHash2ServiceHandle != NULL) {
-    Status = gBS->LocateProtocol (
-                    &gEfiHash2ServiceBindingProtocolGuid,
-                    NULL,
-                    (VOID **)&Hash2ServiceBinding
-                    );
-    if (EFI_ERROR (Status) || (Hash2ServiceBinding == NULL) || (Hash2ServiceBinding->DestroyChild == NULL)) {
-      return EFI_UNSUPPORTED;
-    }
-
-    //
-    // Destroy the instance of the hashing protocol for this controller.
-    //
-    Status = Hash2ServiceBinding->DestroyChild (Hash2ServiceBinding, mHash2ServiceHandle);
-    if (EFI_ERROR (Status)) {
-      return EFI_UNSUPPORTED;
-    }
-
-    mHash2ServiceHandle = NULL;
-  }
-
   Status = gBS->OpenProtocol (
                   NicHandle,
                   ServiceBindingGuid,
@@ -552,6 +536,24 @@ TcpDestroyService (
            ServiceBinding,
            NULL
            );
+
+    if (TcpServiceData->Hash2ServiceHandle != NULL) {
+      Status = gBS->LocateProtocol (
+                      &gEfiHash2ServiceBindingProtocolGuid,
+                      NULL,
+                      (VOID **)&Hash2ServiceBinding
+                      );
+      if (EFI_ERROR (Status) || (Hash2ServiceBinding == NULL) || (Hash2ServiceBinding->DestroyChild == NULL)) {
+        return EFI_UNSUPPORTED;
+      }
+
+      Status = Hash2ServiceBinding->DestroyChild (Hash2ServiceBinding, TcpServiceData->Hash2ServiceHandle);
+      if (EFI_ERROR (Status)) {
+        return EFI_UNSUPPORTED;
+      }
+
+      TcpServiceData->Hash2ServiceHandle = NULL;
+    }
 
     //
     // Destroy the IpIO consumed by TCP driver

--- a/NetworkPkg/TcpDxe/TcpDriver.h
+++ b/NetworkPkg/TcpDxe/TcpDriver.h
@@ -27,6 +27,7 @@ typedef struct _TCP_SERVICE_DATA {
   IP_IO                           *IpIo;
   EFI_SERVICE_BINDING_PROTOCOL    ServiceBinding;
   LIST_ENTRY                      SocketList;
+  EFI_HANDLE                      Hash2ServiceHandle;
 } TCP_SERVICE_DATA;
 
 typedef struct _TCP_PROTO_DATA {


### PR DESCRIPTION
The mHash2ServiceHandle variable was a single global EFI_HANDLE shared across all TCP service instances. When multiple NICs were active (e.g., USB PXE on NIC1 followed by HTTP Boot on NIC2), only the first TCP service created a Hash2 child while subsequent services reused the same global handle without reference tracking.

When NIC1's TCP service was destroyed, TcpDestroyService() destroyed the shared Hash2 child. NIC2's IPv6 TCP service was then left without a valid Hash2 protocol instance. The next TcpGetIsn() call on NIC2 invoked LocateProtocol(gEfiHash2ProtocolGuid) which returned EFI_NOT_FOUND, triggering an ASSERT.

Fix this by tracking a dedicated Hash2 child handle per TCP_SERVICE_DATA instance. TcpCreateService() now always attempts to create its own Hash2 child via Hash2ServiceBinding->CreateChild(), storing the handle in TcpServiceData->Hash2ServiceHandle. TcpDestroyService() then destroys only that service's own child, leaving sibling services unaffected.

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-Williams <zachary.clark-williams@intel.com>
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)

Signed-off-by: Abuthahir M [abuthahirm@ami.com](mailto:abuthahirm@ami.com)