### PR TITLE
MdeModulePkg: Add GoogleTest mocks for IpmiLib and IpmiCommandLib

### DIFF
--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -90,3 +90,5 @@
   MdeModulePkg/Test/Mock/Library/GoogleTest/MockVariablePolicyHelperLib/MockVariablePolicyHelperLib.inf
   MdeModulePkg/Test/Mock/Library/GoogleTest/MockSecurityManagementLib/MockSecurityManagementLib.inf
   MdeModulePkg/Test/Mock/Library/GoogleTest/MockTpmMeasurementLib/MockTpmMeasurementLib.inf
+  MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiLib/MockIpmiLib.inf
+  MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiCommandLib/MockIpmiCommandLib.inf

--- a/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiCommandLib.h
+++ b/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiCommandLib.h
@@ -5,8 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#ifndef MOCK_IPMI_COMMAND_LIB_H_
-#define MOCK_IPMI_COMMAND_LIB_H_
+#pragma once
 
 #include <Library/GoogleTestLib.h>
 #include <Library/FunctionMockLib.h>
@@ -359,5 +358,3 @@ struct MockIpmiCommandLib {
     )
     );
 };
-
-#endif

--- a/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiCommandLib.h
+++ b/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiCommandLib.h
@@ -1,0 +1,363 @@
+/** @file MockIpmiCommandLib.h
+  Google Test mocks for IpmiCommandLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_IPMI_COMMAND_LIB_H_
+#define MOCK_IPMI_COMMAND_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/IpmiCommandLib.h>
+}
+
+struct MockIpmiCommandLib {
+  MOCK_INTERFACE_DECLARATION (MockIpmiCommandLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetDeviceId,
+    (
+     OUT IPMI_GET_DEVICE_ID_RESPONSE  *DeviceId
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSelfTestResult,
+    (
+     OUT IPMI_SELF_TEST_RESULT_RESPONSE  *SelfTestResult
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiResetWatchdogTimer,
+    (
+     OUT UINT8  *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSetWatchdogTimer,
+    (
+     IN  IPMI_SET_WATCHDOG_TIMER_REQUEST  *SetWatchdogTimer,
+     OUT UINT8                            *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetWatchdogTimer,
+    (
+     OUT IPMI_GET_WATCHDOG_TIMER_RESPONSE  *GetWatchdogTimer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSetBmcGlobalEnables,
+    (
+     IN  IPMI_SET_BMC_GLOBAL_ENABLES_REQUEST  *SetBmcGlobalEnables,
+     OUT UINT8                                *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetBmcGlobalEnables,
+    (
+     OUT IPMI_GET_BMC_GLOBAL_ENABLES_RESPONSE  *GetBmcGlobalEnables
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiClearMessageFlags,
+    (
+     IN  IPMI_CLEAR_MESSAGE_FLAGS_REQUEST  *ClearMessageFlagsRequest,
+     OUT UINT8                             *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetMessageFlags,
+    (
+     OUT IPMI_GET_MESSAGE_FLAGS_RESPONSE  *GetMessageFlagsResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetMessage,
+    (
+     OUT IPMI_GET_MESSAGE_RESPONSE  *GetMessageResponse,
+     IN OUT UINT32                  *GetMessageResponseSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSendMessage,
+    (
+     IN  IPMI_SEND_MESSAGE_REQUEST   *SendMessageRequest,
+     IN  UINT32                      SendMessageRequestSize,
+     OUT IPMI_SEND_MESSAGE_RESPONSE  *SendMessageResponse,
+     IN OUT UINT32                   *SendMessageResponseSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSystemUuid,
+    (
+     OUT EFI_GUID  *SystemGuid
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetChannelInfo,
+    (
+     IN  IPMI_GET_CHANNEL_INFO_REQUEST   *GetChannelInfoRequest,
+     OUT IPMI_GET_CHANNEL_INFO_RESPONSE  *GetChannelInfoResponse,
+     OUT UINT32                          *GetChannelInfoResponseSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSystemInterfaceCapability,
+    (
+     IN  IPMI_GET_SYSTEM_INTERFACE_CAPABILITIES_REQUEST   *InterfaceCapabilityRequest,
+     OUT IPMI_GET_SYSTEM_INTERFACE_CAPABILITIES_RESPONSE  *InterfaceCapabilityResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSolActivating,
+    (
+     IN  IPMI_SOL_ACTIVATING_REQUEST  *SolActivatingRequest,
+     OUT UINT8                        *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSetSolConfigurationParameters,
+    (
+     IN  IPMI_SET_SOL_CONFIGURATION_PARAMETERS_REQUEST  *SetConfigurationParametersRequest,
+     IN  UINT32                                         SetConfigurationParametersRequestSize,
+     OUT UINT8                                          *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSolConfigurationParameters,
+    (
+     IN  IPMI_GET_SOL_CONFIGURATION_PARAMETERS_REQUEST   *GetConfigurationParametersRequest,
+     OUT IPMI_GET_SOL_CONFIGURATION_PARAMETERS_RESPONSE  *GetConfigurationParametersResponse,
+     IN OUT UINT32                                       *GetConfigurationParametersResponseSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetLanConfigurationParameters,
+    (
+     IN   IPMI_GET_LAN_CONFIGURATION_PARAMETERS_REQUEST   *GetLanConfigurationParametersRequest,
+     OUT  IPMI_GET_LAN_CONFIGURATION_PARAMETERS_RESPONSE  *GetLanConfigurationParametersResponse,
+     IN OUT UINT32                                        *GetLanConfigurationParametersSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetChassisCapabilities,
+    (
+     OUT IPMI_GET_CHASSIS_CAPABILITIES_RESPONSE  *GetChassisCapabilitiesResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetChassisStatus,
+    (
+     OUT IPMI_GET_CHASSIS_STATUS_RESPONSE  *GetChassisStatusResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiChassisControl,
+    (
+     IN IPMI_CHASSIS_CONTROL_REQUEST  *ChassisControlRequest,
+     OUT UINT8                        *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSetPowerRestorePolicy,
+    (
+     IN  IPMI_SET_POWER_RESTORE_POLICY_REQUEST   *SetPowerRestireRequest,
+     OUT IPMI_SET_POWER_RESTORE_POLICY_RESPONSE  *SetPowerRestireResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSetSystemBootOptions,
+    (
+     IN  IPMI_SET_BOOT_OPTIONS_REQUEST   *BootOptionsRequest,
+     OUT IPMI_SET_BOOT_OPTIONS_RESPONSE  *BootOptionsResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSystemBootOptions,
+    (
+     IN  IPMI_GET_BOOT_OPTIONS_REQUEST   *BootOptionsRequest,
+     OUT IPMI_GET_BOOT_OPTIONS_RESPONSE  *BootOptionsResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetFruInventoryAreaInfo,
+    (
+     IN  IPMI_GET_FRU_INVENTORY_AREA_INFO_REQUEST   *GetFruInventoryAreaInfoRequest,
+     OUT IPMI_GET_FRU_INVENTORY_AREA_INFO_RESPONSE  *GetFruInventoryAreaInfoResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiReadFruData,
+    (
+     IN  IPMI_READ_FRU_DATA_REQUEST   *ReadFruDataRequest,
+     OUT IPMI_READ_FRU_DATA_RESPONSE  *ReadFruDataResponse,
+     IN OUT UINT32                    *ReadFruDataResponseSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiWriteFruData,
+    (
+     IN  IPMI_WRITE_FRU_DATA_REQUEST   *WriteFruDataRequest,
+     IN  UINT32                        WriteFruDataRequestSize,
+     OUT IPMI_WRITE_FRU_DATA_RESPONSE  *WriteFruDataResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSelInfo,
+    (
+     OUT IPMI_GET_SEL_INFO_RESPONSE  *GetSelInfoResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSelEntry,
+    (
+     IN IPMI_GET_SEL_ENTRY_REQUEST    *GetSelEntryRequest,
+     OUT IPMI_GET_SEL_ENTRY_RESPONSE  *GetSelEntryResponse,
+     IN OUT UINT32                    *GetSelEntryResponseSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiAddSelEntry,
+    (
+     IN IPMI_ADD_SEL_ENTRY_REQUEST    *AddSelEntryRequest,
+     OUT IPMI_ADD_SEL_ENTRY_RESPONSE  *AddSelEntryResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiPartialAddSelEntry,
+    (
+     IN IPMI_PARTIAL_ADD_SEL_ENTRY_REQUEST    *PartialAddSelEntryRequest,
+     IN UINT32                                PartialAddSelEntryRequestSize,
+     OUT IPMI_PARTIAL_ADD_SEL_ENTRY_RESPONSE  *PartialAddSelEntryResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiClearSel,
+    (
+     IN IPMI_CLEAR_SEL_REQUEST    *ClearSelRequest,
+     OUT IPMI_CLEAR_SEL_RESPONSE  *ClearSelResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSelTime,
+    (
+     OUT IPMI_GET_SEL_TIME_RESPONSE  *GetSelTimeResponse
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSetSelTime,
+    (
+     IN IPMI_SET_SEL_TIME_REQUEST  *SetSelTimeRequest,
+     OUT UINT8                     *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSdrRepositoryInfo,
+    (
+     OUT IPMI_GET_SDR_REPOSITORY_INFO_RESPONSE  *GetSdrRepositoryInfoResp
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSdr,
+    (
+     IN  IPMI_GET_SDR_REQUEST   *GetSdrRequest,
+     OUT IPMI_GET_SDR_RESPONSE  *GetSdrResponse,
+     IN OUT UINT32              *GetSdrResponseSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSetSensorThreshold,
+    (
+     IN IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA  *SetSensorThresholdRequestData,
+     OUT UINT8                                         *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSensorThreshold,
+    (
+     IN UINT8                                            SensorNumber,
+     OUT IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA  *GetSensorThresholdResponse
+    )
+    );
+};
+
+#endif

--- a/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiLib.h
+++ b/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiLib.h
@@ -5,8 +5,7 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#ifndef MOCK_IPMI_LIB_H_
-#define MOCK_IPMI_LIB_H_
+#pragma once
 
 #include <Library/GoogleTestLib.h>
 #include <Library/FunctionMockLib.h>
@@ -31,5 +30,3 @@ struct MockIpmiLib {
     )
     );
 };
-
-#endif

--- a/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiLib.h
+++ b/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiLib.h
@@ -1,0 +1,35 @@
+/** @file MockIpmiLib.h
+  Google Test mocks for IpmiLib
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_IPMI_LIB_H_
+#define MOCK_IPMI_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/IpmiLib.h>
+}
+
+struct MockIpmiLib {
+  MOCK_INTERFACE_DECLARATION (MockIpmiLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSubmitCommand,
+    (
+     IN     UINT8   NetFunction,
+     IN     UINT8   Command,
+     IN     UINT8   *RequestData,
+     IN     UINT32  RequestDataSize,
+     OUT UINT8      *ResponseData,
+     IN OUT UINT32  *ResponseDataSize
+    )
+    );
+};
+
+#endif

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiCommandLib/MockIpmiCommandLib.cpp
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiCommandLib/MockIpmiCommandLib.cpp
@@ -1,0 +1,48 @@
+/** @file MockIpmiCommandLib.cpp
+  Google Test mocks for IpmiCommandLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockIpmiCommandLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockIpmiCommandLib);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetDeviceId, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSelfTestResult, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiResetWatchdogTimer, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetWatchdogTimer, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetWatchdogTimer, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetBmcGlobalEnables, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetBmcGlobalEnables, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiClearMessageFlags, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetMessageFlags, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetMessage, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSendMessage, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSystemUuid, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetChannelInfo, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSystemInterfaceCapability, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSolActivating, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetSolConfigurationParameters, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSolConfigurationParameters, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetLanConfigurationParameters, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetChassisCapabilities, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetChassisStatus, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiChassisControl, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetPowerRestorePolicy, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetSystemBootOptions, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSystemBootOptions, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetFruInventoryAreaInfo, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiReadFruData, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiWriteFruData, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSelInfo, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSelEntry, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiAddSelEntry, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiPartialAddSelEntry, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiClearSel, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSelTime, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetSelTime, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSdrRepositoryInfo, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSdr, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetSensorThreshold, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSensorThreshold, 2, EFIAPI);

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiCommandLib/MockIpmiCommandLib.inf
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiCommandLib/MockIpmiCommandLib.inf
@@ -1,0 +1,34 @@
+## @file
+# Google Test mocks for IpmiCommandLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockIpmiCommandLib
+  FILE_GUID                      = 7872E434-BE62-45CB-BBF9-6C5D74447E9C
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IpmiCommandLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockIpmiCommandLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiLib/MockIpmiLib.cpp
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiLib/MockIpmiLib.cpp
@@ -1,0 +1,11 @@
+/** @file MockIpmiLib.cpp
+  Google Test mocks for IpmiLib
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockIpmiLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockIpmiLib);
+MOCK_FUNCTION_DEFINITION (MockIpmiLib, IpmiSubmitCommand, 6, EFIAPI);

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiLib/MockIpmiLib.inf
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockIpmiLib/MockIpmiLib.inf
@@ -1,0 +1,34 @@
+## @file
+# Google Test mocks for IpmiLib
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockIpmiLib
+  FILE_GUID                      = 8687F0BC-C9FD-483C-AC06-F57DC2A5AFF4
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IpmiLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockIpmiLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
MdeModulePkg: Add GoogleTest mocks for IpmiLib and IpmiCommandLib

# Description

Add GoogleTest mocks for IpmiLib and IpmiCommandLib

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Testing with CI Build validation

## Integration Instructions

N/A
