### PR TITLE
MdeModulePkg/UefiHiiLib: Fix regression from 12828

### DIFF
--- a/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
+++ b/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
@@ -2927,7 +2927,6 @@ HiiGetBrowserData (
   //
   ResultsData = InternalHiiBrowserCallback (VariableGuid, VariableName, NULL);
   if (ResultsData == NULL) {
-    ASSERT (ResultsData != NULL);
     return FALSE;
   }
 


### PR DESCRIPTION

# Description

12828 introduced an ASSERT in HiiGetBrowserData() that fires when InternalHiiBrowserCallback() returns NULL. This is a valid return value indicating the browser has no data for the requested variable, and callers already handle this by checking the FALSE return value.

The ASSERT is incorrect because it triggers on a non-error path, causing a crash when the browser callback legitimately returns no data. Remove the unnecessary ASSERT while keeping the existing FALSE return so callers continue to handle this case gracefully.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Run OvmfPkg's PlatformCI X64 with SECURE_BOOT enabled: 
`stuart_build -c OvmfPkg\PlatformCI\PlatformBuild.py -a X64  BLD_*_SECURE_BOOT_ENABLE=TRUE --flashrom TARGET=DEBUG`

Navigate into Setup Menu, Goto Device Security and attempt to enter Secure Boot Menu to observe assert

## Integration Instructions
No integration necessary.