### PR TITLE
MdeModulePkg/BootMaintenanceManagerUiLib: Change numeric step to 1

### DIFF
--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManagerCustomizedUiSupport.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenanceManagerCustomizedUiSupport.c
@@ -131,7 +131,7 @@ BmmCreateTimeOutMenu (
     EFI_IFR_NUMERIC_SIZE_2 | EFI_IFR_DISPLAY_UINT_DEC,
     0,
     65535,
-    0,
+    1,
     NULL
     );
 }


### PR DESCRIPTION
# Description

Set the numeric step to 1 to allow +/- key adjustment.

## How This Was Tested

Press + or - key, the value of `Auto Boot Time-out` can be increased or decreased by 1.

## Integration Instructions

N/A
