### PR TITLE
UefiCpuPkg: Enable RISC-V and LoongArch package builds

### DIFF
--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -15,7 +15,7 @@
   PLATFORM_VERSION               = 0.90
   DSC_SPECIFICATION              = 0x00010005
   OUTPUT_DIRECTORY               = Build/UefiCpu
-  SUPPORTED_ARCHITECTURES        = IA32|X64|AARCH64
+  SUPPORTED_ARCHITECTURES        = IA32|X64|AARCH64|RISCV64|LOONGARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
 
@@ -119,6 +119,10 @@
 [LibraryClasses.common.UEFI_APPLICATION]
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+
+[LibraryClasses.RISCV64]
+  RiscVSbiLib|MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
+  RiscVMmuLib|UefiCpuPkg/Library/BaseRiscVMmuLib/BaseRiscVMmuLib.inf
 
 [LibraryClasses.LoongArch64]
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf


### PR DESCRIPTION
# Description

The Ubuntu GCC CI job passes RISCV64 and LOONGARCH64 in the
architecture list for the UefiCpuPkg package build. However,
UefiCpuPkg.dsc does not list either architecture in
SUPPORTED_ARCHITECTURES, so BaseTools filters them out and does not
build the existing modules for either architecture.

Add RISCV64 and LOONGARCH64 to SUPPORTED_ARCHITECTURES. Also provide
the RiscVSbiLib and RiscVMmuLib instances required by the existing
RISC-V components. This enables package-level build coverage without
changing firmware behavior.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Built UefiCpuPkg for LOONGARCH64 with GCC in DEBUG, RELEASE, and
  NOOPT configurations
- Built UefiCpuPkg for RISCV64 with GCC in DEBUG, RELEASE, and NOOPT
  configurations
- PatchCheck

## Integration Instructions

No special integration steps are required.
