### PR TITLE
ShellPkg/Shell: Preserve multi-instance device paths

### DIFF
--- a/ShellPkg/Application/Shell/ShellProtocol.c
+++ b/ShellPkg/Application/Shell/ShellProtocol.c
@@ -290,16 +290,8 @@ EfiShellGetMapFromDevicePath (
   }
 
   if (PathForReturn != NULL) {
-    while (!IsDevicePathEndType (*DevicePath)) {
+    while (!IsDevicePathEnd (*DevicePath)) {
       *DevicePath = NextDevicePathNode (*DevicePath);
-    }
-
-    //
-    // Do not call SetDevicePathEndNode() if the device path node is already the
-    // end of an entire device path.
-    //
-    if (!IsDevicePathEnd (*DevicePath)) {
-      SetDevicePathEndNode (*DevicePath);
     }
   }
 


### PR DESCRIPTION
# Description

`EfiShellGetMapFromDevicePath()` currently stops at any end-type node. For a
multi-instance device path, this is the first End Instance node. The function
then calls `SetDevicePathEndNode()` on that node, changing it to End Entire and
truncating all remaining instances.

Walk until the End Entire node instead and remove the in-place
`SetDevicePathEndNode()` call. This preserves intermediate instances and
leaves the installed Device Path Protocol data unchanged.

Fixes #11673.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Reproduced the issue with OVMF and the two-NVMe test patch attached to
  #11673.
- Before the fix, `BLK4` was truncated to the first NVMe instance.
- After the fix, `BLK4` retained both NVMe instances across three consecutive
  Shell mapping operations.
- Automated output checks reported `BASELINE_FULL_BLK4_COUNT=0` and
  `FIXED_FULL_BLK4_COUNT=3`.
- Built BaseTools and ran all 301 Python tests successfully.
- Built `OvmfPkg/OvmfPkgX64.dsc` for X64 DEBUG with CLANGDWARF on the latest
  upstream master.

## Integration Instructions

N/A.