### PR TITLE
UefiPayloadPkg: Fix SPI device config space base truncation

### DIFF
--- a/UefiPayloadPkg/Library/SpiFlashLib/SpiFlashLib.c
+++ b/UefiPayloadPkg/Library/SpiFlashLib/SpiFlashLib.c
@@ -84,9 +84,9 @@ SpiConstructor (
     DEBUG ((DEBUG_ERROR, "SPI FLASH HOB is not expected. need check the hob or enhance SPI flash driver.\n"));
   }
 
-  SpiInstance->PchSpiBase = (UINT32)(UINTN)SpiFlashInfo->SpiAddress.Address;
+  SpiInstance->PchSpiBase = (UINTN)SpiFlashInfo->SpiAddress.Address;
   SpiInstance->Flags      = SpiFlashInfo->Flags;
-  DEBUG ((DEBUG_INFO, "PchSpiBase at 0x%x\n", SpiInstance->PchSpiBase));
+  DEBUG ((DEBUG_INFO, "PchSpiBase at 0x%Lx\n", (UINT64)SpiInstance->PchSpiBase));
 
   ScSpiBar0 = AcquireSpiBar0 (SpiInstance->PchSpiBase);
   DEBUG ((DEBUG_INFO, "ScSpiBar0 at 0x%08X\n", ScSpiBar0));


### PR DESCRIPTION
SPI device's config space base address is getting uncoditionally truncated to 32-bit. Removed the explicit typecast to let it fetch the full 64-bit address.
Also, modified the corresponding debug print to print the full 64-bit address.

