### PR TITLE
EmbeddedPkg/MmcDxe: Fix MmcIoBlocks() when MultiBlock() is not supported

### DIFF
--- a/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcBlockIo.c
@@ -250,10 +250,10 @@ MmcIoBlocks (
   UINTN                  BytesRemainingToBeTransfered;
   UINTN                  BlockCount;
   UINTN                  ConsumeSize;
-  UINT32                 MaxBlock;
+  UINTN                  MaxBlock;
   UINTN                  RemainingBlock;
 
-  BlockCount      = 1;
+  MaxBlock        = 1;
   MmcHostInstance = MMC_HOST_INSTANCE_FROM_BLOCK_IO_THIS (This);
   ASSERT (MmcHostInstance != NULL);
   MmcHost = MmcHostInstance->MmcHost;
@@ -283,7 +283,7 @@ MmcIoBlocks (
   }
 
   if (MMC_HOST_HAS_ISMULTIBLOCK (MmcHost) && MmcHost->IsMultiBlock (MmcHost)) {
-    BlockCount = BufferSize / This->Media->BlockSize;
+    MaxBlock = BufferSize / This->Media->BlockSize;
   }
 
   // All blocks must be within the device
@@ -300,16 +300,14 @@ MmcIoBlocks (
     return EFI_INVALID_PARAMETER;
   }
 
-  // Max block number in single cmd is 65535 blocks.
-  MaxBlock                     = 0xFFFF;
-  RemainingBlock               = BlockCount;
+  RemainingBlock               = BufferSize / This->Media->BlockSize;
   BytesRemainingToBeTransfered = BufferSize;
   while (BytesRemainingToBeTransfered > 0) {
-    if (RemainingBlock <= MaxBlock) {
-      BlockCount = RemainingBlock;
-    } else {
-      BlockCount = MaxBlock;
-    }
+    //
+    // Max block number in single cmd is 65535 blocks.
+    // Access as many blocks as possible.
+    //
+    BlockCount = MIN (MaxBlock, MIN (RemainingBlock, 0xFFFF));
 
     // Check if the Card is in Ready status
     CmdArg      = MmcHostInstance->CardInfo.RCA << 16;


### PR DESCRIPTION
BlockCount is used as both:
- maximum number of blocks possible to access
- number of blocks accessed in the current loop iteration If MultiBlock() is not supported, accessing more than 1 block can lead to BlockCount=0 and an infinite loop.

Rationalize the variables as:
- MaxBlock: maximum number of blocks to access
- BlockCount: number of blocks accessed in the current loop iteration

## How This Was Tested

Ran Arm Base FVP with `-C bp.mmc.p_mmc_file=XXX`