### PR TITLE
NetworkPkg/IScsiDxe: Validate DHCPv6 RootPath fields

### DIFF
--- a/NetworkPkg/IScsiDxe/GoogleTest/IScsiDhcp6GoogleTest.cpp
+++ b/NetworkPkg/IScsiDxe/GoogleTest/IScsiDhcp6GoogleTest.cpp
@@ -1,0 +1,239 @@
+/** @file
+  Host based unit tests for IScsiDhcp6.c.
+
+  Copyright (c) 2026, 20000419. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+
+#include <string>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseMemoryLib.h>
+  #include "../IScsiImpl.h"
+}
+
+#if defined (_WIN32)
+extern "C" {
+  typedef UINT32 (__stdcall *PARSER_THREAD_START_ROUTINE)(VOID *Context);
+
+  __declspec(dllimport)
+  VOID *
+  __stdcall
+  CreateThread (
+    VOID                         *ThreadAttributes,
+    UINTN                        StackSize,
+    PARSER_THREAD_START_ROUTINE  StartAddress,
+    VOID                         *Parameter,
+    UINT32                       CreationFlags,
+    UINT32                       *ThreadId
+    );
+
+  __declspec(dllimport)
+  UINT32
+  __stdcall
+  WaitForSingleObject (
+    VOID    *Handle,
+    UINT32  Milliseconds
+    );
+
+  __declspec(dllimport)
+  INT32
+  __stdcall
+  TerminateThread (
+    VOID    *Thread,
+    UINT32  ExitCode
+    );
+
+  __declspec(dllimport)
+  INT32
+  __stdcall
+  CloseHandle (
+    VOID  *Object
+    );
+}
+#elif defined (__linux__)
+  #include <signal.h>
+  #include <sys/wait.h>
+  #include <unistd.h>
+#endif
+
+namespace {
+constexpr UINT32  PARSER_WATCHDOG_MS = 3000;
+ #if defined (_WIN32)
+constexpr UINT32  WIN_WAIT_OBJECT_0 = 0;
+ #endif
+
+void
+InitializeConfig (
+  OUT ISCSI_ATTEMPT_CONFIG_NVDATA  *ConfigData
+  )
+{
+  ZeroMem (ConfigData, sizeof (*ConfigData));
+  ConfigData->SessionConfigData.IpMode = IP_MODE_AUTOCONFIG;
+  ConfigData->AutoConfigureMode        = IP_MODE_IP6;
+}
+
+ #if defined (_WIN32)
+typedef struct {
+  std::string    RootPath;
+  EFI_STATUS     Status;
+} PARSER_CONTEXT;
+
+UINT32
+__stdcall
+RunParser (
+  IN VOID  *Context
+  )
+{
+  PARSER_CONTEXT               *ParserContext;
+  ISCSI_ATTEMPT_CONFIG_NVDATA  ConfigData;
+
+  ParserContext = (PARSER_CONTEXT *)Context;
+  InitializeConfig (&ConfigData);
+  ParserContext->Status = IScsiDhcp6ExtractRootPath (
+                            ParserContext->RootPath.data (),
+                            (UINT16)ParserContext->RootPath.size (),
+                            &ConfigData
+                            );
+  return 0;
+}
+
+ #endif
+
+bool
+RejectsWithinWatchdog (
+  IN const std::string  &RootPath
+  )
+{
+ #if defined (_WIN32)
+  PARSER_CONTEXT  Context;
+  VOID            *Thread;
+  UINT32          WaitStatus;
+
+  Context.RootPath = RootPath;
+  Context.Status   = EFI_SUCCESS;
+  Thread           = CreateThread (NULL, 0, RunParser, &Context, 0, NULL);
+  if (Thread == NULL) {
+    return false;
+  }
+
+  WaitStatus = WaitForSingleObject (Thread, PARSER_WATCHDOG_MS);
+  if (WaitStatus != WIN_WAIT_OBJECT_0) {
+    TerminateThread (Thread, 1);
+    CloseHandle (Thread);
+    return false;
+  }
+
+  CloseHandle (Thread);
+  return Context.Status == EFI_INVALID_PARAMETER;
+ #elif defined (__linux__)
+  pid_t   ChildPid;
+  int     ChildStatus;
+  UINT32  ElapsedMs;
+
+  ChildPid = fork ();
+  if (ChildPid == -1) {
+    return false;
+  }
+
+  if (ChildPid == 0) {
+    ISCSI_ATTEMPT_CONFIG_NVDATA  ConfigData;
+    EFI_STATUS                   Status;
+    std::string                  MutableRootPath;
+
+    MutableRootPath = RootPath;
+    InitializeConfig (&ConfigData);
+    Status = IScsiDhcp6ExtractRootPath (
+               MutableRootPath.data (),
+               (UINT16)MutableRootPath.size (),
+               &ConfigData
+               );
+    _exit (Status == EFI_INVALID_PARAMETER ? 0 : 1);
+  }
+
+  ElapsedMs = 0;
+  while (ElapsedMs < PARSER_WATCHDOG_MS) {
+    pid_t  WaitResult;
+
+    WaitResult = waitpid (ChildPid, &ChildStatus, WNOHANG);
+    if (WaitResult == ChildPid) {
+      return WIFEXITED (ChildStatus) && (WEXITSTATUS (ChildStatus) == 0);
+    }
+
+    if (WaitResult == -1) {
+      return false;
+    }
+
+    usleep (10 * 1000);
+    ElapsedMs += 10;
+  }
+
+  kill (ChildPid, SIGKILL);
+  (VOID)waitpid (ChildPid, &ChildStatus, 0);
+  return false;
+ #else
+  return false;
+ #endif
+}
+} // namespace
+
+extern "C" {
+  EFI_STATUS
+  IScsiAsciiStrToIp (
+    IN  CHAR8           *Str,
+    IN  UINT8           IpMode,
+    OUT EFI_IP_ADDRESS  *Ip
+    )
+  {
+    ZeroMem (Ip, sizeof (*Ip));
+    return EFI_SUCCESS;
+  }
+
+  EFI_STATUS
+  IScsiAsciiStrToLun (
+    IN  CHAR8  *Str,
+    OUT UINT8  *Lun
+    )
+  {
+    ZeroMem (Lun, 8);
+    return EFI_SUCCESS;
+  }
+
+  EFI_STATUS
+  IScsiNormalizeName (
+    IN OUT CHAR8  *Name,
+    IN     UINTN  Len
+    )
+  {
+    return EFI_SUCCESS;
+  }
+}
+
+TEST (IScsiDhcp6ExtractRootPathTest, ParsesDnsRootPath) {
+  ISCSI_ATTEMPT_CONFIG_NVDATA  ConfigData;
+  CHAR8                        RootPath[] = "iscsi:target.example.com:6:3260:0:iqn.2026-08.com.example.target";
+
+  InitializeConfig (&ConfigData);
+
+  ASSERT_EQ (
+    IScsiDhcp6ExtractRootPath (
+      RootPath,
+      (UINT16)(sizeof (RootPath) - 1),
+      &ConfigData
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_TRUE (ConfigData.SessionConfigData.DnsMode);
+  EXPECT_EQ (ConfigData.SessionConfigData.TargetPort, 3260);
+  EXPECT_STREQ (ConfigData.SessionConfigData.TargetUrl, "target.example.com");
+  EXPECT_STREQ (ConfigData.SessionConfigData.TargetName, "iqn.2026-08.com.example.target");
+}
+
+TEST (IScsiDhcp6ExtractRootPathTest, RejectsOverlongServerName) {
+  std::string  RootPath = "iscsi:" + std::string (256, 'A') + ":0:3260:0:target";
+
+  EXPECT_TRUE (RejectsWithinWatchdog (RootPath));
+}

--- a/NetworkPkg/IScsiDxe/GoogleTest/IScsiDxeGoogleTest.cpp
+++ b/NetworkPkg/IScsiDxe/GoogleTest/IScsiDxeGoogleTest.cpp
@@ -1,0 +1,18 @@
+/** @file
+  Unit test suite entry point for IScsiDxe Google Tests.
+
+  Copyright (c) 2026, 20000419. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/NetworkPkg/IScsiDxe/GoogleTest/IScsiDxeGoogleTest.inf
+++ b/NetworkPkg/IScsiDxe/GoogleTest/IScsiDxeGoogleTest.inf
@@ -1,0 +1,41 @@
+## @file
+# Unit test suite for the IScsiDxe using Google Test
+#
+# Copyright (c) 2026, 20000419. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = IScsiDxeGoogleTest
+  FILE_GUID           = F43D3E58-0E4D-4E94-84BE-51355C8F2D9E
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = HOST_APPLICATION
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+[Sources]
+  IScsiDxeGoogleTest.cpp
+  IScsiDhcp6GoogleTest.cpp
+  ../IScsiDhcp6.c
+
+[Packages]
+  CryptoPkg/CryptoPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  NetworkPkg/NetworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+  DebugLib
+  NetLib
+  PcdLib
+
+[Protocols]
+  gEfiDhcp6ProtocolGuid
+  gEfiDhcp6ServiceBindingProtocolGuid
+
+[Pcd]
+  gEfiNetworkPkgTokenSpaceGuid.PcdMaxIScsiAttemptNumber

--- a/NetworkPkg/IScsiDxe/IScsiDhcp.h
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp.h
@@ -22,7 +22,7 @@ typedef struct _ISCSI_ATTEMPT_CONFIG_NVDATA ISCSI_ATTEMPT_CONFIG_NVDATA;
 
 typedef struct _ISCSI_ROOT_PATH_FIELD {
   CHAR8    *Str;
-  UINT8    Len;
+  UINTN    Len;
 } ISCSI_ROOT_PATH_FIELD;
 
 /**

--- a/NetworkPkg/IScsiDxe/IScsiDhcp6.c
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp6.c
@@ -37,7 +37,7 @@ IScsiDhcp6ExtractRootPath (
   ISCSI_ROOT_PATH_FIELD        Fields[RP_FIELD_IDX_MAX];
   ISCSI_ROOT_PATH_FIELD        *Field;
   UINT32                       FieldIndex;
-  UINT8                        Index;
+  UINTN                        Index;
   ISCSI_SESSION_CONFIG_NVDATA  *ConfigNvData;
   EFI_IP_ADDRESS               Ip;
   UINT8                        IpMode;
@@ -88,8 +88,17 @@ IScsiDhcp6ExtractRootPath (
   Fields[RP_FIELD_IDX_SERVERNAME].Str = &TmpStr[Index];
 
   if (!ConfigNvData->DnsMode) {
-    while ((TmpStr[Index] != ISCSI_ROOT_PATH_ADDR_END_DELIMITER) && (Index < Length)) {
+    while ((Index < Length) && (TmpStr[Index] != ISCSI_ROOT_PATH_ADDR_END_DELIMITER)) {
       Index++;
+    }
+
+    if ((Index >= Length) ||
+        ((Index + 1) >= Length) ||
+        (TmpStr[Index] != ISCSI_ROOT_PATH_ADDR_END_DELIMITER) ||
+        (TmpStr[Index + 1] != ISCSI_ROOT_PATH_FIELD_DELIMITER))
+    {
+      Status = EFI_INVALID_PARAMETER;
+      goto ON_EXIT;
     }
 
     //
@@ -98,8 +107,13 @@ IScsiDhcp6ExtractRootPath (
     TmpStr[Index] = '\0';
     Index        += 2;
   } else {
-    while ((TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER) && (Index < Length)) {
+    while ((Index < Length) && (TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER)) {
       Index++;
+    }
+
+    if ((Index >= Length) || (TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER)) {
+      Status = EFI_INVALID_PARAMETER;
+      goto ON_EXIT;
     }
 
     //
@@ -109,7 +123,7 @@ IScsiDhcp6ExtractRootPath (
     Index        += 1;
   }
 
-  Fields[RP_FIELD_IDX_SERVERNAME].Len = (UINT8)AsciiStrLen (Fields[RP_FIELD_IDX_SERVERNAME].Str);
+  Fields[RP_FIELD_IDX_SERVERNAME].Len = AsciiStrLen (Fields[RP_FIELD_IDX_SERVERNAME].Str);
 
   //
   // Extract others fields in the Root Path option string.
@@ -119,18 +133,18 @@ IScsiDhcp6ExtractRootPath (
       Fields[FieldIndex].Str = &TmpStr[Index];
     }
 
-    while ((TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER) && (Index < Length)) {
+    while ((Index < Length) && (TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER)) {
       Index++;
     }
 
-    if (TmpStr[Index] == ISCSI_ROOT_PATH_FIELD_DELIMITER) {
+    if ((Index < Length) && (TmpStr[Index] == ISCSI_ROOT_PATH_FIELD_DELIMITER)) {
       if (FieldIndex != RP_FIELD_IDX_TARGETNAME) {
         TmpStr[Index] = '\0';
         Index++;
       }
 
       if (Fields[FieldIndex].Str != NULL) {
-        Fields[FieldIndex].Len = (UINT8)AsciiStrLen (Fields[FieldIndex].Str);
+        Fields[FieldIndex].Len = AsciiStrLen (Fields[FieldIndex].Str);
       }
     }
   }

--- a/NetworkPkg/Test/NetworkPkgHostTest.dsc
+++ b/NetworkPkg/Test/NetworkPkgHostTest.dsc
@@ -26,6 +26,7 @@
   # Build HOST_APPLICATION that tests NetworkPkg
   #
   NetworkPkg/Dhcp6Dxe/GoogleTest/Dhcp6DxeGoogleTest.inf
+  NetworkPkg/IScsiDxe/GoogleTest/IScsiDxeGoogleTest.inf
   NetworkPkg/Ip6Dxe/GoogleTest/Ip6DxeGoogleTest.inf
   NetworkPkg/UefiPxeBcDxe/GoogleTest/UefiPxeBcDxeGoogleTest.inf {
     <LibraryClasses>


### PR DESCRIPTION
# Description

Update DHCPv6 RootPath parsing so the parser cursor and field-length types match the payload length. Validate expected field delimiters before advancing through the input.

Add host-based tests for a normal DNS RootPath and rejection of an overlong server-name field. The regression case uses a three-second watchdog.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- `build -p NetworkPkg/Test/NetworkPkgHostTest.dsc -m NetworkPkg/IScsiDxe/GoogleTest/IScsiDxeGoogleTest.inf -a X64 -b NOOPT -t GCC -D CONTINUOUS_INTEGRATION`
- `Build/NetworkPkg/HostTest/NOOPT_GCC/X64/IScsiDxeGoogleTest --gtest_filter=IScsiDhcp6ExtractRootPathTest.*` (2 tests passed)
- Uncrustify 73.0.11 `--check` on all modified C/C++ files

## Integration Instructions

N/A.
