### PR TITLE
OvmfPkg/PlatformBootManagerLib: register pci display for both ConOut and ErrOut

### DIFF
--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -783,6 +783,7 @@ PreparePciDisplayDevicePath (
   DevicePath = GopDevicePath;
 
   EfiBootManagerUpdateConsoleVariable (ConOut, DevicePath, NULL);
+  EfiBootManagerUpdateConsoleVariable (ErrOut, DevicePath, NULL);
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
# Description

This makes sure the set of devices for ConOut and ErrOut is identical.

Without this things get a bit messy because ConSplitterDxe can not deal
very well with the situation that a ConOut + ErrOut share some but not
all devices (i.e. vga + serial for ConOut and serial only for ErrOut).
It ends up running ConOut in 128x40 and ErrOut in 80x50 mode.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
