### PR TITLE
MdeModulePkg/UefiBootManagerLib: Add constructor to INF file

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -20,6 +20,7 @@
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = UefiBootManagerLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  CONSTRUCTOR                    = UefiBootManagerLibConstructor
 
 #
 # The following information is for reference only and not required by the build tools.


### PR DESCRIPTION
# Description

UefiBootManagerLibConstructor() is a constructor function in BmBoot.c that is missing as the constructor in the INF file.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- MdeModulePkg CI
- Verify the constructor executes during QEMU boot

## Integration Instructions

- N/A