### PR TITLE
ShellPkg/Ls: Initialize list pointer variable

### DIFF
--- a/ShellPkg/Library/UefiShellLevel2CommandsLib/Ls.c
+++ b/ShellPkg/Library/UefiShellLevel2CommandsLib/Ls.c
@@ -709,6 +709,8 @@ PrintLsOutputRec (
     return ShellStatus;
   }
 
+  ListHead = NULL;
+
   Status = ShellOpenFileMetaArg ((CHAR16 *)CorrectedPath, EFI_FILE_MODE_READ, &ListHead);
   if (EFI_ERROR (Status)) {
     SHELL_FREE_NON_NULL (CorrectedPath);


### PR DESCRIPTION
# Description

This fixes the system exception using recursive `ls` in EFI shell.

The ShellOpenFileMetaArg() function allocates the list header only when the variable is `NULL`, and appends the data to whatever it points to otherwise. If the variable contains a garbage pointer, a system exception is raised.

## How This Was Tested

1. Open EFI Shell
2. Type `fs0:` (or other file system)
3. Type `ls -r`
4. See system exception

## Integration Instructions

N/A