### PR TITLE
DynamicTablesPkg/AcpiEinjLib: Fix undefined shift for 64-bit masks

### DIFF
--- a/DynamicTablesPkg/Library/Acpi/Common/AcpiEinjLib/EinjGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Common/AcpiEinjLib/EinjGenerator.c
@@ -101,7 +101,11 @@ PopulateEinjTable (
       return EFI_INVALID_PARAMETER;
     }
 
-    if ((Instructions->Mask >> Instructions->RegisterRegion.RegisterBitWidth) != 0) {
+    if ((Instructions->RegisterRegion.RegisterBitWidth > 64) ||
+        ((Instructions->RegisterRegion.RegisterBitWidth < 64) &&
+         ((Instructions->Mask >>
+           Instructions->RegisterRegion.RegisterBitWidth) != 0)))
+    {
       return EFI_INVALID_PARAMETER;
     }
 


### PR DESCRIPTION
The EINJ generator validates that an instruction mask fits within the register region width by shifting the 64-bit mask by RegisterBitWidth.

When RegisterBitWidth is 64, this shifts a UINT64 value by its full width, which is undefined behavior in C. A 64-bit mask always fits within a 64-bit register and does not require this check.

Only perform the shift when RegisterBitWidth is less than 64, and reject widths greater than 64 because the EINJ Mask field is 64 bits.
