### PR TITLE
OvmfPkg/PlatformInitLib: Set dynamic MMIO window size to 1/4 of total address space

### DIFF
--- a/OvmfPkg/Library/PlatformInitLib/MemDetect.c
+++ b/OvmfPkg/Library/PlatformInitLib/MemDetect.c
@@ -815,7 +815,7 @@ PlatformDynamicMmioWindow (
   UINT64  AddrSpace, MmioSpace;
 
   AddrSpace = LShiftU64 (1, PlatformInfoHob->PhysMemAddressWidth);
-  MmioSpace = LShiftU64 (1, PlatformInfoHob->PhysMemAddressWidth - 3);
+  MmioSpace = LShiftU64 (1, PlatformInfoHob->PhysMemAddressWidth - 2);
 
   if (PlatformInfoHob->PcdPciMmio64Override) {
     DEBUG ((DEBUG_INFO, "%a: using fwcfg override for mmio window\n", __func__));


### PR DESCRIPTION
# Description

Large multi-GPU passthrough configurations can exhaust the current MMIO window sizing rule (1/8 of guest physical address space), especially with newer GPUs that have very large BAR requirements and alignment overhead.

With 46-bit guest physical addressing, the 1/8 rule provides an 8TB MMIO window. Newer GPUs with 512GB VRAM can exhaust an 8TB window when passing through up to 8 devices.

Increase the MMIO window size to 1/4 of guest physical address space. This provides a 16TB MMIO window on a 46-bit setup.

Tested with 8-GPU passthrough (512GB VRAM per GPU). With this change, all GPUs are visible and functional in the VM; without it, one GPU was unusable.

- [ ] Breaking change? **None**
- [ ] Impacts security? **No**
- [ ] Includes tests? **No**
## How This Was Tested
Validated on QEMU/KVM with an Ubuntu guest configured for 8-GPU passthrough (512GB VRAM per GPU). The guest powered on successfully, and all 8 GPUs were detected and usable in the VM.

Following is the debug log collected to verify that 16TB is allocated for MMIO

```
PlatformAddressWidthFromCpuid: limit PhysBits to 46 (4-level paging)
PlatformDynamicMmioWindow: using dynamic mmio window
PlatformDynamicMmioWindow:   Addr Space 0x400000000000 (65536 GB)
PlatformDynamicMmioWindow:   MMIO Space 0x100000000000 (16384 GB)
Select Item: 0x19
Select Item: 0x25
PlatformDynamicMmioWindow:   Pci64 Base 0x300000000000
PlatformDynamicMmioWindow:   Pci64 Size 0x100000000000
AddressWidthInitialization: Pci64Base=0x300000000000 Pci64Size=0x100000000000
Select Item: 0x5
PlatformMaxCpuCountInitialization: CmdData2=0x0
PlatformMaxCpuCountInitialization: BootCpuCount=120 MaxCpuCount=240
Select Item: 0x19
Select Item: 0x25
```

## Integration Instructions
NA