### PR TITLE
OvmfPkg/LoongArchVirt: Clear per-CPU KS registers in SEC

### DIFF
--- a/OvmfPkg/LoongArchVirt/Library/EarlyFdtSerialPortLib16550/EarlyFdtSerialPortLib16550.c
+++ b/OvmfPkg/LoongArchVirt/Library/EarlyFdtSerialPortLib16550/EarlyFdtSerialPortLib16550.c
@@ -128,8 +128,9 @@ GetSerialRegisterBase (
   UINTN          SerialRegisterBase;
 
   //
-  // The LoongArchVirt serial hook path uses KS1 to hand off the UART base.
-  // Reuse it here to avoid repeated FDT lookups during early debug output.
+  // SEC initializes KS1 before the first debug output. The LoongArchVirt
+  // serial hook path then uses it to hand off the UART base. Reuse the value
+  // here to avoid repeated FDT lookups during early debug output.
   //
   SerialRegisterBase = CsrRead (LOONGARCH_CSR_KS1);
   if (SerialRegisterBase != 0) {

--- a/OvmfPkg/LoongArchVirt/Sec/LoongArch64/Start.S
+++ b/OvmfPkg/LoongArchVirt/Sec/LoongArch64/Start.S
@@ -29,6 +29,17 @@ ASM_PFX(_ModuleEntryPoint):
   li.w     $a0, 0x1FFF
   bl       DisableLocalInterrupts
 
+  /* Clear per-CPU scratch registers left by the previous boot */
+  csrwr    $zero, LOONGARCH_CSR_KS0
+  csrwr    $zero, LOONGARCH_CSR_KS1
+  csrwr    $zero, LOONGARCH_CSR_KS2
+  csrwr    $zero, LOONGARCH_CSR_KS3
+  csrwr    $zero, LOONGARCH_CSR_KS4
+  csrwr    $zero, LOONGARCH_CSR_KS5
+  csrwr    $zero, LOONGARCH_CSR_KS6
+  csrwr    $zero, LOONGARCH_CSR_KS7
+  csrwr    $zero, LOONGARCH_CSR_KS8
+
   /* Read physical cpu number id */
   bl       GetApicId
   li.d     $t0, BOOTCORE_ID  //0


### PR DESCRIPTION
# Description

The LoongArch KS registers are software scratch state. Firmware cannot
rely on their values being zero after reset, so values written during a
previous boot may be observed as stale data.

LoongArchVirt uses KS1 as a firmware-local cache for the early UART base,
as introduced by #12586. The early serial path treats a non-zero KS1 value
as valid, so stale data can be mistaken for the UART MMIO base during the
first SEC debug output.

Clear KS0 through KS8 in `Start.S` after disabling local interrupts and
before reading the CPU ID. Every CPU entering the SEC module therefore
clears its own scratch-register state before the BSP/AP split. The BSP
serial path then resolves the UART base from the device tree and caches the
valid value in KS1 for the rest of the firmware boot.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- `PatchCheck.py`: PASS
- LoongArchVirtQemu LOONGARCH64 GCC DEBUG build: PASS
- QEMU TCG `-smp 4` boot smoke to BDS: PASS
- Disassembly check: KS0-KS8 are cleared before `GetApicId` and the BSP/AP split
- QEMU monitor check: CPU1-CPU3 reached the SEC AP wait path after the clear block
- Stale KS1 clear A/B test:
  - before clearing: stale data affected the early serial path
  - after clearing: SEC/DXE/BDS output completed normally

## Integration Instructions

No special integration steps are required.
