### PR TITLE
NetworkPkg/DxeNetLib: Set *MediaState to EFI_NO_MEDIA if no SNP handle

### DIFF
--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -1308,7 +1308,8 @@ NetLibDetectMedia (
 
   @retval EFI_SUCCESS           Media detection success.
   @retval EFI_INVALID_PARAMETER ServiceHandle is not a valid network device handle or
-                                MediaState pointer is NULL.
+                                MediaState pointer is NULL. When returned because no SNP
+                                handle is found, *MediaState is set to EFI_NO_MEDIA.
   @retval EFI_DEVICE_ERROR      A device error occurred.
   @retval EFI_TIMEOUT           Network is connecting but timeout.
 

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -2673,7 +2673,8 @@ Exit:
 
   @retval EFI_SUCCESS           Media detection success.
   @retval EFI_INVALID_PARAMETER ServiceHandle is not a valid network device handle or
-                                MediaState pointer is NULL.
+                                MediaState pointer is NULL. When returned because no SNP
+                                handle is found, *MediaState is set to EFI_NO_MEDIA.
   @retval EFI_DEVICE_ERROR      A device error occurred.
   @retval EFI_TIMEOUT           Network is connecting but timeout.
 
@@ -2710,6 +2711,7 @@ NetLibDetectMediaWaitTimeout (
   Snp       = NULL;
   SnpHandle = NetLibGetSnpHandle (ServiceHandle, &Snp);
   if (SnpHandle == NULL) {
+    *MediaState = EFI_NO_MEDIA;
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
In NetLibDetectMediaWaitTimeout(), *MediaState is pre-initialized to EFI_SUCCESS before the SNP handle lookup. When no SNP handle is found, the function returns EFI_INVALID_PARAMETER but leaves *MediaState as EFI_SUCCESS. Callers such as PxeCheckMediaState() that rely solely on *MediaState (ignoring the return value) incorrectly treat a system with no network device as having media connected.

Fix this by setting *MediaState = EFI_NO_MEDIA inside the (SnpHandle == NULL) branch before returning EFI_INVALID_PARAMETER.

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)

Signed-off-by: Abuthahir M [abuthahirm@ami.com](mailto:abuthahirm@ami.com)