### PR TITLE
MdeModulePkg: Add optional variable runtime hooks

### DIFF
--- a/MdeModulePkg/Include/Protocol/VariableSmmRuntimeDxeHook.h
+++ b/MdeModulePkg/Include/Protocol/VariableSmmRuntimeDxeHook.h
@@ -1,0 +1,84 @@
+/** @file
+  Optional hooks around VariableSmmRuntimeDxe SetVariable() MM communication.
+
+  A provider must be a DXE_RUNTIME_DRIVER, or otherwise guarantee that its code
+  and data remain runtime-resident. It must not use boot services or allocate
+  boot-services memory after ExitBootServices().
+
+  Hook inputs are untrusted runtime-service inputs. Providers must validate all
+  inputs they consume, bound all waits, and must not call SetVariable() from
+  either hook. These hooks do not replace SMM validation, VarCheck, variable
+  policy, Secure Boot authentication, MOR handling, or flash-write
+  authorization.
+
+  A provider MAY access MMIO, PIO, mailbox, or device resources reserved
+  exclusively for firmware and not exposed to or accessed by the OS. If a
+  resource may also be accessed by the OS, the provider MUST use a
+  platform-defined ownership or synchronization mechanism shared with the OS.
+  UEFI locks and TPL do not synchronize with OS drivers. For this contract,
+  "not exposed to the OS" means absent from OS discovery and description
+  mechanisms such as ACPI, PCI BAR assignment, and device tree. It is not
+  sufficient that the currently loaded OS driver does not use the resource.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#define EDKII_VARIABLE_RUNTIME_HOOK_PROTOCOL_GUID \
+  { \
+    0xdeddcd7a, 0xd76d, 0x46a3, { 0xba, 0xa5, 0xbf, 0x25, 0x50, 0x77, 0xdc, 0x10 } \
+  }
+
+/**
+  Invoked immediately before runtime SetVariable() communication is sent to MM.
+
+  The provider owns its runtime-safe synchronization state. The interface
+  intentionally carries no opaque per-operation context.
+
+  @param[in] VariableName  Name of the variable.
+  @param[in] VendorGuid    Variable vendor GUID.
+  @param[in] Attributes    Variable attributes.
+  @param[in] DataSize      Size of Data in bytes.
+  @param[in] Data          Variable data.
+
+  @retval EFI_SUCCESS  Continue with the existing MM variable service.
+  @retval Others       Reject or defer the operation without entering MM.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *EDKII_VARIABLE_PRE_SET_VARIABLE)(
+  IN CONST CHAR16    *VariableName,
+  IN CONST EFI_GUID  *VendorGuid,
+  IN       UINT32    Attributes,
+  IN       UINTN     DataSize,
+  IN CONST VOID      *Data
+  );
+
+/**
+  Invoked after runtime SetVariable() communication completes.
+
+  This notification is called only when PreSetVariable() returned success.
+  SetVariableStatus is authoritative and is returned unchanged by the existing
+  variable service.
+
+  @param[in] SetVariableStatus  Result from the existing MM variable service.
+**/
+typedef
+VOID
+(EFIAPI *EDKII_VARIABLE_POST_SET_VARIABLE)(
+  IN EFI_STATUS  SetVariableStatus
+  );
+
+///
+/// This protocol is optional. Both callbacks are required. The first valid
+/// provider discovered before EndOfDxe is used.
+///
+typedef struct {
+  EDKII_VARIABLE_PRE_SET_VARIABLE     PreSetVariable;
+  EDKII_VARIABLE_POST_SET_VARIABLE    PostSetVariable;
+} EDKII_VARIABLE_RUNTIME_HOOK_PROTOCOL;
+
+extern EFI_GUID  gEdkiiVariableSmmRuntimeDxeHookProtocolGuid;

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -639,6 +639,10 @@
   #  Include/Protocol/VariableLock.h
   gEdkiiVariableLockProtocolGuid = { 0xcd3d0a05, 0x9e24, 0x437c, { 0xa8, 0x91, 0x1e, 0xe0, 0x53, 0xdb, 0x76, 0x38 }}
 
+  ## Optional hooks around runtime SetVariable() MM communication.
+  # Include/Protocol/VariableSmmRuntimeDxeHook.h
+  gEdkiiVariableSmmRuntimeDxeHookProtocolGuid = { 0xdeddcd7a, 0xd76d, 0x46a3, { 0xba, 0xa5, 0xbf, 0x25, 0x50, 0x77, 0xdc, 0x10 }}
+
   ## Include/Protocol/VarCheck.h
   gEdkiiVarCheckProtocolGuid     = { 0xaf23b340, 0x97b4, 0x4685, { 0x8d, 0x4f, 0xa3, 0xf2, 0x81, 0x69, 0xb2, 0x1d } }
 
@@ -800,6 +804,12 @@
   #   FALSE - The UEFI variable runtime cache is disabled.<BR>
   # @Prompt Enable the UEFI variable runtime cache.
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache|TRUE|BOOLEAN|0x00010039
+
+  ## Indicates if optional hooks around runtime SetVariable() MM communication are enabled.<BR><BR>
+  #   TRUE  - Discover and invoke the variable runtime hook protocol.<BR>
+  #   FALSE - Do not discover or invoke the variable runtime hook protocol.<BR>
+  # @Prompt Enable variable runtime hooks.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableSmmRuntimeDxeHook|FALSE|BOOLEAN|0x00010043
 
   ## Indicates if the statistics about variable usage will be collected. This information is
   #  stored as a vendor configuration table into the EFI system table.

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -44,6 +44,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "PrivilegePolymorphic.h"
 #include "VariableParsing.h"
+#include "VariableSmmRuntimeDxeHookInternal.h"
 
 EFI_HANDLE                      mHandle                    = NULL;
 EFI_SMM_VARIABLE_PROTOCOL       *mSmmVariable              = NULL;
@@ -1154,6 +1155,7 @@ RuntimeServiceSetVariable (
   UINTN                                     PayloadSize;
   SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE  *SmmVariableHeader;
   UINTN                                     VariableNameSize;
+  BOOLEAN                                   HookInvoked;
 
   //
   // Check input parameters.
@@ -1176,6 +1178,21 @@ RuntimeServiceSetVariable (
       (DataSize > mVariableBufferPayloadSize - OFFSET_OF (SMM_VARIABLE_COMMUNICATE_ACCESS_VARIABLE, Name) - VariableNameSize))
   {
     return EFI_INVALID_PARAMETER;
+  }
+
+  HookInvoked = FALSE;
+  if (FeaturePcdGet (PcdEnableVariableSmmRuntimeDxeHook)) {
+    Status = VariableRuntimeHookPreSetVariable (
+               VariableName,
+               VendorGuid,
+               Attributes,
+               DataSize,
+               Data,
+               &HookInvoked
+               );
+    if (Status != EFI_SUCCESS) {
+      return Status;
+    }
   }
 
   AcquireLockOnlyAtBootTime (&mVariableServicesLock);
@@ -1206,6 +1223,10 @@ RuntimeServiceSetVariable (
 
 Done:
   ReleaseLockOnlyAtBootTime (&mVariableServicesLock);
+
+  if (FeaturePcdGet (PcdEnableVariableSmmRuntimeDxeHook)) {
+    VariableRuntimeHookPostSetVariable (HookInvoked, Status);
+  }
 
   if (!EfiAtRuntime ()) {
     if (!EFI_ERROR (Status)) {
@@ -1307,6 +1328,10 @@ OnExitBootServices (
   IN      VOID       *Context
   )
 {
+  if (FeaturePcdGet (PcdEnableVariableSmmRuntimeDxeHook)) {
+    VariableRuntimeHookStopDiscovery ();
+  }
+
   //
   // Init the communicate buffer. The buffer data size is:
   // SMM_COMMUNICATE_HEADER_SIZE + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE.
@@ -1388,6 +1413,9 @@ VariableAddressChangeEvent (
   EfiConvertPointer (EFI_OPTIONAL_PTR, (VOID **)&mVariableRtCacheInfo.RuntimeHobCacheBuffer);
   EfiConvertPointer (EFI_OPTIONAL_PTR, (VOID **)&mVariableRtCacheInfo.RuntimeNvCacheBuffer);
   EfiConvertPointer (EFI_OPTIONAL_PTR, (VOID **)&mVariableRtCacheInfo.RuntimeVolatileCacheBuffer);
+  if (FeaturePcdGet (PcdEnableVariableSmmRuntimeDxeHook)) {
+    VariableRuntimeHookConvertPointers ();
+  }
 }
 
 /**
@@ -1961,13 +1989,21 @@ VariableSmmRuntimeInitialize (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  VOID       *SmmVariableRegistration;
-  VOID       *SmmVariableWriteRegistration;
-  EFI_EVENT  OnReadyToBootEvent;
-  EFI_EVENT  ExitBootServiceEvent;
-  EFI_EVENT  LegacyBootEvent;
+  VOID        *SmmVariableRegistration;
+  VOID        *SmmVariableWriteRegistration;
+  EFI_EVENT   OnReadyToBootEvent;
+  EFI_EVENT   ExitBootServiceEvent;
+  EFI_EVENT   LegacyBootEvent;
+  EFI_STATUS  Status;
 
   EfiInitializeLock (&mVariableServicesLock, TPL_NOTIFY);
+
+  if (FeaturePcdGet (PcdEnableVariableSmmRuntimeDxeHook)) {
+    Status = VariableRuntimeHookInitialize ();
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_WARN, "Variable runtime hook discovery failed: %r\n", Status));
+    }
+  }
 
   //
   // Smm variable service is ready

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -38,6 +38,8 @@
 
 [Sources]
   VariableSmmRuntimeDxe.c
+  VariableSmmRuntimeDxeHook.c
+  VariableSmmRuntimeDxeHookInternal.h
   PrivilegePolymorphic.h
   Measurement.c
   VariableParsing.c
@@ -72,10 +74,12 @@
   ## UNDEFINED # Used to do smm communication
   gEfiSmmVariableProtocolGuid
   gEdkiiVariableLockProtocolGuid                ## PRODUCES
+  gEdkiiVariableSmmRuntimeDxeHookProtocolGuid   ## SOMETIMES_CONSUMES ## NOTIFY
   gEdkiiVarCheckProtocolGuid                    ## PRODUCES
   gEdkiiVariablePolicyProtocolGuid              ## PRODUCES
 
 [FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableSmmRuntimeDxeHook         ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdVariableCollectStatistics            ## CONSUMES
 
 [Pcd]

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxeHook.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxeHook.c
@@ -1,0 +1,302 @@
+/** @file
+  Support for the optional VariableSmmRuntimeDxe hook protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+
+#include <Guid/EventGroup.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeLib.h>
+
+#include "VariableSmmRuntimeDxeHookInternal.h"
+
+STATIC EDKII_VARIABLE_PRE_SET_VARIABLE   mPreSetVariable;
+STATIC EDKII_VARIABLE_POST_SET_VARIABLE  mPostSetVariable;
+STATIC EFI_EVENT                         mVariableRuntimeHookNotifyEvent;
+STATIC EFI_EVENT                         mVariableRuntimeHookEndOfDxeEvent;
+STATIC VOID                              *mVariableRuntimeHookRegistration;
+STATIC BOOLEAN                           mVariableRuntimeHookDiscoveryEnded;
+
+/**
+  Caches the first valid variable runtime hook provider.
+
+  @param[in] Protocol  Variable runtime hook protocol instance.
+
+  @retval TRUE   The provider was valid and its callbacks were cached.
+  @retval FALSE  The provider was invalid or provider discovery has ended.
+**/
+STATIC
+BOOLEAN
+CacheVariableRuntimeHook (
+  IN EDKII_VARIABLE_RUNTIME_HOOK_PROTOCOL  *Protocol
+  )
+{
+  if (mVariableRuntimeHookDiscoveryEnded ||
+      (mPreSetVariable != NULL) ||
+      (Protocol == NULL) ||
+      (Protocol->PreSetVariable == NULL) ||
+      (Protocol->PostSetVariable == NULL))
+  {
+    return FALSE;
+  }
+
+  mPreSetVariable  = Protocol->PreSetVariable;
+  mPostSetVariable = Protocol->PostSetVariable;
+  return TRUE;
+}
+
+/**
+  Closes an event and clears its cached event handle.
+
+  @param[in,out] Event  Address of the cached event handle.
+**/
+STATIC
+VOID
+CloseVariableRuntimeHookEvent (
+  IN OUT EFI_EVENT  *Event
+  )
+{
+  EFI_EVENT  EventToClose;
+
+  EventToClose = *Event;
+  *Event       = NULL;
+  if (EventToClose != NULL) {
+    gBS->CloseEvent (EventToClose);
+  }
+}
+
+/**
+  Closes the variable runtime hook protocol notification event and clears its
+  registration key.
+**/
+STATIC
+VOID
+CloseVariableRuntimeHookNotifyEvent (
+  VOID
+  )
+{
+  CloseVariableRuntimeHookEvent (&mVariableRuntimeHookNotifyEvent);
+  mVariableRuntimeHookRegistration = NULL;
+}
+
+/**
+  Notification function invoked when the variable runtime hook protocol is
+  installed.
+
+  @param[in] Event    Event whose notification function is being invoked.
+  @param[in] Context  Pointer to the notification function context.
+**/
+STATIC
+VOID
+EFIAPI
+VariableRuntimeHookInstalled (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EFI_STATUS                            Status;
+  EDKII_VARIABLE_RUNTIME_HOOK_PROTOCOL  *Protocol;
+
+  if (mVariableRuntimeHookDiscoveryEnded || (mPreSetVariable != NULL)) {
+    return;
+  }
+
+  do {
+    Protocol = NULL;
+    Status   = gBS->LocateProtocol (
+                      &gEdkiiVariableSmmRuntimeDxeHookProtocolGuid,
+                      mVariableRuntimeHookRegistration,
+                      (VOID **)&Protocol
+                      );
+    if (EFI_ERROR (Status)) {
+      return;
+    }
+  } while (!CacheVariableRuntimeHook (Protocol));
+
+  CloseVariableRuntimeHookNotifyEvent ();
+}
+
+/**
+  Stops variable runtime hook provider discovery and closes discovery events.
+**/
+VOID
+VariableRuntimeHookStopDiscovery (
+  VOID
+  )
+{
+  mVariableRuntimeHookDiscoveryEnded = TRUE;
+  CloseVariableRuntimeHookNotifyEvent ();
+  CloseVariableRuntimeHookEvent (&mVariableRuntimeHookEndOfDxeEvent);
+}
+
+/**
+  EndOfDxe notification function that accepts any pending provider and then
+  stops provider discovery.
+
+  @param[in] Event    Event whose notification function is being invoked.
+  @param[in] Context  Pointer to the notification function context.
+**/
+STATIC
+VOID
+EFIAPI
+VariableRuntimeHookEndOfDxe (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  if ((mPreSetVariable == NULL) && (mVariableRuntimeHookNotifyEvent != NULL)) {
+    VariableRuntimeHookInstalled (mVariableRuntimeHookNotifyEvent, NULL);
+  }
+
+  VariableRuntimeHookStopDiscovery ();
+}
+
+/**
+  Discovers the first valid variable runtime hook provider and registers for
+  notification if a provider is not yet available.
+
+  @retval EFI_SUCCESS  Discovery was initialized or a provider was cached.
+  @retval Others       Event or protocol notification registration failed.
+**/
+EFI_STATUS
+VariableRuntimeHookInitialize (
+  VOID
+  )
+{
+  EFI_STATUS                            Status;
+  EDKII_VARIABLE_RUNTIME_HOOK_PROTOCOL  *Protocol;
+
+  if (mVariableRuntimeHookDiscoveryEnded || (mPreSetVariable != NULL)) {
+    return EFI_SUCCESS;
+  }
+
+  Protocol = NULL;
+  Status   = gBS->LocateProtocol (
+                    &gEdkiiVariableSmmRuntimeDxeHookProtocolGuid,
+                    NULL,
+                    (VOID **)&Protocol
+                    );
+  if (!EFI_ERROR (Status) && CacheVariableRuntimeHook (Protocol)) {
+    return EFI_SUCCESS;
+  }
+
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  VariableRuntimeHookEndOfDxe,
+                  NULL,
+                  &gEfiEndOfDxeEventGroupGuid,
+                  &mVariableRuntimeHookEndOfDxeEvent
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gBS->CreateEvent (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  VariableRuntimeHookInstalled,
+                  NULL,
+                  &mVariableRuntimeHookNotifyEvent
+                  );
+  if (EFI_ERROR (Status)) {
+    VariableRuntimeHookStopDiscovery ();
+    return Status;
+  }
+
+  Status = gBS->RegisterProtocolNotify (
+                  &gEdkiiVariableSmmRuntimeDxeHookProtocolGuid,
+                  mVariableRuntimeHookNotifyEvent,
+                  &mVariableRuntimeHookRegistration
+                  );
+  if (EFI_ERROR (Status)) {
+    VariableRuntimeHookStopDiscovery ();
+    return Status;
+  }
+
+  //
+  // Process providers installed between the initial lookup and registration.
+  //
+  VariableRuntimeHookInstalled (mVariableRuntimeHookNotifyEvent, NULL);
+  return EFI_SUCCESS;
+}
+
+/**
+  Converts cached variable runtime hook callback pointers to virtual addresses.
+**/
+VOID
+VariableRuntimeHookConvertPointers (
+  VOID
+  )
+{
+  EfiConvertPointer (EFI_OPTIONAL_PTR, (VOID **)&mPreSetVariable);
+  EfiConvertPointer (EFI_OPTIONAL_PTR, (VOID **)&mPostSetVariable);
+}
+
+/**
+  Invokes the cached pre-hook for an OS runtime SetVariable() request.
+
+  @param[in]  VariableName  Name of the variable.
+  @param[in]  VendorGuid    Variable vendor GUID.
+  @param[in]  Attributes    Variable attributes.
+  @param[in]  DataSize      Size of Data in bytes.
+  @param[in]  Data          Variable data.
+  @param[out] HookInvoked   TRUE if the pre-hook returned success.
+
+  @retval EFI_SUCCESS  Continue with MM communication.
+  @retval Others       The pre-hook rejected or deferred the operation.
+**/
+EFI_STATUS
+VariableRuntimeHookPreSetVariable (
+  IN  CONST CHAR16    *VariableName,
+  IN  CONST EFI_GUID  *VendorGuid,
+  IN        UINT32    Attributes,
+  IN        UINTN     DataSize,
+  IN  CONST VOID      *Data,
+  OUT       BOOLEAN   *HookInvoked
+  )
+{
+  EFI_STATUS  Status;
+
+  *HookInvoked = FALSE;
+  if (!EfiAtRuntime () || (mPreSetVariable == NULL)) {
+    return EFI_SUCCESS;
+  }
+
+  Status = mPreSetVariable (
+             VariableName,
+             VendorGuid,
+             Attributes,
+             DataSize,
+             Data
+             );
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  *HookInvoked = TRUE;
+  return EFI_SUCCESS;
+}
+
+/**
+  Invokes the cached post-hook after MM communication completes.
+
+  @param[in] HookInvoked        TRUE if the pre-hook returned success.
+  @param[in] SetVariableStatus  Authoritative MM variable service result.
+**/
+VOID
+VariableRuntimeHookPostSetVariable (
+  IN BOOLEAN     HookInvoked,
+  IN EFI_STATUS  SetVariableStatus
+  )
+{
+  if (!HookInvoked) {
+    return;
+  }
+
+  mPostSetVariable (SetVariableStatus);
+}

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxeHookInternal.h
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxeHookInternal.h
@@ -1,0 +1,74 @@
+/** @file
+  Internal support for the optional VariableSmmRuntimeDxe hook protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#pragma once
+
+#include <Protocol/VariableSmmRuntimeDxeHook.h>
+
+/**
+  Discovers the first valid variable runtime hook provider and registers for
+  notification if a provider is not yet available.
+
+  @retval EFI_SUCCESS  Discovery was initialized or a provider was cached.
+  @retval Others       Event or protocol notification registration failed.
+**/
+EFI_STATUS
+VariableRuntimeHookInitialize (
+  VOID
+  );
+
+/**
+  Stops variable runtime hook provider discovery and closes discovery events.
+**/
+VOID
+VariableRuntimeHookStopDiscovery (
+  VOID
+  );
+
+/**
+  Converts cached variable runtime hook callback pointers to virtual addresses.
+**/
+VOID
+VariableRuntimeHookConvertPointers (
+  VOID
+  );
+
+/**
+  Invokes the cached pre-hook for an OS runtime SetVariable() request.
+
+  @param[in]  VariableName  Name of the variable.
+  @param[in]  VendorGuid    Variable vendor GUID.
+  @param[in]  Attributes    Variable attributes.
+  @param[in]  DataSize      Size of Data in bytes.
+  @param[in]  Data          Variable data.
+  @param[out] HookInvoked   TRUE if the pre-hook returned success.
+
+  @retval EFI_SUCCESS  Continue with MM communication.
+  @retval Others       The pre-hook rejected or deferred the operation.
+**/
+EFI_STATUS
+VariableRuntimeHookPreSetVariable (
+  IN  CONST CHAR16    *VariableName,
+  IN  CONST EFI_GUID  *VendorGuid,
+  IN        UINT32    Attributes,
+  IN        UINTN     DataSize,
+  IN  CONST VOID      *Data,
+  OUT       BOOLEAN   *HookInvoked
+  );
+
+/**
+  Invokes the cached post-hook after MM communication completes.
+
+  @param[in] HookInvoked        TRUE if the pre-hook returned success.
+  @param[in] SetVariableStatus  Authoritative MM variable service result.
+**/
+VOID
+VariableRuntimeHookPostSetVariable (
+  IN BOOLEAN     HookInvoked,
+  IN EFI_STATUS  SetVariableStatus
+  );


### PR DESCRIPTION
# Description

## Motivation

Some platforms need custom work before and after an OS runtime variable write. Examples include a platform security or precondition check and a resource-ownership handshake, such as coordinating SPI ownership with another component.

This protocol lets a platform run a pre-hook before MM communication and a paired post-hook after it completes. If the pre-hook rejects or defers the request, `VariableSmmRuntimeDxe` can return without entering SMM, avoiding unnecessary SMI execution time. Existing variable validation and security policy remain in SMM.

`PcdEnableVariableSmmRuntimeDxeHook` defaults to `FALSE`, so existing platforms keep the current behavior unless they explicitly enable the feature.

## Summary

- Add `EDKII_VARIABLE_RUNTIME_HOOK_PROTOCOL` with required pre/post callbacks.
- Add `PcdEnableVariableSmmRuntimeDxeHook` as a FeaturePcd with a default value of `FALSE`; no hook discovery or invocation occurs by default.
- Apply the hooks only to the MM-backed `VariableSmmRuntimeDxe` implementation.
- Discover and cache the first valid `gEdkiiVariableSmmRuntimeDxeHookProtocolGuid` provider before `EndOfDxe`.
- Convert cached callback pointers for runtime use.
- Invoke the provider for every independent OS runtime `SetVariable()` request; the provider owns runtime-safe serialization.
- Preserve the existing path when the feature is disabled or no provider is present.
- Keep all variable validation, policy, authentication, and flash authorization in SMM.

## Provider discovery and lifetime

```mermaid
flowchart LR
    A[VariableSmmRuntimeInitialize] --> B{FeaturePcd enabled?}
    B -- No --> C[Use existing variable path]
    B -- Yes --> D[Locate hook protocol]
    D --> E{Both callbacks valid?}
    E -- Yes --> F[Cache first provider callbacks]
    E -- No / not found --> G[Register protocol notification]
    G --> H{Provider appears before EndOfDxe?}
    H -- Yes --> F
    H -- No --> I[EndOfDxe closes discovery]
    F --> I
    I --> J[Ignore later installations]
    J --> K[Convert cached callbacks on virtual-address change]
    K --> L[Use cached callbacks at OS runtime]
```

The protocol database is used only during DXE discovery. The consumer copies the two callback addresses and performs no protocol lookup after `ExitBootServices()`.

Both callbacks are required. The first structurally valid provider wins and is never replaced. Every independent OS runtime request invokes the provider pre-hook so the provider can serialize any shared platform resource.

The pre-hook must return exactly `EFI_SUCCESS` to continue. Any warning or error status is returned to the caller without entering MM or invoking the post-hook.

## Runtime `SetVariable()` flow

```mermaid
flowchart LR
    A[OS calls gRT SetVariable] --> B[Existing input and MM payload validation]
    B --> C{At OS runtime and provider cached?}
    C -- No --> F[Existing MM communication path]
    C -- Yes --> D[PreSetVariable outside SMM]
    D --> E{Pre-hook status}
    E -- Not EFI_SUCCESS --> R[Return pre-hook status; do not enter SMM; do not call post-hook]
    E -- EFI_SUCCESS --> F

    subgraph SMM_TIME[SMM timeframe]
      F[Enter MM / SMI] --> G[PlatformHookBeforeSmmDispatch]
      G --> H[SmiManage dispatches variable SMM handler]
      H --> I[PlatformHookAfterSmmDispatch]
      I --> J[Exit MM / SMI]
    end

    J --> K{Was pre-hook invoked successfully?}
    K -- Yes --> L[PostSetVariable outside SMM]
    K -- No --> M[Return existing result]
    L --> M
```

The pre-hook runs only after the existing checks validate the variable name, GUID, data pointer, name size, and communication payload bounds. It runs before acquiring the boot-time variable lock and before initializing the MM communication buffer.

If the pre-hook returns `EFI_SUCCESS`, the post-hook runs exactly once after MM communication, including when MM transport or SMM variable processing fails. The post-hook receives the authoritative existing `SetVariable()` status and cannot replace it.

Boot-time `SetVariable()` calls skip both hooks.

## Security and compatibility

- The protocol is optional and disabled by default.
- Provider acceptance closes at `EndOfDxe`, limiting late installation of this specific hook.
- SMM remains authoritative for VarCheck, variable policy, Secure Boot authentication, MOR handling, and flash-write authorization.
- The non-SMM `VariableRuntimeDxe` implementation is unchanged because this extension point is specifically around MM communication.

- [ ] Breaking change?
  - No. The feature PCD defaults to `FALSE`, so existing platforms retain the current build and runtime behavior without DSC changes.
- [ ] Impacts security?
  - No direct change to existing SMM validation or authorization. The optional provider receives untrusted runtime-service inputs and must follow the requirements below.
- [ ] Includes tests?
  - No explicit test code is included in this PR.

## How This Was Tested

- Built the full `MdeModulePkg` package for X64 NOOPT with VS2022.
- Built `VariableSmmRuntimeDxe` with the feature disabled.
- Built `VariableSmmRuntimeDxe` with `PcdEnableVariableSmmRuntimeDxeHook=TRUE`.
- Verified with a platform provider that both pre- and post-hooks are invoked for an OS runtime `SetVariable()` request.
- Verified that neither hook is invoked by boot-time/POST `SetVariable()` requests.
- Confirmed this behavior matches the implementation: `VariableRuntimeHookPreSetVariable()` returns before calling the provider when `EfiAtRuntime()` is false and leaves `HookInvoked` false; `VariableRuntimeHookPostSetVariable()` then skips the provider. At OS runtime, a successful pre-hook sets `HookInvoked` true and the post-hook runs after MM communication.
- Passed MdeModulePkg ECC, GUID, dependency, license, and character-encoding checks.

## Integration Instructions

### Build-time opt-in

The feature is disabled by default. A platform must explicitly enable it in its DSC:

```ini
[PcdsFeatureFlag]
  gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableSmmRuntimeDxeHook|TRUE
```

When the PCD is `FALSE`, `VariableSmmRuntimeDxe` does not discover the protocol and does not invoke either callback.

### Platform provider

The provider must be dispatched before `EndOfDxe` and remain resident at OS runtime.

#### INF

```ini
[Defines]
  MODULE_TYPE = DXE_RUNTIME_DRIVER
  ENTRY_POINT = VariableSmmRuntimeDxeHookProviderEntryPoint

[Packages]
  MdePkg/MdePkg.dec
  MdeModulePkg/MdeModulePkg.dec

[LibraryClasses]
  UefiBootServicesTableLib
  UefiDriverEntryPoint

[Protocols]
  gEdkiiVariableSmmRuntimeDxeHookProtocolGuid  ## PRODUCES

[Depex]
  TRUE
```

#### Provider skeleton

```c
#include <Protocol/VariableSmmRuntimeDxeHook.h>

STATIC
EFI_STATUS
EFIAPI
PlatformPreSetVariable (
  IN CONST CHAR16    *VariableName,
  IN CONST EFI_GUID  *VendorGuid,
  IN       UINT32    Attributes,
  IN       UINTN     DataSize,
  IN CONST VOID      *Data
  )
{
  // Perform platform-specific preparation with a bounded timeout.
  return EFI_SUCCESS;
}

STATIC
VOID
EFIAPI
PlatformPostSetVariable (
  IN EFI_STATUS  SetVariableStatus
  )
{
  // Perform paired platform cleanup after the variable operation.
}

STATIC EDKII_VARIABLE_RUNTIME_HOOK_PROTOCOL  mVariableRuntimeHook = {
  PlatformPreSetVariable,
  PlatformPostSetVariable
};

EFI_STATUS
EFIAPI
VariableSmmRuntimeDxeHookProviderEntryPoint (
  IN EFI_HANDLE        ImageHandle,
  IN EFI_SYSTEM_TABLE  *SystemTable
  )
{
  return gBS->InstallProtocolInterface (
                &ImageHandle,
                &gEdkiiVariableSmmRuntimeDxeHookProtocolGuid,
                EFI_NATIVE_INTERFACE,
                &mVariableRuntimeHook
                );
}
```

`InstallProtocolInterface()` registers the provider-owned interface pointer in the DXE protocol database; it does not copy or allocate the interface. The protocol database is not needed at runtime because `VariableSmmRuntimeDxe` caches the callback addresses before `EndOfDxe`.

### Provider runtime requirements

A provider must:

- Be a `DXE_RUNTIME_DRIVER` and install the protocol before `EndOfDxe`.
- Never call `SetVariable()` from either callback.
- Own its runtime-safe synchronization and bound every wait or ownership request.
- Treat all callback inputs as untrusted runtime-service inputs.
- Access only firmware-exclusive resources, or use ownership/arbitration shared with the OS for OS-visible resources.

UEFI locks and TPL do not synchronize with OS drivers. A resource is considered firmware-exclusive only when it is not exposed through OS discovery or description mechanisms such as ACPI, PCI BAR assignment, or device tree; it is not enough that the currently loaded OS driver does not use it.
