### PR TITLE
MdeModulePkg/ConSplitterDxe: fix nested loop

### DIFF
--- a/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
+++ b/MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitter.c
@@ -2531,13 +2531,13 @@ ConSplitterGetIntersectionBetweenConOutAndStrErr (
 
   ConOutNumOfConsoles = mConOut.CurrentNumberOfConsoles;
   StdErrNumOfConsoles = mStdErr.CurrentNumberOfConsoles;
-  ConOutTextOutList   = mConOut.TextOutList;
-  StdErrTextOutList   = mStdErr.TextOutList;
 
   Indexi              = 0;
+  ConOutTextOutList   = mConOut.TextOutList;
   FoundTheSameTextOut = FALSE;
   while ((Indexi < ConOutNumOfConsoles) && (!FoundTheSameTextOut)) {
-    Indexj = 0;
+    Indexj            = 0;
+    StdErrTextOutList = mStdErr.TextOutList;
     while (Indexj < StdErrNumOfConsoles) {
       if (ConOutTextOutList->TextOut == StdErrTextOutList->TextOut) {
         FoundTheSameTextOut = TRUE;


### PR DESCRIPTION
# Description

The nested loop can walk mStdErr.TextOutList multiple times but
initializes the pointer variable StdErrTextOutList only once so
the inner loop is not working correctly for the second (and any
following) runs.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
