### PR TITLE
OvmfPkg/QemuFlashFvbServicesRuntimeDxe: reject insecure pflash config

### DIFF
--- a/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+++ b/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
@@ -83,6 +83,7 @@
 
 [FeaturePcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire
+  gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported
 
 [Depex]
   TRUE

--- a/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesSmm.inf
+++ b/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesSmm.inf
@@ -76,6 +76,7 @@
 
 [FeaturePcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire
+  gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported
 
 [Depex]
   TRUE

--- a/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesStandaloneMm.inf
+++ b/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/FvbServicesStandaloneMm.inf
@@ -73,6 +73,7 @@
 
 [FeaturePcd]
   gUefiOvmfPkgTokenSpaceGuid.PcdSmmSmramRequire
+  gUefiOvmfPkgTokenSpaceGuid.PcdSecureBootSupported
 
 [Depex]
   TRUE

--- a/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlash.c
+++ b/OvmfPkg/QemuFlashFvbServicesRuntimeDxe/QemuFlash.c
@@ -284,6 +284,14 @@ QemuFlashInitialize (
   if (!QemuFlashDetected ()) {
     ASSERT (!FeaturePcdGet (PcdSmmSmramRequire));
     return EFI_WRITE_PROTECTED;
+  } else {
+    if (!FeaturePcdGet (PcdSmmSmramRequire) && FeaturePcdGet (PcdSecureBootSupported)) {
+      DEBUG ((DEBUG_ERROR, "ERROR: This VM configuration is not secure.\n"));
+      DEBUG ((DEBUG_ERROR, "When using secure boot and storing UEFI variables in pflash SMM mode\n"));
+      DEBUG ((DEBUG_ERROR, "must be used to prevent unauthorized updates of secure boot variables.\n"));
+      ASSERT (FeaturePcdGet (PcdSmmSmramRequire) || !FeaturePcdGet (PcdSecureBootSupported));
+      CpuDeadLoop ();
+    }
   }
 
   return EFI_SUCCESS;


### PR DESCRIPTION
# Description

In case the variable store is backed by qemu pflash make sure the edk2
build and the virtual machine setup are properly configured for secure
boot.

With this patch applied the pflash driver will only load if:
  (a) The edk2 build uses SMM to properly protect pflash storage, or
  (b) The edk2 build has secure boot support turned off.

Should that not be the case the firmware will CpuDeadLoop().

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>

- [x] Breaking change?
  - insecure edk2 / VM configurations will stop booting.
- [x] Impacts security?
  - ovmf is more strict on proper pflash configuration.
