### PR TITLE
NetworkPkg/UefiPxeBcDxe: Fix ESC abort in PxeBcDiscoverBootFile

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
@@ -901,6 +901,8 @@ PxeBcDiscoverBootFile (
   UINT16                      Type;
   UINT16                      Layer;
   BOOLEAN                     UseBis;
+  PXEBC_DHCP_PACKET_CACHE     *Cache;
+  PXEBC_VENDOR_OPTION         *VendorOpt;
 
   PxeBc = &Private->PxeBc;
   Mode  = PxeBc->Mode;
@@ -915,6 +917,9 @@ PxeBcDiscoverBootFile (
   if (EFI_ERROR (Status)) {
     return Status;
   }
+
+  Cache     = Mode->ProxyOfferReceived ? &Private->ProxyOffer : &Private->DhcpAck;
+  VendorOpt = &Cache->Dhcp4.VendorOpt;
 
   //
   // Select a boot server from boot server list.
@@ -931,6 +936,21 @@ PxeBcDiscoverBootFile (
     // Choose by default item.
     //
     Status = PxeBcSelectBootMenu (Private, &Type, TRUE);
+  }
+
+  //
+  // According to PXE spec 2.1, Table 2-1, when PXE_DISCOVERY_CONTROL bit 3 is
+  // set in Vendor Options (43) and a boot file name is present in the offer,
+  // PxeBcSelectBootPrompt() returns EFI_ABORTED to signal that boot prompt and
+  // menu must be skipped; fall through to PxeBcDhcp4BootInfo() in that case.
+  // Any other EFI_ABORTED (e.g. user pressed ESC) must abort PXE boot.
+  //
+  if ((Status == EFI_ABORTED) &&
+      (Mode->UsingIpv6 ||
+       !IS_DISABLE_PROMPT_MENU (VendorOpt->DiscoverCtrl) ||
+       (Cache->Dhcp4.OptList[PXEBC_DHCP4_TAG_INDEX_BOOTFILE] == NULL)))
+  {
+    return EFI_ABORTED;
   }
 
   if (!EFI_ERROR (Status)) {


### PR DESCRIPTION
PxeBcSelectBootPrompt() returns EFI_ABORTED for two reasons:
  1. PXE_DISCOVERY_CONTROL (option 43, sub-option 6) bit 3 (0x08) is set with a boot file in the offer. Per PXE spec 2.1 Table 2-1, skip boot prompt and menu; fall through to PxeBcDhcp4BootInfo() to boot from the file in the DHCP offer.
  2. User pressed ESC/Ctrl-C to cancel -- abort PXE boot.

Previously PxeBcDiscoverBootFile() did not distinguish these cases. Both caused Status=EFI_ABORTED after the prompt/menu block and fell through to PxeBcDhcp4BootInfo(), so ESC did not actually abort boot.

Add an explicit check after prompt/menu selection: if EFI_ABORTED and the PXE_DISCOVERY_CONTROL-plus-boot-file condition is not met (or IPv6 is in use), return EFI_ABORTED to abort PXE. When the DiscoverCtrl condition is met, fall through as the PXE spec requires.

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)

Signed-off-by: Abuthahir M [abuthahirm@ami.com](mailto:abuthahirm@ami.com)