### PR TITLE
MdeModulePkg/XhciDxe: Handled malformed configuration descriptors

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -1072,6 +1072,21 @@ XhcControlTransfer (
         // Default to use AlternateSetting 0 for all interfaces.
         //
         Xhc->UsbDevContext[SlotId].ActiveAlternateSetting = AllocateZeroPool (Xhc->UsbDevContext[SlotId].ConfDesc[Index]->NumInterfaces * sizeof (UINT8));
+      } else if (*DataLength == 8) {
+        //
+        // Allow the initial 8-byte probe issued by UsbGetOneConfig() to read
+        // TotalLength. To distinguish the valid initial probe request from an invalid
+        // descriptor transfer, explicitly allow the 8-byte request used to
+        // retrieve TotalLength and report an error for any other size mismatch.
+        //
+      } else {
+        //
+        // Descriptor length mismatch on the full-length request indicating corrupt descriptor,
+        // treat as ERROR
+        DEBUG ((DEBUG_ERROR, "XHCI: Invalid configuration descriptor length: received %u, expected %u\n", (UINT32)*DataLength, (UINT32)((UINT16 *)Data)[1]));
+        Status          = EFI_DEVICE_ERROR;
+        *TransferResult = EFI_USB_ERR_SYSTEM;
+        goto ON_EXIT;
       }
     } else if (((DescriptorType == USB_DESC_TYPE_HUB) ||
                 (DescriptorType == USB_DESC_TYPE_HUB_SUPER_SPEED)) && (*DataLength > 2))
@@ -1106,6 +1121,12 @@ XhcControlTransfer (
     // Hook Set_Config request from UsbBus as we need configure device endpoint.
     //
     for (Index = 0; Index < Xhc->UsbDevContext[SlotId].DevDesc.NumConfigurations; Index++) {
+      if (Xhc->UsbDevContext[SlotId].ConfDesc[Index] == NULL) {
+        // ConfDesc[Index] is NULL because GET_DESCRIPTOR failed with mismatch size.
+        DEBUG ((DEBUG_ERROR, "XhcControlTransfer: ConfDesc[%d] is NULL\n", Index));
+        continue;
+      }
+
       if (Xhc->UsbDevContext[SlotId].ConfDesc[Index]->ConfigurationValue == (UINT8)Request->Value) {
         if (Xhc->HcCParams.Data.Csz == 0) {
           Status = XhcSetConfigCmd (Xhc, SlotId, DeviceSpeed, Xhc->UsbDevContext[SlotId].ConfDesc[Index]);


### PR DESCRIPTION
# Description
Handle malformed configuration descriptor responses in UsbGetOneConfig().

UsbGetOneConfig() retrieves the configuration descriptor in two steps:
1. Request the first 8 bytes to obtain TotalLength.
2. Request the full descriptor using the TotalLength value returned in the first request.

The original implementation only processes the descriptor when *DataLength matches
the descriptor's TotalLength. A size mismatch is ignored to allow the first 8-byte
probe request to succeed.

However, if the second (full-length) GetDescriptor request encounters a transfer error
and returns an incomplete descriptor, the size check also fails and the error is silently
ignored. As a result, ConfDesc[Index] is never allocated, but the operation still returns
success, which can later lead to a NULL pointer dereference when accessing:

  Xhc->UsbDevContext[SlotId].ConfDesc[Index]

This fix explicitly allows the 8-byte probe request used to retrieve TotalLength and
reports an error for any other size mismatch, distinguishing a valid initial probe from
an invalid descriptor transfer.

- [ ] Breaking change?
- [x] Impacts security?
- [ ] Includes tests?

# How This Was Tested
Reproduced the NULL pointer dereference by simulating a malformed USB configuration
descriptor response where the second full-length GetDescriptor request returned an
incomplete descriptor. Verified that with this fix, the error is correctly reported
and ConfDesc[Index] is not accessed when not allocated.

# Integration Instructions
N/A