### PR TITLE
OvmfPkg/LoongArchVirt: Don't add Shell driver if secure boot is enabled

### DIFF
--- a/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
+++ b/OvmfPkg/LoongArchVirt/LoongArchVirtQemu.fdf
@@ -207,10 +207,7 @@ INF  FatPkg/EnhancedFatDxe/Fat.inf
 INF  MdeModulePkg/Universal/Disk/UdfDxe/UdfDxe.inf
 INF  OvmfPkg/VirtioFsDxe/VirtioFsDxe.inf
 
-#
-#Boot OS
-#
-INF ShellPkg/Application/Shell/Shell.inf
+!include OvmfPkg/Include/Fdf/ShellDxe.fdf.inc
 
 INF MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.inf
 INF ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf


### PR DESCRIPTION
# Description

For security reason, the UEFI Shell should not be available when Secure Boot is enabled, as discussed in https://github.com/tianocore/edk2/issues/10471.

This patch removes the direct inclusion of the Shell driver and switches to using the common ShellDxe.fdf.inc include file, as done for other architectures. This makes the Shell driver conditionally included based on the Secure Boot configuration, so that it will be excluded when Secure Boot is enabled.

## How This Was Tested

Build Loongarch Qemu firmware with `-D SECURE_BOOT_ENABLE=TRUE`, UEFI SHELL cann't be found as a boot option; Build Loongarch Qemu firmware with `-D SECURE_BOOT_ENABLE=FALSE`, UEFI SHELL can be found as a boot option.

## Integration Instructions

N/A
