### PR TITLE
DynamicTablesPkg: Rename the DMC 620 PMU generator

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -47,7 +47,53 @@ None
 
 #### edk2-stable202611: Changes without Removal
 
-None
+##### Breaking Change: Rename the DMC-620 PMU Dynamic Tables interfaces
+
+- **Status**: Announced
+- **Tracking Issue**: [tianocore/edk2#13070](https://github.com/tianocore/edk2/issues/13070)
+- **Pull Request**: [tianocore/edk2#12994](https://github.com/tianocore/edk2/pull/12994)
+- **Type**: Source-Level (Non-removal) - Public identifier, structure,
+  structure member, generator symbol, file, and library path rename
+
+**What changed**: The DMC-620 PMU Dynamic Tables interfaces and SSDT
+generator were renamed to use the DMC PMU terminology adopted by the
+ACPI for Arm Components 1.3 Platform Design Document. The
+table-generator ID, Configuration Manager object IDs and structures,
+structure member, generator symbol, source files and library path were
+renamed. The generated AML, `ARMHD620` hardware identifier and generator
+behaviour are unchanged.
+
+**Why it changed**: ACPI for Arm Components 1.3 updates the relevant
+section and interface terminology from “DMC620 Memory Controller” and
+“DMC620 PMU” to “DMC Memory Controller” and “DMC PMU”. The edk2
+interfaces are renamed to align with the terminology used by the latest
+specification.
+
+**What replaces it**:
+
+- `EStdAcpiTableIdSsdtDmc620Pmu` is replaced by
+  `EStdAcpiTableIdSsdtDmcPmu`.
+- `EArmObjDmc620PmuSocketInfo` is replaced by
+  `EArmObjDmcPmuSocketInfo`.
+- `EArmObjDmc620PmuRegInfo` is replaced by `EArmObjDmcPmuRegInfo`.
+- `CM_ARM_DMC620_PMU_REG_INFO` is replaced by
+  `CM_ARM_DMC_PMU_REG_INFO`.
+- `CM_ARM_DMC620_INFO` is replaced by `CM_ARM_DMC_INFO`.
+- `Dmc620PmuRegInfoToken` is replaced by `DmcPmuRegInfoToken`.
+- `SsdtDmc620PmuGenerator` is replaced by `SsdtDmcPmuGenerator`.
+- `AcpiSsdtDmc620PmuLibArm` is replaced by `AcpiSsdtDmcPmuLibArm`.
+
+**How to migrate**: Replace the DMC-620-specific identifiers, structure
+names, structure member, generator symbol, filenames and library path with
+the DMC PMU equivalents listed above. No platform-data or behavioural changes
+are required.
+
+**Breaking conditions**: This affects out-of-tree platforms that consume
+the DMC-620 PMU Configuration Manager interfaces or reference the old
+generator symbol, filenames or library path. No consumer was found in the
+current edk2 or edk2-platforms repositories.
+
+**Companion PR**: None required; no edk2-platforms consumer was identified.
 
 ### edk2-stable202611: Behavioral Breaking Changes
 

--- a/DynamicTablesPkg/DynamicTables.dsc.inc
+++ b/DynamicTablesPkg/DynamicTables.dsc.inc
@@ -138,7 +138,7 @@
   # AML Fixup (Arm specific)
   DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCmn600LibArm/SsdtCmn600LibArm.inf
 
-  DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmc620PmuLibArm/SsdtDmc620PmuLibArm.inf
+  DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmcPmuLibArm/SsdtDmcPmuLibArm.inf
 
   #
   # Dynamic Table Factory Dxe
@@ -174,7 +174,7 @@
       NULL|DynamicTablesPkg/Library/Acpi/Common/AcpiSsdtSerialPortLib/SsdtSerialPortLib.inf
       #  Arm specific
       NULL|DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtCmn600LibArm/SsdtCmn600LibArm.inf
-      NULL|DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmc620PmuLibArm/SsdtDmc620PmuLibArm.inf
+      NULL|DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmcPmuLibArm/SsdtDmcPmuLibArm.inf
 
       # AML Codegen
       #  Common

--- a/DynamicTablesPkg/Include/AcpiTableGenerator.h
+++ b/DynamicTablesPkg/Include/AcpiTableGenerator.h
@@ -68,10 +68,10 @@ The Dynamic Tables Framework implements the following ACPI table generators:
             The SSDT Cpu-Topology generator collates the cpu and LPI
             information from the Configuration Manager and generates a
             SSDT table describing the CPU hierarchy.
-  - SSDT DMC-620 PMU:
-            The SSDT DMC620 PMU generator collates the PMU specific information
+  - SSDT DMC PMU:
+            The SSDT DMC PMU generator collates the PMU specific information
             from the Configuration Manager and uses the Dynamic AML CodeGen
-            API's to build the SSDT DMC620 PMU table.
+            API's to build the SSDT DMC PMU table.
   - SSDT Pci-Express:
             The SSDT Pci Express generator collates the Pci Express
             information from the Configuration Manager and generates a
@@ -132,7 +132,7 @@ typedef enum StdAcpiTableId {
   EStdAcpiTableIdCedt,                          ///< CEDT Generator
   EStdAcpiTableIdSlit,                          ///< SLIT Generator
   EStdAcpiTableIdRhct,                          ///< RHCT Generator
-  EStdAcpiTableIdSsdtDmc620Pmu,                 ///< SSDT DMC620 PMU Generator
+  EStdAcpiTableIdSsdtDmcPmu,                    ///< SSDT DMC PMU Generator
   EStdAcpiTableIdHest,                          ///< Hest Generator
   EStdAcpiTableIdEinj,                          ///< EINJ Generator
   EStdAcpiTableIdHmat,                          ///< HMAT Generator

--- a/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
+++ b/DynamicTablesPkg/Include/ArmNameSpaceObjects.h
@@ -51,8 +51,8 @@ typedef enum ArmObjectID {
   EArmObjRmr,                                                  ///< 21 - Reserved Memory Range Node
   EArmObjMemoryRangeDescriptor,                                ///< 22 - Memory Range Descriptor
   EArmObjEtInfo,                                               ///< 23 - Embedded Trace Extension/Module Info
-  EArmObjDmc620PmuSocketInfo,                                  ///< 24 - DMC620 Socket Info
-  EArmObjDmc620PmuRegInfo,                                     ///< 25 - DMC620 PMU Reg Info
+  EArmObjDmcPmuSocketInfo,                                     ///< 24 - DMC Socket Info
+  EArmObjDmcPmuRegInfo,                                        ///< 25 - DMC PMU Reg Info
   EArmObjProcessorSpecificBlockInfo,                           ///< 26 - Processor Specific Block.
   EArmObjProcessorSpecificSubDataArchInfo,                     ///< 27 - Processor Specific Sub Data (ArchData)
   EArmObjCoresightPmuInfo,                                     ///< 28 - Coresight PMU Info
@@ -695,34 +695,34 @@ typedef struct CmArmCmn600Info {
   CM_ARM_EXTENDED_INTERRUPT    DtcInterrupt[4];
 } CM_ARM_CMN_600_INFO;
 
-/** A structure that describes the DMC620 PMU hardware
+/** A structure that describes the DMC PMU hardware
     registers and interrupt.
 
-    ID: EArmObjDmc620PmuRegInfo
+    ID: EArmObjDmcPmuRegInfo
 */
-typedef struct CmArmDmc620PmuRegInfo {
-  /// The Base address of PMU register space in the DMC620 device.
+typedef struct CmArmDmcPmuRegInfo {
+  /// The Base address of PMU register space in the DMC device.
   UINT64                       BaseAddress;
 
-  /// Length of the DMC620 PMU registers
+  /// Length of the DMC PMU registers
   UINT64                       Length;
 
-  /// The DMC620 PMU interrupt descriptor
+  /// The DMC PMU interrupt descriptor
   CM_ARM_EXTENDED_INTERRUPT    PmuIntr;
-} CM_ARM_DMC620_PMU_REG_INFO;
+} CM_ARM_DMC_PMU_REG_INFO;
 
-/** A structure that describes the DMC620 PMU hardware
+/** A structure that describes the DMC PMU hardware
     on a socket.
 
-    ID: EArmObjDmc620PmuSocketInfo
+    ID: EArmObjDmcPmuSocketInfo
 */
-typedef struct CmArmDmc620PmuSocketInfo {
+typedef struct CmArmDmcPmuSocketInfo {
   /// Number of devices on this socket
   UINT8              NumDevices;
 
-  /// Array of DMC620 PMU devices on this socket
-  CM_OBJECT_TOKEN    Dmc620PmuRegInfoToken;
-} CM_ARM_DMC620_INFO;
+  /// Array of DMC PMU devices on this socket
+  CM_OBJECT_TOKEN    DmcPmuRegInfoToken;
+} CM_ARM_DMC_INFO;
 
 /** A structure that describes the
     RMR node for the Platform.

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmcPmuLibArm/SsdtDmcPmuGenerator.c
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmcPmuLibArm/SsdtDmcPmuGenerator.c
@@ -1,12 +1,12 @@
 /** @file
-  SSDT DMC620 AML Table Generator.
+  SSDT DMC AML Table Generator.
 
   Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Reference(s):
-  - Arm CoreLink DMC-620 Dynamic Memory Controller Technical Reference Manual r1p0
+  - Arm CoreLink DMC Dynamic Memory Controller Technical Reference Manual r1p0
   - ACPI for the Arm Components 1.2 EAC1 Platform Design Document,
       dated July 2025.
     (https://developer.arm.com/documentation/den0093/1-2eac1/)
@@ -23,39 +23,39 @@
 #include <Library/AmlLib/AmlLib.h>
 #include <Protocol/ConfigurationManagerProtocol.h>
 #include <Library/TableHelperLib.h>
-#include "SsdtDmc620PmuGenerator.h"
+#include "SsdtDmcPmuGenerator.h"
 
-/** SSDT DMC620 PMU Table Generator.
+/** SSDT DMC PMU Table Generator.
 
   Requirements:
   The following Configuration Manager Object(s) are required by
   this Generator:
-  - EArmObjDmc620SocketInfo
-  - EArmObjDmc620PmuRegInfo
+  - EArmObjDmcPmuSocketInfo
+  - EArmObjDmcPmuRegInfo
 */
 
-/** This macro expands to a function that retrieves the DMC620 PMU
+/** This macro expands to a function that retrieves the DMC PMU
     Socket Information from the Configuration Manager.
 */
 GET_OBJECT_LIST (
   EObjNameSpaceArm,
-  EArmObjDmc620PmuSocketInfo,
-  CM_ARM_DMC620_INFO
+  EArmObjDmcPmuSocketInfo,
+  CM_ARM_DMC_INFO
   );
 
-/** This macro expands to a function that retrieves the DMC620 PMU
+/** This macro expands to a function that retrieves the DMC PMU
     Register Information from the Configuration Manager.
 */
 GET_OBJECT_LIST (
   EObjNameSpaceArm,
-  EArmObjDmc620PmuRegInfo,
-  CM_ARM_DMC620_PMU_REG_INFO
+  EArmObjDmcPmuRegInfo,
+  CM_ARM_DMC_PMU_REG_INFO
   );
 
-/** Check the DMC620 PMU Information for a given socket.
+/** Check the DMC PMU Information for a given socket.
 
-  @param [in] Dmc620PmuRegInfo         Array of DMC620 information structure.
-  @param [in] DevCount                 Count of DMC620 devices to validate.
+  @param [in] DmcPmuRegInfo            Array of DMC information structure.
+  @param [in] DevCount                 Count of DMC devices to validate.
 
   @retval  EFI_SUCCESS            The function completed successfully.
   @retval  EFI_INVALID_PARAMETER  Invalid parameter.
@@ -63,46 +63,46 @@ GET_OBJECT_LIST (
 STATIC
 EFI_STATUS
 EFIAPI
-ValidateDmc620PmuInfo (
-  IN  CONST CM_ARM_DMC620_PMU_REG_INFO  *CONST  Dmc620PmuRegInfo,
-  IN        UINT32                              DevCount
+ValidateDmcPmuInfo (
+  IN  CONST CM_ARM_DMC_PMU_REG_INFO  *CONST  DmcPmuRegInfo,
+  IN        UINT32                           DevCount
   )
 {
   UINT32                                  DevNum;
-  CONST CM_ARM_DMC620_PMU_REG_INFO        *RegInfo;
+  CONST CM_ARM_DMC_PMU_REG_INFO           *RegInfo;
   CONST CM_ARCH_COMMON_GENERIC_INTERRUPT  *PmuIntr;
 
-  if ((Dmc620PmuRegInfo == NULL) || (DevCount == 0)) {
+  if ((DmcPmuRegInfo == NULL) || (DevCount == 0)) {
     return EFI_INVALID_PARAMETER;
   }
 
   for (DevNum = 0; DevNum < DevCount; DevNum++) {
-    RegInfo = &Dmc620PmuRegInfo[DevNum];
+    RegInfo = &DmcPmuRegInfo[DevNum];
     // Check Base address is initialized
     if (RegInfo->BaseAddress == 0) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620: Invalid PMU Base Address.\n"
+        "ERROR: SSDT-DMC: Invalid PMU Base Address.\n"
         ));
       goto error_handler;
     }
 
-    if (RegInfo->Length != DMC620_PERIPHBASE_MAX_ADDRESS_LENGTH) {
+    if (RegInfo->Length != DMC_PERIPHBASE_MAX_ADDRESS_LENGTH) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620: Invalid PMU Length.\n"
+        "ERROR: SSDT-DMC: Invalid PMU Length.\n"
         ));
       goto error_handler;
     }
 
-    // The PMU registers in the DMC620 start at an offset of
+    // The PMU registers in the DMC start at an offset of
     // 0xA00. Check that that is so.
-    if ((RegInfo->BaseAddress & DMC620_REGISTER_SPACE_MASK) !=
-        DMC620_PMU_ADDRESS_OFFSET)
+    if ((RegInfo->BaseAddress & DMC_REGISTER_SPACE_MASK) !=
+        DMC_PMU_ADDRESS_OFFSET)
     {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620: PMU Address offset must be 0xA00.\n"
+        "ERROR: SSDT-DMC: PMU Address offset must be 0xA00.\n"
         ));
       goto error_handler;
     }
@@ -111,7 +111,7 @@ ValidateDmc620PmuInfo (
     if ((PmuIntr->Flags & BIT0) != 0) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC-620: PMU Interrupt must be Level Triggered.\n"
+        "ERROR: SSDT-DMC: PMU Interrupt must be Level Triggered.\n"
         ));
       goto error_handler;
     }
@@ -119,7 +119,7 @@ ValidateDmc620PmuInfo (
     if ((PmuIntr->Flags & BIT1) != 0) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC-620: PMU Interrupt must be Active High.\n"
+        "ERROR: SSDT-DMC: PMU Interrupt must be Active High.\n"
         ));
       goto error_handler;
     }
@@ -149,7 +149,7 @@ error_handler:
 /**
   Create the _CRS (Current Resource Settings) AML node for the device.
 
-  @param [in]  Dmc620PmuRegInfo   Pointer to the register info structure.
+  @param [in]  DmcPmuRegInfo   Pointer to the register info structure.
   @param [in]  DeviceNode         AML device node handle.
 
   @retval EFI_SUCCESS           The CRS node was created successfully.
@@ -158,9 +158,9 @@ error_handler:
 STATIC
 EFI_STATUS
 EFIAPI
-CreateDmc620PmuCrs (
-  IN CONST CM_ARM_DMC620_PMU_REG_INFO        *CONST  Dmc620PmuRegInfo,
-  IN       AML_OBJECT_NODE_HANDLE                    DeviceNode
+CreateDmcPmuCrs (
+  IN CONST CM_ARM_DMC_PMU_REG_INFO        *CONST  DmcPmuRegInfo,
+  IN       AML_OBJECT_NODE_HANDLE                 DeviceNode
   )
 {
   UINT32                  Intr;
@@ -173,15 +173,15 @@ CreateDmc620PmuCrs (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to create AML _CRS Node."
+      "ERROR: SSDT-DMC-AML-CODEGEN: Failed to create AML _CRS Node."
       " Status = %r\n",
       Status
       ));
     return Status;
   }
 
-  BaseAddress = Dmc620PmuRegInfo->BaseAddress;
-  Length      = Dmc620PmuRegInfo->Length;
+  BaseAddress = DmcPmuRegInfo->BaseAddress;
+  Length      = DmcPmuRegInfo->Length;
   Status      = AmlCodeGenRdQWordMemory (
                   FALSE,
                   TRUE,
@@ -211,7 +211,7 @@ CreateDmc620PmuCrs (
     return Status;
   }
 
-  Intr   = Dmc620PmuRegInfo->PmuIntr.Interrupt;
+  Intr   = DmcPmuRegInfo->PmuIntr.Interrupt;
   Status = AmlCodeGenRdInterrupt (
              TRUE,
              FALSE,
@@ -235,9 +235,9 @@ CreateDmc620PmuCrs (
   return EFI_SUCCESS;
 }
 
-/** Build a SSDT table describing the DMC620 PMU register space.
+/** Build a SSDT table describing the DMC PMU register space.
 
-  Add device nodes describing the DMC620 PMU register space, one
+  Add device nodes describing the DMC PMU register space, one
   socket at a time.
 
   @param [in]  Uid               For this socket, generate UID ids
@@ -246,7 +246,7 @@ CreateDmc620PmuCrs (
                                  present.
   @param [in]  DevCount          Number of devices on this socket.
   @param [in]  ScopeNode         AML System Bus node handle.
-  @param [in]  Dmc620PmuRegInfo  Array of DMC620 information structure.
+  @param [in]  DmcPmuRegInfo  Array of DMC information structure.
 
   @retval EFI_SUCCESS            Device nodes added successfully.
   @retval Others                 Failed to create the device nodes.
@@ -254,12 +254,12 @@ CreateDmc620PmuCrs (
 STATIC
 EFI_STATUS
 EFIAPI
-BuildDmc620PmuSocket (
-  IN       UINT64                                    Uid,
-  IN CONST UINT32                                    SockNum,
-  IN CONST UINT32                                    DevCount,
-  IN CONST AML_OBJECT_NODE_HANDLE                    ScopeNode,
-  IN CONST CM_ARM_DMC620_PMU_REG_INFO        *CONST  Dmc620PmuRegInfo
+BuildDmcPmuSocket (
+  IN       UINT64                                 Uid,
+  IN CONST UINT32                                 SockNum,
+  IN CONST UINT32                                 DevCount,
+  IN CONST AML_OBJECT_NODE_HANDLE                 ScopeNode,
+  IN CONST CM_ARM_DMC_PMU_REG_INFO        *CONST  DmcPmuRegInfo
   )
 {
   UINT32                  DevNum;
@@ -268,12 +268,12 @@ BuildDmc620PmuSocket (
   EFI_STATUS              Status;
   AML_OBJECT_NODE_HANDLE  DeviceNode;
 
-  // Validate the DMC620 Info and get the number of devices.
-  Status = ValidateDmc620PmuInfo (Dmc620PmuRegInfo, DevCount);
+  // Validate the DMC Info and get the number of devices.
+  Status = ValidateDmcPmuInfo (DmcPmuRegInfo, DevCount);
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: SSDT-DMC620: Invalid DMC620 PMU information. Status = %r\n",
+      "ERROR: SSDT-DMC: Invalid DMC PMU information. Status = %r\n",
       Status
       ));
     return Status;
@@ -291,7 +291,7 @@ BuildDmc620PmuSocket (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620: Failed to create AML Device Node."
+        "ERROR: SSDT-DMC: Failed to create AML Device Node."
         " Status = %r\n",
         Status
         ));
@@ -307,7 +307,7 @@ BuildDmc620PmuSocket (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to create AML _HID Node."
+        "ERROR: SSDT-DMC-AML-CODEGEN: Failed to create AML _HID Node."
         " Status = %r\n",
         Status
         ));
@@ -323,7 +323,7 @@ BuildDmc620PmuSocket (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to create AML _CID Node."
+        "ERROR: SSDT-DMC-AML-CODEGEN: Failed to create AML _CID Node."
         " Status = %r\n",
         Status
         ));
@@ -334,7 +334,7 @@ BuildDmc620PmuSocket (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to create AML _UID Node."
+        "ERROR: SSDT-DMC-AML-CODEGEN: Failed to create AML _UID Node."
         " Status = %r\n",
         Status
         ));
@@ -345,7 +345,7 @@ BuildDmc620PmuSocket (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to create AML _CCA Node."
+        "ERROR: SSDT-DMC-AML-CODEGEN: Failed to create AML _CCA Node."
         " Status = %r\n",
         Status
         ));
@@ -362,7 +362,7 @@ BuildDmc620PmuSocket (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to create AML _STR Node."
+        "ERROR: SSDT-DMC-AML-CODEGEN: Failed to create AML _STR Node."
         " Status = %r\n",
         Status
         ));
@@ -381,18 +381,18 @@ BuildDmc620PmuSocket (
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to create AML _STA Node."
+        "ERROR: SSDT-DMC-AML-CODEGEN: Failed to create AML _STA Node."
         " Status = %r\n",
         Status
         ));
       return Status;
     }
 
-    Status = CreateDmc620PmuCrs (&Dmc620PmuRegInfo[DevNum], DeviceNode);
+    Status = CreateDmcPmuCrs (&DmcPmuRegInfo[DevNum], DeviceNode);
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to create AML _CRS Node."
+        "ERROR: SSDT-DMC-AML-CODEGEN: Failed to create AML _CRS Node."
         " Status = %r\n",
         Status
         ));
@@ -403,7 +403,7 @@ BuildDmc620PmuSocket (
   return EFI_SUCCESS;
 }
 
-/** Construct SSDT tables for describing DMC620 PMU interface.
+/** Construct SSDT tables for describing DMC PMU interface.
 
   This function invokes the Configuration Manager protocol interface
   to get the required hardware information for generating the ACPI
@@ -425,23 +425,23 @@ BuildDmc620PmuSocket (
 STATIC
 EFI_STATUS
 EFIAPI
-BuildSsdtDmc620PmuTable (
+BuildSsdtDmcPmuTable (
   IN  CONST ACPI_TABLE_GENERATOR                           *This,
   IN  CONST CM_STD_OBJ_ACPI_TABLE_INFO             *CONST  AcpiTableInfo,
   IN  CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
   OUT       EFI_ACPI_DESCRIPTION_HEADER                    **Table
   )
 {
-  AML_ROOT_NODE_HANDLE        RootNode;
-  AML_OBJECT_NODE_HANDLE      ScopeNode;
-  EFI_STATUS                  Status;
-  EFI_STATUS                  Status1;
-  UINT64                      Uid;
-  UINT32                      DevCount;
-  UINT32                      SockNum;
-  UINT32                      SocketCount;
-  CM_ARM_DMC620_PMU_REG_INFO  *Dmc620PmuRegInfo;
-  CM_ARM_DMC620_INFO          *Dmc620PmuSockInfo;
+  AML_ROOT_NODE_HANDLE     RootNode;
+  AML_OBJECT_NODE_HANDLE   ScopeNode;
+  EFI_STATUS               Status;
+  EFI_STATUS               Status1;
+  UINT64                   Uid;
+  UINT32                   DevCount;
+  UINT32                   SockNum;
+  UINT32                   SocketCount;
+  CM_ARM_DMC_PMU_REG_INFO  *DmcPmuRegInfo;
+  CM_ARM_DMC_INFO          *DmcPmuSockInfo;
 
   ASSERT (This != NULL);
   ASSERT (AcpiTableInfo != NULL);
@@ -452,16 +452,16 @@ BuildSsdtDmc620PmuTable (
 
   *Table = NULL;
 
-  Status = GetEArmObjDmc620PmuSocketInfo (
+  Status = GetEArmObjDmcPmuSocketInfo (
              CfgMgrProtocol,
              CM_NULL_TOKEN,
-             &Dmc620PmuSockInfo,
+             &DmcPmuSockInfo,
              &SocketCount
              );
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: SSDT-DMC620: Failed to get the DMC620 Socket information."
+      "ERROR: SSDT-DMC: Failed to get the DMC Socket information."
       " Status = %r\n",
       Status
       ));
@@ -471,7 +471,7 @@ BuildSsdtDmc620PmuTable (
   if (SocketCount == 0) {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: SSDT-DMC620: Invalid DMC620 Socket information.\n"
+      "ERROR: SSDT-DMC: Invalid DMC Socket information.\n"
       ));
     return EFI_INVALID_PARAMETER;
   }
@@ -479,14 +479,14 @@ BuildSsdtDmc620PmuTable (
   Status = AmlCodeGenDefinitionBlock (
              "SSDT",
              "ARMLTD",
-             "DMC-620",
+             "DMC-",
              0x01,
              &RootNode
              );
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: SSDT-DMC620: Failed to create AML Definition Block."
+      "ERROR: SSDT-DMC: Failed to create AML Definition Block."
       " Status = %r\n",
       Status
       ));
@@ -498,7 +498,7 @@ BuildSsdtDmc620PmuTable (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: SSDT-DMC620: Failed to create AML Scope Node."
+      "ERROR: SSDT-DMC: Failed to create AML Scope Node."
       " Status = %r\n",
       Status
       ));
@@ -508,17 +508,17 @@ BuildSsdtDmc620PmuTable (
   Uid = 0;
   for (SockNum = 0; SockNum < SocketCount; SockNum++) {
     DevCount = 0;
-    Status   = GetEArmObjDmc620PmuRegInfo (
+    Status   = GetEArmObjDmcPmuRegInfo (
                  CfgMgrProtocol,
-                 Dmc620PmuSockInfo[SockNum].Dmc620PmuRegInfoToken,
-                 &Dmc620PmuRegInfo,
+                 DmcPmuSockInfo[SockNum].DmcPmuRegInfoToken,
+                 &DmcPmuRegInfo,
                  &DevCount
                  );
 
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620: Failed to get the DMC620 per socket device information.\n"
+        "ERROR: SSDT-DMC: Failed to get the DMC per socket device information.\n"
         " Status = %r\n",
         Status
         ));
@@ -526,26 +526,26 @@ BuildSsdtDmc620PmuTable (
       goto error_handler;
     }
 
-    if ((DevCount == 0) || (Dmc620PmuSockInfo[SockNum].NumDevices != DevCount)) {
+    if ((DevCount == 0) || (DmcPmuSockInfo[SockNum].NumDevices != DevCount)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620: Invalid DMC620 device information.\n"
+        "ERROR: SSDT-DMC: Invalid DMC device information.\n"
         ));
       ASSERT_EFI_ERROR (Status);
       goto error_handler;
     }
 
-    Status = BuildDmc620PmuSocket (
+    Status = BuildDmcPmuSocket (
                Uid,
                SockNum,
                DevCount,
                ScopeNode,
-               Dmc620PmuRegInfo
+               DmcPmuRegInfo
                );
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620: Failed to build table for DMC620."
+        "ERROR: SSDT-DMC: Failed to build table for DMC."
         " Status = %r\n",
         Status
         ));
@@ -563,7 +563,7 @@ BuildSsdtDmc620PmuTable (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: SSDT-DMC620: Failed to Serialize SSDT Table Data."
+      "ERROR: SSDT-DMC: Failed to Serialize SSDT Table Data."
       " Status = %r\n",
       Status
       ));
@@ -578,7 +578,7 @@ error_handler:
     if (EFI_ERROR (Status1)) {
       DEBUG ((
         DEBUG_ERROR,
-        "ERROR: SSDT-DMC620-AML-CODEGEN: Failed to cleanup AML tree."
+        "ERROR: SSDT-DMC-AML-CODEGEN: Failed to cleanup AML tree."
         " Status = %r\n",
         Status1
         ));
@@ -588,7 +588,7 @@ error_handler:
   return Status;
 }
 
-/** Free any resources allocated for constructing the SSDT tables for DMC620 PMU.
+/** Free any resources allocated for constructing the SSDT tables for DMC PMU.
 
   @param [in]      This           Pointer to the ACPI table generator.
   @param [in]      AcpiTableInfo  Pointer to the ACPI Table Info.
@@ -602,7 +602,7 @@ error_handler:
 STATIC
 EFI_STATUS
 EFIAPI
-FreeSsdtDmc620PmuTableRes (
+FreeSsdtDmcPmuTableRes (
   IN      CONST ACPI_TABLE_GENERATOR                   *CONST  This,
   IN      CONST CM_STD_OBJ_ACPI_TABLE_INFO             *CONST  AcpiTableInfo,
   IN      CONST EDKII_CONFIGURATION_MANAGER_PROTOCOL   *CONST  CfgMgrProtocol,
@@ -616,7 +616,7 @@ FreeSsdtDmc620PmuTableRes (
   ASSERT (AcpiTableInfo->AcpiTableSignature == This->AcpiTableSignature);
 
   if ((Table == NULL) || (*Table == NULL)) {
-    DEBUG ((DEBUG_ERROR, "ERROR: SSDT-DMC620: Invalid Table Pointer\n"));
+    DEBUG ((DEBUG_ERROR, "ERROR: SSDT-DMC: Invalid Table Pointer\n"));
     ASSERT ((Table != NULL) && (*Table != NULL));
     return EFI_INVALID_PARAMETER;
   }
@@ -629,17 +629,17 @@ FreeSsdtDmc620PmuTableRes (
 
 /** This macro defines the Raw Generator revision.
 */
-#define SSDT_DMC620_PMU_GENERATOR_REVISION  CREATE_REVISION (1, 0)
+#define SSDT_DMC_PMU_GENERATOR_REVISION  CREATE_REVISION (1, 0)
 
 /** The interface for the Raw Table Generator.
 */
 STATIC
 CONST
-ACPI_TABLE_GENERATOR  SsdtDmc620PmuGenerator = {
+ACPI_TABLE_GENERATOR  SsdtDmcPmuGenerator = {
   // Generator ID
-  CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSsdtDmc620Pmu),
+  CREATE_STD_ACPI_TABLE_GEN_ID (EStdAcpiTableIdSsdtDmcPmu),
   // Generator Description
-  L"ACPI.STD.SSDT.DMC620.PMU.GENERATOR",
+  L"ACPI.STD.SSDT.DMC.PMU.GENERATOR",
   // ACPI Table Signature
   EFI_ACPI_6_6_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE,
   // ACPI Table Revision - Unused
@@ -649,11 +649,11 @@ ACPI_TABLE_GENERATOR  SsdtDmc620PmuGenerator = {
   // Creator ID
   TABLE_GENERATOR_CREATOR_ID_ARM,
   // Creator Revision
-  SSDT_DMC620_PMU_GENERATOR_REVISION,
+  SSDT_DMC_PMU_GENERATOR_REVISION,
   // Build table function.
-  BuildSsdtDmc620PmuTable,
+  BuildSsdtDmcPmuTable,
   // Free table function.
-  FreeSsdtDmc620PmuTableRes,
+  FreeSsdtDmcPmuTableRes,
   // Build Table function. Extended version not needed.
   NULL,
   // Free Resource function. Extended version not needed.
@@ -672,17 +672,17 @@ ACPI_TABLE_GENERATOR  SsdtDmc620PmuGenerator = {
 **/
 EFI_STATUS
 EFIAPI
-AcpiSsdtDmc620PmuConstructor (
+AcpiSsdtDmcPmuConstructor (
   IN  EFI_HANDLE        ImageHandle,
   IN  EFI_SYSTEM_TABLE  *SystemTable
   )
 {
   EFI_STATUS  Status;
 
-  Status = RegisterAcpiTableGenerator (&SsdtDmc620PmuGenerator);
+  Status = RegisterAcpiTableGenerator (&SsdtDmcPmuGenerator);
   DEBUG ((
     DEBUG_INFO,
-    "SSDT-DMC620: Register Generator. Status = %r\n",
+    "SSDT-DMC: Register Generator. Status = %r\n",
     Status
     ));
   ASSERT_EFI_ERROR (Status);
@@ -700,17 +700,17 @@ AcpiSsdtDmc620PmuConstructor (
 **/
 EFI_STATUS
 EFIAPI
-AcpiSsdtDmc620PmuDestructor (
+AcpiSsdtDmcPmuDestructor (
   IN  EFI_HANDLE        ImageHandle,
   IN  EFI_SYSTEM_TABLE  *SystemTable
   )
 {
   EFI_STATUS  Status;
 
-  Status = DeregisterAcpiTableGenerator (&SsdtDmc620PmuGenerator);
+  Status = DeregisterAcpiTableGenerator (&SsdtDmcPmuGenerator);
   DEBUG ((
     DEBUG_INFO,
-    "SSDT-DMC620: Deregister Generator. Status = %r\n",
+    "SSDT-DMC: Deregister Generator. Status = %r\n",
     Status
     ));
   ASSERT_EFI_ERROR (Status);

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmcPmuLibArm/SsdtDmcPmuGenerator.h
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmcPmuLibArm/SsdtDmcPmuGenerator.h
@@ -10,7 +10,7 @@
     - Std or STD - Standard
 
   @par Reference(s):
-  - Arm CoreLink DMC-620 Coherent Mesh Network Technical Reference Manual r3p0
+  - Arm CoreLink DMC Coherent Mesh Network Technical Reference Manual r3p0
   - Generic ACPI for Arm Components 1.0 Platform Design Document
 **/
 
@@ -18,12 +18,12 @@
 
 /** PeriphBase maximum address length is 512 bytes (0x200)
 */
-#define DMC620_PERIPHBASE_MAX_ADDRESS_LENGTH  0x200
+#define DMC_PERIPHBASE_MAX_ADDRESS_LENGTH  0x200
 
-/** Mask covering the DMC620 Address space
+/** Mask covering the DMC Address space
 */
-#define DMC620_REGISTER_SPACE_MASK  0x1FFF
+#define DMC_REGISTER_SPACE_MASK  0x1FFF
 
-/** Offset of the PMU registers in the DMC620 register space
+/** Offset of the PMU registers in the DMC register space
 */
-#define DMC620_PMU_ADDRESS_OFFSET  0x0A00
+#define DMC_PMU_ADDRESS_OFFSET  0x0A00

--- a/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmcPmuLibArm/SsdtDmcPmuLibArm.inf
+++ b/DynamicTablesPkg/Library/Acpi/Arm/AcpiSsdtDmcPmuLibArm/SsdtDmcPmuLibArm.inf
@@ -1,5 +1,5 @@
 ## @file
-# Ssdt DMC-600 Table Generator
+# Ssdt DMC PMU Table Generator
 #
 #  Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
 #
@@ -8,17 +8,17 @@
 
 [Defines]
   INF_VERSION    = 0x0001001B
-  BASE_NAME      = SsdtDmc620PmuLibArm
+  BASE_NAME      = SsdtDmcPmuLibArm
   FILE_GUID      = 156e6d73-e594-49d9-8828-8c5b1a40e7af
   VERSION_STRING = 1.0
   MODULE_TYPE    = DXE_DRIVER
   LIBRARY_CLASS  = NULL|DXE_DRIVER
-  CONSTRUCTOR    = AcpiSsdtDmc620PmuConstructor
-  DESTRUCTOR     = AcpiSsdtDmc620PmuDestructor
+  CONSTRUCTOR    = AcpiSsdtDmcPmuConstructor
+  DESTRUCTOR     = AcpiSsdtDmcPmuDestructor
 
 [Sources]
-  SsdtDmc620PmuGenerator.c
-  SsdtDmc620PmuGenerator.h
+  SsdtDmcPmuGenerator.c
+  SsdtDmcPmuGenerator.h
 
 [Packages]
   DynamicTablesPkg/DynamicTablesPkg.dec

--- a/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
+++ b/DynamicTablesPkg/Library/Common/TableHelperLib/ConfigurationManagerObjectParser.c
@@ -419,16 +419,16 @@ STATIC CONST CM_OBJ_PARSER  CmArchCommonGenericInitiatorAffinityInfoParser[] = {
   { "ProximityDomainToken", sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
 };
 
-/** A parser for EArmObjDmc620PmuSocketInfo.
+/** A parser for EArmObjDmcPmuSocketInfo.
 */
-STATIC CONST CM_OBJ_PARSER  CmArmDmc620PmuSocketInfoParser[] = {
-  { "NumDevices",            1,                        "0x%x", NULL },
-  { "Dmc620PmuRegInfoToken", sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
+STATIC CONST CM_OBJ_PARSER  CmArmDmcPmuSocketInfoParser[] = {
+  { "NumDevices",         1,                        "0x%x", NULL },
+  { "DmcPmuRegInfoToken", sizeof (CM_OBJECT_TOKEN), "0x%p", NULL },
 };
 
-/** A parser for EArmObjDmc620PmuRegInfo.
+/** A parser for EArmObjDmcPmuRegInfo.
 */
-STATIC CONST CM_OBJ_PARSER  CmArmDmc620PmuRegInfoParser[] = {
+STATIC CONST CM_OBJ_PARSER  CmArmDmcPmuRegInfoParser[] = {
   { "BaseAddress", 8,                                         "0x%llx", NULL },
   { "Length",      8,                                         "0x%llx", NULL },
   { "PmuIntr",     sizeof (CM_ARCH_COMMON_GENERIC_INTERRUPT),
@@ -1701,8 +1701,8 @@ STATIC CONST CM_OBJ_PARSER_ARRAY  ArmNamespaceObjectParser[] = {
   CM_PARSER_ADD_OBJECT (EArmObjRmr,                             CmArmRmrInfoParser),
   CM_PARSER_ADD_OBJECT (EArmObjMemoryRangeDescriptor,           CmArmMemoryRangeDescriptorInfoParser),
   CM_PARSER_ADD_OBJECT (EArmObjEtInfo,                          CmArmEtInfo),
-  CM_PARSER_ADD_OBJECT (EArmObjDmc620PmuSocketInfo,             CmArmDmc620PmuSocketInfoParser),
-  CM_PARSER_ADD_OBJECT (EArmObjDmc620PmuRegInfo,                CmArmDmc620PmuRegInfoParser),
+  CM_PARSER_ADD_OBJECT (EArmObjDmcPmuSocketInfo,                CmArmDmcPmuSocketInfoParser),
+  CM_PARSER_ADD_OBJECT (EArmObjDmcPmuRegInfo,                   CmArmDmcPmuRegInfoParser),
   CM_PARSER_ADD_OBJECT (EArmObjProcessorSpecificBlockInfo,      CmArmProcessorSpecificBlockInfoParser),
   CM_PARSER_ADD_OBJECT (EArmObjProcessorSpecificSubDataArchInfo,CmArmProcessorSpecificSubDataArchInfoParser),
   CM_PARSER_ADD_OBJECT (EArmObjCoresightPmuInfo,                CmArmCoresightPmuInfoParser),


### PR DESCRIPTION
## Description

Rename the DMC-620 PMU Dynamic Tables interfaces and SSDT generator to
use the DMC PMU terminology adopted by the ACPI for Arm Components 1.3
Platform Design Document.

This is a source-level non-removal breaking change. It renames public
identifiers, structures, a structure member, the generator symbol,
source files and the library path. It does not change the generated AML,
the `ARMHD620` hardware identifier, platform-data requirements or
generator behaviour.

No consumers of the renamed interfaces were found in the current edk2
or edk2-platforms repositories.

- [x] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## Integration Instructions

Breaking change tracking issue: #13070

The corresponding migration guidance is documented in
`BREAKING-CHANGES.md`.

Out-of-tree consumers must replace the following names:

- `EStdAcpiTableIdSsdtDmc620Pmu` with `EStdAcpiTableIdSsdtDmcPmu`
- `EArmObjDmc620PmuSocketInfo` with `EArmObjDmcPmuSocketInfo`
- `EArmObjDmc620PmuRegInfo` with `EArmObjDmcPmuRegInfo`
- `CM_ARM_DMC620_PMU_REG_INFO` with `CM_ARM_DMC_PMU_REG_INFO`
- `CM_ARM_DMC620_INFO` with `CM_ARM_DMC_INFO`
- `Dmc620PmuRegInfoToken` with `DmcPmuRegInfoToken`
- `SsdtDmc620PmuGenerator` with `SsdtDmcPmuGenerator`
- `AcpiSsdtDmc620PmuLibArm` with `AcpiSsdtDmcPmuLibArm`

References to the renamed source files and library path must also be
updated. No platform-data or behavioural changes are required.