### PR TITLE
UefiCpuPkg/LoongArch64: Keep no-read mappings valid

### DIFF
--- a/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/CpuMmu.c
+++ b/UefiCpuPkg/Library/CpuMmuLib/LoongArch64/CpuMmu.c
@@ -514,10 +514,6 @@ UpdateRegionMappingRecursive (
         EntryValue |= PAGE_GLOBAL;
       }
 
-      if ((AttributeSetMask & PAGE_NO_READ) != 0) {
-        EntryValue &= ~(PAGE_PRESENT | PAGE_VALID);
-      }
-
       ReplaceTableEntry (Entry, EntryValue, RegionStart, TableIsLive);
     }
   }


### PR DESCRIPTION
# Description

This resubmits #12661 after it was automatically closed as stale.

Keep LoongArch64 `EFI_MEMORY_RP` mappings valid and rely on the architectural
`PAGE_NO_READ` permission bit.

The current LoongArch64 MMU code makes `EFI_MEMORY_RP` effective by setting
`PAGE_NO_READ` and then clearing `PAGE_PRESENT` and `PAGE_VALID`. That makes
the NULL-page guard fault reliably, but it is stronger than the requested
read-protect semantics: the mapping becomes fully invalid instead of
present, valid, and not readable.

Both the hardware page-table-walk and software TLB refill paths should preserve
the no-read permission bit. A PTE with `P=1`, `V=1`, and `NR=1` should fault a
data load with a page non-readable exception.

This change keeps `PAGE_PRESENT` and `PAGE_VALID` set for `EFI_MEMORY_RP`
mappings and avoids turning every read-protected mapping into a fully invalid
mapping. With this change, a protected load faults with `#PNR` instead of
`#PIL`.

During bring-up, a local older QEMU binary appeared to require the stronger
invalid-PTE fallback. Further debugging showed that edk2 had written `NR=1` into
the page-table PTE, but the QEMU `LDPTE`/`TLBFILL` path dropped the `NR` bit
before installing the guest TLB entry. QEMU then installed the mapping as
readable.

That QEMU issue has been fixed by:

```text
2d877bc02a3b (target/loongarch: Preserve PTE permission bits in LDPTE)
```

Link:

```text
https://github.com/qemu/qemu/commit/2d877bc02a3b94998cbdd784d194c173d308a98a
```

With that QEMU fix, and on hardware that preserves the architectural
LoongArch64 TLB permission bits, `PAGE_NO_READ` is honored without requiring
firmware to invalidate the PTE.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Built LoongArchVirt:

```bash
export GCC_LOONGARCH64_PREFIX=loongarch64-linux-gnu-
. edksetup.sh
build -a LOONGARCH64 -t GCC \
  -p OvmfPkg/LoongArchVirt/LoongArchVirtQemu.dsc \
  -b DEBUG
```

Also validated the rebased head against current master after the new
LoongArch64 hardware-PTW support landed:

- `PatchCheck.py HEAD`: PASS
- UefiCpuPkg Uncrustify check: PASS
- LoongArchVirtQemu LOONGARCH64 GCC DEBUG build: PASS
- QEMU TCG boot smoke to `[Bds] Entry...`: PASS
- QEMU early exceptions and ASSERTs: none

Runtime validation was performed with an external UEFI diagnostic application
that executes a real LoongArch64 load from a protected address using inline
assembly. The reference source is available at:

```text
https://github.com/MarsDoge/UefiToolsPkg/blob/main/Applications/NullAddressProbe/NullAddressProbe.c
```

Before the hardware-PTW support was merged, the protected page was made invalid
by clearing `PAGE_VALID`. The diagnostic load faulted with a page-invalid-load
exception:

```text
!!!! LoongArch64 Exception Type - 01(#PIL - Page invalid exception for Load option) !!!!
BADV - 0x0000000000000000
```

With the semantic change, the mapping remains valid with `PAGE_NO_READ` set;
on the rebased code it also remains present for hardware PTW. The protected NULL
page load faults with a page non-readable exception instead:

```text
!!!! LoongArch64 Exception Type - 05(#PNR - Page non-readable exception) !!!!
BADV - 0x0000000000000000
```

This confirms that the protected mapping is still enforced through the
architectural no-read permission rather than by invalidating the PTE.

During bring-up on an older local QEMU binary, additional debug output confirmed
that edk2 wrote `NR=1` into the page-table PTE:

```text
PTE0[VA0]=2000000000000053 V=1 D=1 G=1 NR=1 NX=0
```

The same older QEMU binary dropped `NR` while loading the PTE into the guest TLB
through `LDPTE`/`TLBFILL`:

```text
TLBELO0=0000000000000053 V=1 D=1 G=1 NR=0 NX=0
```

QEMU then installed the mapping as readable:

```text
loongarch_cpu_tlb_fill address=0 physical 0000000000000000 prot 7
```

This matches the emulator issue fixed by QEMU commit:

```text
2d877bc02a3b (target/loongarch: Preserve PTE permission bits in LDPTE)
```

## Integration Instructions

N/A

