### PR TITLE
NetworkPkg/UefiPxeBcDxe: Fix IPv6 PXE boot failure via routing

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
@@ -1565,6 +1565,7 @@ PxeBcUnregisterIp6Address (
   @param[in]  Private             The pointer to PXEBC_PRIVATE_DATA.
   @param[in]  TimeOutInSecond     Timeout value in seconds.
   @param[out] GatewayAddr         Pointer to store the gateway IP address.
+  @param[out] PrefixLength        Pointer to store the prefix length of the station IPv6 address.
 
   @retval     EFI_SUCCESS         Found a valid gateway address successfully.
   @retval     EFI_TIMEOUT         The operation is time out.
@@ -1575,7 +1576,8 @@ EFI_STATUS
 PxeBcCheckRouteTable (
   IN  PXEBC_PRIVATE_DATA  *Private,
   IN  UINTN               TimeOutInSecond,
-  OUT EFI_IPv6_ADDRESS    *GatewayAddr
+  OUT EFI_IPv6_ADDRESS    *GatewayAddr,
+  OUT UINT8               *PrefixLength
   )
 {
   EFI_STATUS         Status;
@@ -1585,14 +1587,16 @@ PxeBcCheckRouteTable (
   EFI_EVENT          TimeOutEvt;
   UINTN              RetryCount;
   BOOLEAN            GatewayIsFound;
+  BOOLEAN            PrefixLengthFound;
 
   ASSERT (GatewayAddr != NULL);
   ASSERT (Private != NULL);
 
-  Ip6            = Private->Ip6;
-  GatewayIsFound = FALSE;
-  RetryCount     = 0;
-  TimeOutEvt     = NULL;
+  Ip6               = Private->Ip6;
+  GatewayIsFound    = FALSE;
+  PrefixLengthFound = FALSE;
+  RetryCount        = 0;
+  TimeOutEvt        = NULL;
   ZeroMem (GatewayAddr, sizeof (EFI_IPv6_ADDRESS));
 
   while (TRUE) {
@@ -1609,6 +1613,25 @@ PxeBcCheckRouteTable (
         IP6_COPY_ADDRESS (GatewayAddr, &Ip6ModeData.RouteTable[Index].Gateway);
         GatewayIsFound = TRUE;
         break;
+      }
+    }
+
+    //
+    // Find the prefix length for the station IP from the on-link prefix table.
+    // This is needed when the router uses a non-default prefix length (e.g. /124).
+    //
+    if (!PrefixLengthFound) {
+      for (Index = 0; Index < Ip6ModeData.PrefixCount; Index++) {
+        if (NetIp6IsNetEqual (
+              &Private->StationIp.v6,
+              &Ip6ModeData.PrefixTable[Index].Address,
+              Ip6ModeData.PrefixTable[Index].PrefixLength
+              ))
+        {
+          *PrefixLength     = Ip6ModeData.PrefixTable[Index].PrefixLength;
+          PrefixLengthFound = TRUE;
+          break;
+        }
       }
     }
 
@@ -1709,13 +1732,15 @@ PxeBcRegisterIp6Address (
   BOOLEAN                        NoGateway;
   EFI_IPv6_ADDRESS               *Ip6Addr;
   UINTN                          Index;
+  UINT8                          PrefixLength;
 
-  MappedEvt = NULL;
-  Ip6Addr   = NULL;
-  DataSize  = sizeof (EFI_IP6_CONFIG_POLICY);
-  Ip6Cfg    = Private->Ip6Cfg;
-  Ip6       = Private->Ip6;
-  NoGateway = FALSE;
+  MappedEvt    = NULL;
+  Ip6Addr      = NULL;
+  DataSize     = sizeof (EFI_IP6_CONFIG_POLICY);
+  Ip6Cfg       = Private->Ip6Cfg;
+  Ip6          = Private->Ip6;
+  NoGateway    = FALSE;
+  PrefixLength = 0;
 
   ZeroMem (&CfgAddr, sizeof (EFI_IP6_CONFIG_MANUAL_ADDRESS));
   CopyMem (&CfgAddr.Address, Address, sizeof (EFI_IPv6_ADDRESS));
@@ -1728,9 +1753,17 @@ PxeBcRegisterIp6Address (
   //
   // Retrieve the gateway address from IP6 route table.
   //
-  Status = PxeBcCheckRouteTable (Private, PXEBC_IP6_ROUTE_TABLE_TIMEOUT, &GatewayAddr);
+  Status = PxeBcCheckRouteTable (Private, PXEBC_IP6_ROUTE_TABLE_TIMEOUT, &GatewayAddr, &PrefixLength);
   if (EFI_ERROR (Status)) {
     NoGateway = TRUE;
+  }
+
+  //
+  // Use the prefix length from the router advertisement if available,
+  // so that a non-default prefix (e.g. /124) is correctly applied.
+  //
+  if (PrefixLength != 0) {
+    CfgAddr.PrefixLength = PrefixLength;
   }
 
   //


### PR DESCRIPTION
When the IPv6 router advertises a prefix length other than 64, PXE boot fails because Ip6ConfigOnPolicyChanged() clears all prefix information when the PXE driver switches from Automatic to Manual IP6 policy. The manual address configuration then falls back to the default prefix length (IP6_LINK_LOCAL_PREFIX_LENGTH = 64) instead of the actual prefix length from the Router Advertisement (e.g. 124).

Fix PxeBcCheckRouteTable to search the on-link prefix table for the station IP and return its prefix length. PxeBcRegisterIp6Address uses this value when it is non-zero to populate CfgAddr.PrefixLength before calling SetData(Ip6ConfigDataTypeManualAddress).

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Michael D Kinney [michael.d.kinney@intel.com](mailto:michael.d.kinney@intel.com)

Signed-off-by: Abuthahir M [abuthahirm@ami.com](mailto:abuthahirm@ami.com)