### PR TITLE
MdeModulePkg/UsbMassStorageDxe: Report blank optical media as media absent

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBoot.c
+++ b/MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassBoot.c
@@ -722,6 +722,17 @@ UsbBootDetectMedia (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "UsbBootDetectMedia: UsbBootReadCapacity (%r)\n", Status));
     }
+
+    if (UsbMass->OpticalStorage && (Media->LastBlock == 0)) {
+      //
+      // A blank (unwritten) optical disc reports a zero capacity: there is no
+      // user data block that can be read.  Report the media as absent so that
+      // upper layers (e.g. PartitionDxe and the BDS boot option probe) skip it
+      // instead of repeatedly reading LBA 0 and getting "LBA out of range".
+      //
+      Media->MediaPresent = FALSE;
+      Status              = EFI_NO_MEDIA;
+    }
   }
 
   if (EFI_ERROR (Status) && (Status != EFI_NO_MEDIA)) {


### PR DESCRIPTION
## Description

### Problem Statement

When a blank (unwritten) optical disc is inserted into a USB CD/DVD drive, the UEFI USB mass storage driver currently exposes the device to upper layers with `BlockSize = 2048` and `LastBlock = 0`. This occurs because the `READ CAPACITY` command returns zero capacity for blank media, which the driver treats as a valid medium.

Upper layers such as `PartitionDxe` and BDS removable-media boot probing then attempt to read from the device (typically LBA 0) to detect partition tables or boot signatures. However, the optical drive rejects the read request with `Illegal Request / LBA out of range` (Sense Key 5/ASC 21/ASCQ 0) because the blank disc has no valid data blocks.

Upon receiving this error, `UsbMassReadBlocks` enters its error recovery path, which performs a device reset and retries the read operation. This cycle repeats until the retry count is exhausted . Each failed probe can block the boot process for tens of seconds, causing the system to appear hung or significantly delaying boot.

### Root Cause

The driver does not check whether the reported media capacity is zero before registering the block I/O protocol and exposing the device to upper layers. For optical media, a zero capacity is a valid state indicating "blank/unwritten disc" or "no readable data," and should be treated as `EFI_NO_MEDIA` rather than a valid block device.

### Fix

In `UsbMassInitMedia()`, after successfully retrieving the media parameters via `UsbBootGetParams()`, add a check for `LastBlock == 0`. If the device is an optical storage device (`OpticalStorage == TRUE`) and the capacity is zero, return `EFI_NO_MEDIA` instead of treating it as a valid medium.

This prevents the block I/O protocol from being installed for blank optical discs, eliminating the subsequent read attempts and reset recovery loops entirely.

### Impact

- Boot time is significantly reduced when a blank optical disc is present in a USB drive.
- No functional regression for non-optical devices or optical devices with readable media (CD-ROM, DVD-ROM, etc.).
- Behavior now aligns with SCSI specifications, where zero capacity indicates no readable medium.

---

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- **Hardware**: USB DVD-ROM drive with blank CD-R media inserted.
- **Platform**: LoongArch64
- **Verification**:
  1. Boot with blank optical disc inserted → boot proceeds normally, no delay.
  2. Boot with readable CD-ROM inserted → device is correctly enumerated and accessible.
  3. Boot with no disc inserted → device reports `EFI_NO_MEDIA`, skipped immediately.
  4. USB flash drive (non-optical) → unaffected, normal operation.

Example debug log after fix:

UsbMassInitMedia: UsbBootGetParams (Success)
UsbMassInitMedia: Zero capacity detected on optical device, treating as NO_MEDIA

## Integration Instructions

N/A. This change is self-contained within `UsbMassStorageDxe` and does not introduce new dependencies, libraries, or configuration options. No platform-specific integration is required.