### PR TITLE
EmbeddedPkg: fixup mmc interaction latency

### DIFF
--- a/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
@@ -325,7 +325,7 @@ MmcIoBlocks (
       }
     }
 
-    if (0 == Timeout) {
+    if (0 >= Timeout) {
       DEBUG ((DEBUG_ERROR, "The Card is busy\n"));
       return EFI_NOT_READY;
     }

--- a/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
@@ -210,6 +210,7 @@ MmcTransferBlock (
         break;  // Prevents delay once finished
       }
     }
+    gBS->Stall (1);
   }
 
   if (BufferSize > This->Media->BlockSize) {
@@ -323,6 +324,7 @@ MmcIoBlocks (
       if (!EFI_ERROR (Status)) {
         MmcHost->ReceiveResponse (MmcHost, MMC_RESPONSE_TYPE_R1, Response);
       }
+      gBS->Stall (1);
     }
 
     if (0 >= Timeout) {

--- a/EmbeddedPkg/Universal/MmcDxe/MmcIdentification.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcIdentification.c
@@ -596,6 +596,10 @@ MmcIdentificationMode (
       return Status;
     }
 
+    if (!OcrResponse.Ocr.PowerUp) {
+        gBS->Stall (1);
+    }
+
     Timeout--;
   } while (!OcrResponse.Ocr.PowerUp && (Timeout > 0));
 


### PR DESCRIPTION
# Description

I encountered an eMMC block read/write timeout when attempting to boot an operating system on the OrangePi Nova V1.1 board (Loongson 2K30000). The eMMC module used on this board is a Greenliant 85VM1032T.

Upon inspecting the source code, I found that the original implementation of eMMC timeout in MmcDxe is affected by the CPU execution speed. With higher-performance CPUs, the actual timeout duration would be shortened as it was not based on wall clock.

Add a precise 1us delay to each iteration of the wait loop to make the actual duration of the delay clock- and performance-agnostic. Also, move `MAX_RETRY_COUNT' to Mmc.h to save a definition.

Please note that the `MAX_RETRY_COUNT' defined here is still a value based on empirical testing (but is no less accurate than the previous value).

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

N/A.

## Integration Instructions

N/A.
