### PR TITLE
.pytool/Plugin/SpellCheck: fix ignored paths to cspell

### DIFF
--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -151,7 +151,7 @@ class SpellCheck(ICiBuildPlugin):
 
         # Parse the config for other ignored paths and use os separator.
         if "IgnoreFiles" in pkgconfig:
-            pkgfiles = [os.path.join(packagename, x).replace(os.sep, "/")
+            pkgfiles = [os.path.join(relpath, x).replace(os.sep, "/")
                         for x in pkgconfig["IgnoreFiles"]]
             config["ignorePaths"].extend(pkgfiles)
 


### PR DESCRIPTION
The IgnoreFiles key does not work when the package is not at the workspace root. Since cspell is executed at the workspace root, the ignorePaths key should be relative to it, not the package path.
