### PR TITLE
OvmfPkg/PlatformInitLib: tolerate an interrupted nvram write

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/Platform.c
+++ b/OvmfPkg/Library/PlatformInitLib/Platform.c
@@ -1003,7 +1003,7 @@ PlatformInitEmuVariableNvStore (
   ASSERT (Size < EmuVariableNvStoreSize);
 
   if (!PlatformValidateNvVarStore (Base, PcdGet32 (PcdCfvRawDataSize))) {
-    ASSERT (FALSE);
+    DEBUG ((DEBUG_ERROR, "Invalid FlashNvStorage, EmuVariableNvStore not initialized.\n"));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/OvmfPkg/Library/PlatformInitLib/Platform.c
+++ b/OvmfPkg/Library/PlatformInitLib/Platform.c
@@ -787,6 +787,8 @@ PlatformValidateNvVarStore (
   UINTN                          VariableBase;
   UINT32                         VariableOffset;
   UINT32                         VariableOffsetBeforeAlign;
+  UINT32                         VariableNameSize;
+  UINT32                         VariableDataSize;
   EFI_FIRMWARE_VOLUME_HEADER     *NvVarStoreFvHeader;
   VARIABLE_STORE_HEADER          *NvVarStoreHeader;
   AUTHENTICATED_VARIABLE_HEADER  *VariableHeader;
@@ -888,17 +890,26 @@ RETRY:
 
       VariableOffset = NvVarStoreHeader->Size - sizeof (VARIABLE_STORE_HEADER);
     } else {
-      if (!((VariableHeader->State == VAR_HEADER_VALID_ONLY) ||
-            (VariableHeader->State == VAR_ADDED) ||
-            (VariableHeader->State == (VAR_ADDED & VAR_DELETED)) ||
-            (VariableHeader->State == (VAR_ADDED & VAR_IN_DELETED_TRANSITION)) ||
-            (VariableHeader->State == (VAR_ADDED & VAR_IN_DELETED_TRANSITION & VAR_DELETED))))
-      {
-        DEBUG ((DEBUG_ERROR, "NvVarStore Variable header State was invalid.\n"));
-        return FALSE;
+      if (VariableHeader->State == 0xFF) {
+        DEBUG ((DEBUG_INFO, "NvVarStore variable header State is unwritten.\n"));
+        VariableNameSize = 0;
+        VariableDataSize = 0;
+      } else {
+        if (!((VariableHeader->State == VAR_HEADER_VALID_ONLY) ||
+              (VariableHeader->State == VAR_ADDED) ||
+              (VariableHeader->State == (VAR_ADDED & VAR_DELETED)) ||
+              (VariableHeader->State == (VAR_ADDED & VAR_IN_DELETED_TRANSITION)) ||
+              (VariableHeader->State == (VAR_ADDED & VAR_IN_DELETED_TRANSITION & VAR_DELETED))))
+        {
+          DEBUG ((DEBUG_ERROR, "NvVarStore Variable header State was invalid.\n"));
+          return FALSE;
+        }
+
+        VariableNameSize = VariableHeader->NameSize;
+        VariableDataSize = VariableHeader->DataSize;
       }
 
-      VariableOffset += sizeof (AUTHENTICATED_VARIABLE_HEADER) + VariableHeader->NameSize + VariableHeader->DataSize;
+      VariableOffset += sizeof (AUTHENTICATED_VARIABLE_HEADER) + VariableNameSize + VariableDataSize;
       // Verify VariableOffset should be less than or equal NvVarStoreHeader->Size - sizeof(VARIABLE_STORE_HEADER)
       if (VariableOffset > (NvVarStoreHeader->Size - sizeof (VARIABLE_STORE_HEADER))) {
         DEBUG ((DEBUG_ERROR, "NvVarStore Variable header VariableOffset was invalid.\n"));


### PR DESCRIPTION
# Description

A variable record whose header write was interrupted keeps `State == 0xFF`.
`PlatformValidateNvVarStore()` rejects that state and
`PlatformInitEmuVariableNvStore()` turns the rejection into `ASSERT (FALSE)`, so
a DEBUG build dead-loops in PEI and the guest never boots again.

Patch 1 handles such a record the way the variable driver already does:
`NameSizeOfVariable()` and `DataSizeOfVariable()` return 0 for it, so it
occupies just its header and the walk continues. Its `NameSize` and `DataSize`
must not be read, they may be unwritten too. Same conclusion as ceb52713b0 and
735d0a5e2e, but not the latter's end-of-list `break`: records can legitimately
sit behind an unwritten one.

Patch 2: the varstore is external input, so a failed validation needs an error
path, not an ASSERT. RELEASE builds already continue without the emulated
store, and both callers ignore the return value.

- [ ] Breaking change?
- [x] Impacts security?
  - Validator on the secure boot path. It accepts only a record shape the
    variable driver already skips; corrupt stores are still rejected, below.
- [ ] Includes tests?
  - No unit test exists for this validator; verified on real firmware.

## How This Was Tested

`OvmfPkgIa32X64.dsc`, `SECURE_BOOT_ENABLE=TRUE`, `SMM_REQUIRE=FALSE`, DEBUG,
booted before and after against the varstore of a VM that had been hanging,
plus mutants of it:

```
case                                 before   after
pristine varstore                    boots    boots
the real torn varstore               hangs    boots
torn record with one behind it       hangs    boots
committed record, impossible State   hangs    rejected, boots on
garbage in the erased area           hangs    rejected, boots on
```

Both commits pass `PatchCheck.py`. I can share the damaged varstore.

## Integration Instructions

N/A

