### PR TITLE
DynamicTablesPkg: Preserve cache associativity when aggregating

### DIFF
--- a/DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Generator.c
+++ b/DynamicTablesPkg/Library/Smbios/SmbiosType7Lib/SmbiosType7Generator.c
@@ -641,7 +641,13 @@ BuildSmbiosType7TableEx (
           SmbiosRecord->SystemCacheType = CacheTypeOther;
         }
 
-        SmbiosRecord->Associativity = CacheAssociativityOther;
+        // Preserve the associativity when all caches being aggregated have
+        // the same associativity.
+        if (SmbiosRecord->Associativity !=
+            GetCacheAssociativity (CacheNode->Associativity))
+        {
+          SmbiosRecord->Associativity = CacheAssociativityOther;
+        }
       } else {
         // No previously seen cache at this level, create new table entry
         Status = StringTableInitialize (&StrTable, SMBIOS_TYPE7_MAX_STRINGS);


### PR DESCRIPTION
DynamicTablesPkg: Preserve cache associativity when aggregating
The SMBIOS Type 7 generator unconditionally reports associativity as
Other when aggregating caches at the same level, even when all caches
have identical associativity.

Preserve the existing associativity when the incoming cache matches it,
and report Other only when the associativities differ.