### PR TITLE
NetworkPkg/SnpDxe: Skip non-QWORD BAR descriptors in BAR scan

### DIFF
--- a/NetworkPkg/SnpDxe/Snp.c
+++ b/NetworkPkg/SnpDxe/Snp.c
@@ -318,7 +318,7 @@ SimpleNetworkDriverStart (
   UINT8                                      BarIndex;
   PXE_STATFLAGS                              InitStatFlags;
   EFI_PCI_IO_PROTOCOL                        *PciIo;
-  EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR          *BarDesc;
+  EFI_ACPI_QWORD_ADDRESS_SPACE_DESCRIPTOR    *BarDesc;
   BOOLEAN                                    FoundIoBar;
   BOOLEAN                                    FoundMemoryBar;
 
@@ -554,6 +554,11 @@ SimpleNetworkDriverStart (
       continue;
     } else if (EFI_ERROR (Status)) {
       goto ErrorDeleteSnp;
+    }
+
+    if (BarDesc->Header.Header.Byte != ACPI_QWORD_ADDRESS_SPACE_DESCRIPTOR) {
+      FreePool (BarDesc);
+      continue;
     }
 
     if ((!FoundMemoryBar) && (BarDesc->ResType == ACPI_ADDRESS_SPACE_TYPE_MEM)) {


### PR DESCRIPTION
## Summary

When enumerating PCI BARs via `GetBarAttributes()`, the UEFI spec allows only `ACPI_QWORD_ADDRESS_SPACE_DESCRIPTOR` and `ACPI_END_TAG_DESCRIPTOR` to be returned. For unused BARs, some PCI bus drivers report `ACPI_END_TAG_DESCRIPTOR`. Accessing the `ResType` field of such a descriptor yields undefined behavior and causes PXE boot failures on NICs with non-continuous BARs (e.g. Realtek where BAR#1 is unused and returns END_TAG).

Add a guard to skip any descriptor that is not `ACPI_QWORD_ADDRESS_SPACE_DESCRIPTOR` before inspecting `ResType`, and update the `BarDesc` pointer type to the more specific `EFI_ACPI_QWORD_ADDRESS_SPACE_DESCRIPTOR` to match.

## Impact

No functional impact on NICs with continuous BARs. Fixes PXE boot failure on NICs where unused BARs return `ACPI_END_TAG_DESCRIPTOR`.

## Changes

- `NetworkPkg/SnpDxe/Snp.c`

Cc: Saloni Kasbekar [saloni.kasbekar@intel.com](mailto:saloni.kasbekar@intel.com)
Cc: Zachary Clark-williams [zachary.clark-williams@intel.com](mailto:zachary.clark-williams@intel.com)
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)

Signed-off-by: Abuthahir M [abuthahirm@ami.com](mailto:abuthahirm@ami.com)