### PR TITLE
TcgTpmPkg: Fix SIZE_MAX, UINTPTR_MAX and intptr_t definitions

### DIFF
--- a/TcgTpmPkg/Private/Include/Standard/CrtLibSupport.h
+++ b/TcgTpmPkg/Private/Include/Standard/CrtLibSupport.h
@@ -51,6 +51,26 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #endif
 
 //
+// Largest value representable in UINTN, as a plain integer constant.
+//
+// The architecture list deliberately matches the one used above to select
+// SIXTY_FOUR_BIT.
+//
+// Cannot be based on SIXTY_FOUR_BIT -- that guides the integer width to use
+// for bignum computations and is not guaranteed to match UINTN or size_t.
+//
+// Cannot use MAX_UINTN because that expands to a cast and cannot be used for
+// preprocessor expressions.
+//
+#if defined (MDE_CPU_X64) || defined (MDE_CPU_AARCH64) || defined (MDE_CPU_IA64) || defined (MDE_CPU_RISCV64) || defined (MDE_CPU_LOONGARCH64)
+#define CRT_MAX_UINTN  0xFFFFFFFFFFFFFFFFUL
+#elif defined (MDE_CPU_IA32) || defined (MDE_CPU_EBC)
+#define CRT_MAX_UINTN  0xFFFFFFFFUL
+#else
+  #error Unknown target architecture
+#endif
+
+//
 // Map all va_xxxx elements to VA_xxx defined in MdePkg/Include/Base.h
 //
 #define va_list   VA_LIST
@@ -70,7 +90,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define UINT_MAX      0xFFFFFFFF      /* Maximum unsigned int value */
 #define ULONG_MAX     0xFFFFFFFF      /* Maximum unsigned long value */
 #define CHAR_BIT      8               /* Number of bits in a char */
-#define SIZE_MAX      0xFFFFFFFF      /* Maximum unsigned size_t */
+#define SIZE_MAX      CRT_MAX_UINTN   /* Maximum unsigned size_t */
 #define INT16_MAX     0x7FFF          /* Maximum (signed) short value */
 #define UINT16_MAX    0xFFFF          /* Maximum unsigned short value */
 
@@ -97,7 +117,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 typedef UINTN   size_t;
 typedef UINTN   off_t;
 typedef UINTN   u_int;
-typedef UINTN   intptr_t;
+typedef INTN    intptr_t;
 typedef INTN    ptrdiff_t;
 typedef INTN    ssize_t;
 typedef INT64   time_t;
@@ -487,8 +507,4 @@ memcpy (
 #endif
 
 #undef UINTPTR_MAX
-#if (UINT_MAX > 0xFFFFFFFFUL)
-#define UINTPTR_MAX  0xFFFFFFFFFFFFFFFFUL
-#else
-#define UINTPTR_MAX  0xFFFFFFFFUL
-#endif
+#define UINTPTR_MAX  CRT_MAX_UINTN


### PR DESCRIPTION
# Description

`CrtLibSupport.h` always defined `SIZE_MAX` and `UINTPTR_MAX` as **MAX_UINT32**.
`UINTPTR_MAX` was selected by `#if (UINT_MAX > 0xFFFFFFFFUL)`
(can never be true) and hard-codes `SIZE_MAX` to `0xFFFFFFFF`. Fixed by defining both
based on CPU architecture (same logic as is used for `SIXTY_FOUR_BIT`).

`CrtLibSupport.h` defines `intptr_t` as `UINTN`. Fixed by defining it as `INTN`.

This doesn't appear to have any effect on current TcgTpmPkg, but could be a problem in
the future. Fix to avoid future problems and to keep in sync with the `CrtLibSupport.h` in
CryptoPkg (where the same issues do cause problems, see
https://github.com/tianocore/edk2/pull/12980).

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Built AARCH64 `TcgTpmPkg/TcgTpmPkg.dsc` with `GCC`, `-b RELEASE`.

## Integration Instructions

N/A