### PR TITLE
ArmVirtPkg, MdeModulePkg, OvmfPkg: enable virtio-input device on arm64

### DIFF
--- a/ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc
+++ b/ArmVirtPkg/ArmVirtQemuFvMain.fdf.inc
@@ -109,6 +109,7 @@ READ_LOCK_STATUS   = TRUE
   INF OvmfPkg/VirtioScsiDxe/VirtioScsi.inf
   INF OvmfPkg/VirtioRngDxe/VirtioRng.inf
   INF OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
+  INF OvmfPkg/VirtioInputDxe/VirtioInput.inf
 
 !include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
 

--- a/ArmVirtPkg/ArmVirtQemuKernel.dsc
+++ b/ArmVirtPkg/ArmVirtQemuKernel.dsc
@@ -251,6 +251,7 @@
   # Platform Driver
   #
   OvmfPkg/VirtioSerialDxe/VirtioSerial.inf
+  OvmfPkg/VirtioInputDxe/VirtioInput.inf
 
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
   OvmfPkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf {

--- a/MdeModulePkg/Include/Library/UefiBootManagerLib.h
+++ b/MdeModulePkg/Include/Library/UefiBootManagerLib.h
@@ -611,6 +611,16 @@ typedef enum {
 } CONSOLE_TYPE;
 
 /**
+  This function will search every input/output device in current system,
+  and make every input/output device as potential console device.
+**/
+VOID
+EFIAPI
+EfiBootManagerConnectAllConsoles (
+  VOID
+  );
+
+/**
   This function will connect all the console devices base on the console
   device variable ConIn, ConOut and ErrOut.
 

--- a/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBm.c
+++ b/OvmfPkg/Library/PlatformBootManagerLibLight/PlatformBm.c
@@ -478,6 +478,21 @@ IsVirtioPciSerial (
 }
 
 /**
+  This FILTER_FUNCTION checks if a handle corresponds to a Virtio input device at
+  the EFI_PCI_IO_PROTOCOL level.
+**/
+STATIC
+BOOLEAN
+EFIAPI
+IsVirtioPciInput (
+  IN EFI_HANDLE    Handle,
+  IN CONST CHAR16  *ReportText
+  )
+{
+  return IsVirtioPci (Handle, ReportText, VIRTIO_SUBSYSTEM_INPUT);
+}
+
+/**
   This CALLBACK_FUNCTION attempts to connect a handle non-recursively, asking
   the matching driver to produce all first-level child handles.
 **/
@@ -820,6 +835,11 @@ PlatformBootManagerBeforeConsole (
   FilterAndProcess (&gEfiGraphicsOutputProtocolGuid, NULL, AddOutput);
 
   //
+  // Find all virtio-input PCI devices and connect them non-recursively.
+  //
+  FilterAndProcess (&gEfiPciIoProtocolGuid, IsVirtioPciInput, Connect);
+
+  //
   // Add the hardcoded short-form USB keyboard device path to ConIn.
   //
   EfiBootManagerUpdateConsoleVariable (
@@ -850,6 +870,13 @@ PlatformBootManagerBeforeConsole (
     (EFI_DEVICE_PATH_PROTOCOL *)&mSerialConsole,
     NULL
     );
+
+  //
+  // Walk over all instances of gEfiSimpleTextInProtocolGuid protocol
+  // and wire them to ConIn, then walk over all instances of
+  // gEfiSimpleTextOutProtocolGuid and set them up as ConOut / ErrOut.
+  //
+  EfiBootManagerConnectAllConsoles ();
 
   //
   // Set the front page timeout from the QEMU configuration.


### PR DESCRIPTION
# Description

Currently, virtio-input device does not work on AArch64 (ARM).
Let's enable it too and add to `ConIn` Variable to make it usable in Boot Menu and in GRUB too.

Note. To make preboot hotkeys work it requires #12890 PR. Without it, this will make virtio-input device
to work in GRUB, but it won't be possible to enter EDKII's Boot Menu.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

This was tested on Raspberry Pi 4 machine with [Incus](https://github.com/lxc/incus) used as a virtual machine manager (uses QEMU/KVM as a hypervisor). I can confirm that this change together with #12890 PR allows to enter EDKII setup utility and navigate in it. Without #12890 it allows to work with GRUB menu.

## Integration Instructions

N/A