### PR TITLE
NetworkPkg: Add configurable PXE and HTTP Boot timeouts

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp4.c
@@ -21,11 +21,6 @@ UINT8  mInterestedDhcp4Tags[HTTP_BOOT_DHCP4_TAG_INDEX_MAX] = {
   DHCP4_TAG_DNS_SERVER
 };
 
-//
-// There are 4 times retries with the value of 4, 8, 16 and 32, refers to UEFI 2.5 spec.
-//
-UINT32  mHttpDhcpTimeout[4] = { 4, 8, 16, 32 };
-
 /**
   Build the options buffer for the DHCPv4 request packet.
 
@@ -817,12 +812,31 @@ HttpBootDhcp4Dora (
   EFI_DHCP4_CONFIG_DATA    Config;
   EFI_STATUS               Status;
   EFI_DHCP4_MODE_DATA      Mode;
+  UINT32                   DiscoverTryCount;
+  UINT32                   *DiscoverTimeout;
 
   Dhcp4 = Private->Dhcp4;
   ASSERT (Dhcp4 != NULL);
 
+  DiscoverTryCount = PcdGet32 (PcdHttpBootDhcp4DiscoverTryCount);
+  if ((PcdGetSize (PcdHttpBootDhcp4DiscoverTimeout) % sizeof (UINT32) != 0) ||
+      (DiscoverTryCount == 0) ||
+      (DiscoverTryCount > (PcdGetSize (PcdHttpBootDhcp4DiscoverTimeout) / sizeof (UINT32))))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DiscoverTimeout = AllocateCopyPool (
+                      DiscoverTryCount * sizeof (UINT32),
+                      PcdGetPtr (PcdHttpBootDhcp4DiscoverTimeout)
+                      );
+  if (DiscoverTimeout == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   Status = HttpBootSetIp4Policy (Private);
   if (EFI_ERROR (Status)) {
+    FreePool (DiscoverTimeout);
     return Status;
   }
 
@@ -837,13 +851,14 @@ HttpBootDhcp4Dora (
   Config.OptionList       = OptList;
   Config.Dhcp4Callback    = HttpBootDhcp4CallBack;
   Config.CallbackContext  = Private;
-  Config.DiscoverTryCount = HTTP_BOOT_DHCP_RETRIES;
-  Config.DiscoverTimeout  = mHttpDhcpTimeout;
+  Config.DiscoverTryCount = DiscoverTryCount;
+  Config.DiscoverTimeout  = DiscoverTimeout;
 
   //
   // Configure the DHCPv4 instance for HTTP boot.
   //
   Status = Dhcp4->Configure (Dhcp4, &Config);
+  FreePool (DiscoverTimeout);
   if (EFI_ERROR (Status)) {
     goto ON_EXIT;
   }

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp4.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp4.h
@@ -88,7 +88,6 @@ typedef enum {
   HttpOfferTypeMax
 } HTTP_BOOT_OFFER_TYPE;
 
-#define HTTP_BOOT_DHCP_RETRIES   4
 #define HTTP_BOOT_OFFER_MAX_NUM  16
 
 // The array index of the DHCP4 option tag interested

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp6.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp6.c
@@ -1067,10 +1067,18 @@ HttpBootDhcp6Sarr (
   Config.IaDescriptor.IaId     = Random;
   Config.IaDescriptor.Type     = EFI_DHCP6_IA_TYPE_NA;
   Config.SolicitRetransmission = Retransmit;
-  Retransmit->Irt              = 4;
-  Retransmit->Mrc              = 4;
-  Retransmit->Mrt              = 32;
-  Retransmit->Mrd              = 60;
+  Retransmit->Irt              = PcdGet32 (PcdHttpBootDhcp6SolicitInitialRetransmissionTime);
+  Retransmit->Mrc              = PcdGet32 (PcdHttpBootDhcp6SolicitMaximumRetransmissionCount);
+  Retransmit->Mrt              = PcdGet32 (PcdHttpBootDhcp6SolicitMaximumRetransmissionTime);
+  Retransmit->Mrd              = PcdGet32 (PcdHttpBootDhcp6SolicitMaximumRetransmissionDuration);
+
+  //
+  // The EFI_DHCP6_PROTOCOL requires at least one retransmission limit.
+  //
+  if ((Retransmit->Mrc == 0) && (Retransmit->Mrd == 0)) {
+    FreePool (Retransmit);
+    return EFI_INVALID_PARAMETER;
+  }
 
   //
   // Configure the DHCPv6 instance for HTTP boot.

--- a/NetworkPkg/HttpBootDxe/HttpBootDxe.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDxe.c
@@ -1304,6 +1304,12 @@ HttpBootDxeDriverEntryPoint (
 {
   EFI_STATUS  Status;
 
+  if ((PcdGetBool (PcdIPv4HttpSupport) == FALSE) &&
+      (PcdGetBool (PcdIPv6HttpSupport) == FALSE))
+  {
+    return EFI_UNSUPPORTED;
+  }
+
   //
   // Install UEFI Driver Model protocol(s).
   //

--- a/NetworkPkg/HttpBootDxe/HttpBootDxe.inf
+++ b/NetworkPkg/HttpBootDxe/HttpBootDxe.inf
@@ -98,6 +98,12 @@
 [Pcd]
   gEfiNetworkPkgTokenSpaceGuid.PcdAllowHttpConnections           ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpIoTimeout                  ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp4DiscoverTimeout   ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp4DiscoverTryCount  ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp6SolicitInitialRetransmissionTime    ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp6SolicitMaximumRetransmissionCount   ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp6SolicitMaximumRetransmissionTime    ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp6SolicitMaximumRetransmissionDuration ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdMaxHttpResumeRetries           ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpDelayBetweenResumeRetries  ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv4HttpSupport                ## CONSUMES

--- a/NetworkPkg/HttpDxe/HttpDxe.inf
+++ b/NetworkPkg/HttpDxe/HttpDxe.inf
@@ -81,6 +81,7 @@
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryInterval       ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpDnsRetryCount          ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpTransferBufferSize     ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpConnectionTimeout      ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   HttpDxeExtra.uni

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -1094,7 +1094,7 @@ HttpConfigureTcp4 (
   Tcp4Option->ReceiveBufferSize   = PcdGet32 (PcdHttpTransferBufferSize);
   Tcp4Option->SendBufferSize      = PcdGet32 (PcdHttpTransferBufferSize);
   Tcp4Option->MaxSynBackLog       = HTTP_MAX_SYN_BACK_LOG;
-  Tcp4Option->ConnectionTimeout   = HTTP_CONNECTION_TIMEOUT;
+  Tcp4Option->ConnectionTimeout   = PcdGet32 (PcdHttpConnectionTimeout);
   Tcp4Option->DataRetries         = HTTP_DATA_RETRIES;
   Tcp4Option->FinTimeout          = HTTP_FIN_TIMEOUT;
   Tcp4Option->KeepAliveProbes     = HTTP_KEEP_ALIVE_PROBES;
@@ -1178,7 +1178,7 @@ HttpConfigureTcp6 (
   Tcp6Option->ReceiveBufferSize   = PcdGet32 (PcdHttpTransferBufferSize);
   Tcp6Option->SendBufferSize      = PcdGet32 (PcdHttpTransferBufferSize);
   Tcp6Option->MaxSynBackLog       = HTTP_MAX_SYN_BACK_LOG;
-  Tcp6Option->ConnectionTimeout   = HTTP_CONNECTION_TIMEOUT;
+  Tcp6Option->ConnectionTimeout   = PcdGet32 (PcdHttpConnectionTimeout);
   Tcp6Option->DataRetries         = HTTP_DATA_RETRIES;
   Tcp6Option->FinTimeout          = HTTP_FIN_TIMEOUT;
   Tcp6Option->KeepAliveProbes     = HTTP_KEEP_ALIVE_PROBES;
@@ -1296,7 +1296,7 @@ HttpConnectTcp4 (
     //
     // Start the timer, and wait Timeout seconds for connection.
     //
-    Status = gBS->SetTimer (HttpInstance->TimeoutEvent, TimerRelative, HTTP_CONNECTION_TIMEOUT * TICKS_PER_SECOND);
+    Status = gBS->SetTimer (HttpInstance->TimeoutEvent, TimerRelative, PcdGet32 (PcdHttpConnectionTimeout) * TICKS_PER_SECOND);
     if (EFI_ERROR (Status)) {
       TlsCloseTxRxEvent (HttpInstance);
       return Status;
@@ -1393,7 +1393,7 @@ HttpConnectTcp6 (
     //
     // Start the timer, and wait Timeout seconds for connection.
     //
-    Status = gBS->SetTimer (HttpInstance->TimeoutEvent, TimerRelative, HTTP_CONNECTION_TIMEOUT * TICKS_PER_SECOND);
+    Status = gBS->SetTimer (HttpInstance->TimeoutEvent, TimerRelative, PcdGet32 (PcdHttpConnectionTimeout) * TICKS_PER_SECOND);
     if (EFI_ERROR (Status)) {
       TlsCloseTxRxEvent (HttpInstance);
       return Status;

--- a/NetworkPkg/HttpDxe/HttpProto.h
+++ b/NetworkPkg/HttpDxe/HttpProto.h
@@ -39,7 +39,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define HTTP_TOS_DEAULT           8
 #define HTTP_TTL_DEAULT           255
 #define HTTP_MAX_SYN_BACK_LOG     5
-#define HTTP_CONNECTION_TIMEOUT   60
 #define HTTP_DATA_RETRIES         12
 #define HTTP_FIN_TIMEOUT          2
 #define HTTP_KEEP_ALIVE_PROBES    6

--- a/NetworkPkg/NetworkPkg.dec
+++ b/NetworkPkg/NetworkPkg.dec
@@ -115,7 +115,7 @@
   # @Prompt Delay in seconds between each HTTP resume retry. Default value is 2s.
   gEfiNetworkPkgTokenSpaceGuid.PcdHttpDelayBetweenResumeRetries|0x00000002|UINT32|0x00000013
 
-[PcdsFixedAtBuild, PcdsPatchableInModule]
+[PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## Indicates whether HTTP connections (i.e., unsecured) are permitted or not.
   # TRUE  - HTTP connections are allowed. Both the "https://" and "http://" URI schemes are permitted.
   # FALSE - HTTP connections are denied. Only the "https://" URI scheme is permitted.
@@ -141,6 +141,38 @@
   # FALSE - Event being triggered upon ExitBootServices call will NOT be created
   # @Prompt Indicates whether SnpDxe creates event for ExitBootServices() call.
   gEfiNetworkPkgTokenSpaceGuid.PcdSnpCreateExitBootServicesEvent|TRUE|BOOLEAN|0x1000000C
+
+  ## The DHCPv4 Discover timeout values in seconds used by UEFI PXE.
+  # The value is an array of UINT32 values, one for each Discover attempt.
+  # The driver uses the first PcdPxeDhcp4DiscoverTryCount elements. Therefore,
+  # the array must contain at least PcdPxeDhcp4DiscoverTryCount elements.
+  # @Prompt PXE DHCPv4 Discover timeout values.
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp4DiscoverTimeout|{ 0x04, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00 }|VOID*|0x10000014
+
+  ## The number of DHCPv4 Discover attempts used by UEFI PXE.
+  # This value specifies how many elements of PcdPxeDhcp4DiscoverTimeout are used.
+  # @Prompt PXE DHCPv4 Discover retry count.
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp4DiscoverTryCount|4|UINT32|0x10000015
+
+  ## The initial retransmission time in seconds for DHCPv6 Solicit used by UEFI PXE.
+  # @Prompt PXE DHCPv6 Solicit initial retransmission time.
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitInitialRetransmissionTime|4|UINT32|0x10000016
+
+  ## The maximum retransmission count for DHCPv6 Solicit used by UEFI PXE.
+  # At least one of PcdPxeDhcp6SolicitMaximumRetransmissionCount and
+  # PcdPxeDhcp6SolicitMaximumRetransmissionDuration must be non-zero.
+  # @Prompt PXE DHCPv6 Solicit maximum retransmission count.
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionCount|4|UINT32|0x10000017
+
+  ## The maximum retransmission time in seconds for DHCPv6 Solicit used by UEFI PXE.
+  # @Prompt PXE DHCPv6 Solicit maximum retransmission time.
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionTime|32|UINT32|0x10000018
+
+  ## The maximum retransmission duration in seconds for DHCPv6 Solicit used by UEFI PXE.
+  # At least one of PcdPxeDhcp6SolicitMaximumRetransmissionCount and
+  # PcdPxeDhcp6SolicitMaximumRetransmissionDuration must be non-zero.
+  # @Prompt PXE DHCPv6 Solicit maximum retransmission duration.
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionDuration|60|UINT32|0x10000019
 
 [PcdsFixedAtBuild, PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## IPv6 DHCP Unique Identifier (DUID) Type configuration (From RFCs 3315 and 6355).
@@ -192,6 +224,44 @@
 
   ## IPv6 HTTP support
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv6HttpSupport|TRUE|BOOLEAN|0x10000013
+
+  ## The TCP and TLS connection timeout in seconds used by HTTP.
+  # @Prompt HTTP connection timeout.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpConnectionTimeout|60|UINT32|0x1000001A
+
+  ## The DHCPv4 Discover timeout values in seconds used by HTTP Boot.
+  # The value is an array of UINT32 values, one for each Discover attempt.
+  # The driver uses the first PcdHttpBootDhcp4DiscoverTryCount elements.
+  # Therefore, the array must contain at least
+  # PcdHttpBootDhcp4DiscoverTryCount elements.
+  # @Prompt HTTP Boot DHCPv4 Discover timeout values.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp4DiscoverTimeout|{ 0x04, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00 }|VOID*|0x1000001B
+
+  ## The number of DHCPv4 Discover attempts used by HTTP Boot.
+  # This value specifies how many elements of
+  # PcdHttpBootDhcp4DiscoverTimeout are used.
+  # @Prompt HTTP Boot DHCPv4 Discover retry count.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp4DiscoverTryCount|4|UINT32|0x1000001C
+
+  ## The initial retransmission time in seconds for DHCPv6 Solicit used by HTTP Boot.
+  # @Prompt HTTP Boot DHCPv6 Solicit initial retransmission time.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp6SolicitInitialRetransmissionTime|4|UINT32|0x1000001D
+
+  ## The maximum retransmission count for DHCPv6 Solicit used by HTTP Boot.
+  # At least one of PcdHttpBootDhcp6SolicitMaximumRetransmissionCount and
+  # PcdHttpBootDhcp6SolicitMaximumRetransmissionDuration must be non-zero.
+  # @Prompt HTTP Boot DHCPv6 Solicit maximum retransmission count.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp6SolicitMaximumRetransmissionCount|4|UINT32|0x1000001E
+
+  ## The maximum retransmission time in seconds for DHCPv6 Solicit used by HTTP Boot.
+  # @Prompt HTTP Boot DHCPv6 Solicit maximum retransmission time.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp6SolicitMaximumRetransmissionTime|32|UINT32|0x1000001F
+
+  ## The maximum retransmission duration in seconds for DHCPv6 Solicit used by HTTP Boot.
+  # At least one of PcdHttpBootDhcp6SolicitMaximumRetransmissionCount and
+  # PcdHttpBootDhcp6SolicitMaximumRetransmissionDuration must be non-zero.
+  # @Prompt HTTP Boot DHCPv6 Solicit maximum retransmission duration.
+  gEfiNetworkPkgTokenSpaceGuid.PcdHttpBootDhcp6SolicitMaximumRetransmissionDuration|60|UINT32|0x10000020
 
   ## The default size of the HTTP transfer data buffer in bytes.
   # This size is used for HTTP transfers, with a default value of 2MB.

--- a/NetworkPkg/Test/NetworkPkgHostTest.dsc
+++ b/NetworkPkg/Test/NetworkPkgHostTest.dsc
@@ -94,3 +94,7 @@
 [PcdsFixedAtBuild]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x2
   gEfiNetworkPkgTokenSpaceGuid.PcdDhcp6UidType|0x4
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitInitialRetransmissionTime|4
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionCount|4
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionTime|32
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionDuration|60

--- a/NetworkPkg/UefiPxeBcDxe/GoogleTest/UefiPxeBcDxeGoogleTest.inf
+++ b/NetworkPkg/UefiPxeBcDxe/GoogleTest/UefiPxeBcDxeGoogleTest.inf
@@ -44,6 +44,10 @@ VERSION_STRING = 1.0
 
 [Pcd]
   gEfiNetworkPkgTokenSpaceGuid.PcdDhcp6UidType
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitInitialRetransmissionTime
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionCount
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionTime
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionDuration
 
 [Guids]
   gZeroGuid

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -22,11 +22,6 @@ UINT8  mInterestedDhcp4Tags[PXEBC_DHCP4_TAG_INDEX_MAX] = {
   DHCP4_TAG_BOOTFILE
 };
 
-//
-// There are 4 times retries with the value of 4, 8, 16 and 32, refers to PXE2.1 spec.
-//
-UINT32  mPxeDhcpTimeout[4] = { 4, 8, 16, 32 };
-
 /**
   Parse a certain dhcp4 option by OptTag in Buffer, and return with start pointer.
 
@@ -1664,10 +1659,28 @@ PxeBcDhcp4Dora (
   EFI_DHCP4_PACKET_OPTION  *OptList[PXEBC_DHCP4_OPTION_MAX_NUM];
   UINT8                    Buffer[PXEBC_DHCP4_OPTION_MAX_SIZE];
   UINT32                   OptCount;
+  UINT32                   DiscoverTryCount;
+  UINT32                   *DiscoverTimeout;
   EFI_STATUS               Status;
 
   ASSERT (Dhcp4 != NULL);
   PxeMode = Private->PxeBc.Mode;
+
+  DiscoverTryCount = PcdGet32 (PcdPxeDhcp4DiscoverTryCount);
+  if ((PcdGetSize (PcdPxeDhcp4DiscoverTimeout) % sizeof (UINT32) != 0) ||
+      (DiscoverTryCount == 0) ||
+      (DiscoverTryCount > (PcdGetSize (PcdPxeDhcp4DiscoverTimeout) / sizeof (UINT32))))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DiscoverTimeout = AllocateCopyPool (
+                      DiscoverTryCount * sizeof (UINT32),
+                      PcdGetPtr (PcdPxeDhcp4DiscoverTimeout)
+                      );
+  if (DiscoverTimeout == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   //
   // Build option list for the request packet.
@@ -1682,13 +1695,14 @@ PxeBcDhcp4Dora (
   Config.OptionList       = OptList;
   Config.Dhcp4Callback    = PxeBcDhcp4CallBack;
   Config.CallbackContext  = Private;
-  Config.DiscoverTryCount = PXEBC_DHCP_RETRIES;
-  Config.DiscoverTimeout  = mPxeDhcpTimeout;
+  Config.DiscoverTryCount = DiscoverTryCount;
+  Config.DiscoverTimeout  = DiscoverTimeout;
 
   //
   // Configure the DHCPv4 instance for PXE boot.
   //
   Status = Dhcp4->Configure (Dhcp4, &Config);
+  FreePool (DiscoverTimeout);
   if (EFI_ERROR (Status)) {
     goto ON_EXIT;
   }

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
@@ -2379,10 +2379,18 @@ PxeBcDhcp6Sarr (
   Config.IaDescriptor.IaId     = Private->IaId;
   Config.IaDescriptor.Type     = EFI_DHCP6_IA_TYPE_NA;
   Config.SolicitRetransmission = Retransmit;
-  Retransmit->Irt              = 4;
-  Retransmit->Mrc              = 4;
-  Retransmit->Mrt              = 32;
-  Retransmit->Mrd              = 60;
+  Retransmit->Irt              = PcdGet32 (PcdPxeDhcp6SolicitInitialRetransmissionTime);
+  Retransmit->Mrc              = PcdGet32 (PcdPxeDhcp6SolicitMaximumRetransmissionCount);
+  Retransmit->Mrt              = PcdGet32 (PcdPxeDhcp6SolicitMaximumRetransmissionTime);
+  Retransmit->Mrd              = PcdGet32 (PcdPxeDhcp6SolicitMaximumRetransmissionDuration);
+
+  //
+  // The EFI_DHCP6_PROTOCOL requires at least one retransmission limit.
+  //
+  if ((Retransmit->Mrc == 0) && (Retransmit->Mrd == 0)) {
+    FreePool (Retransmit);
+    return EFI_INVALID_PARAMETER;
+  }
 
   //
   // Configure the DHCPv6 instance for PXE boot.

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
@@ -66,7 +66,6 @@ typedef struct _PXEBC_VIRTUAL_NIC       PXEBC_VIRTUAL_NIC;
 #define PXEBC_DAD_ADDITIONAL_DELAY  30000000   // 3 seconds
 #define PXEBC_MTFTP_TIMEOUT         4
 #define PXEBC_MTFTP_RETRIES         6
-#define PXEBC_DHCP_RETRIES          4          // refers to mPxeDhcpTimeout, also by PXE2.1 spec.
 #define PXEBC_MENU_MAX_NUM          24
 #define PXEBC_OFFER_MAX_NUM         16
 

--- a/NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
+++ b/NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
@@ -104,6 +104,12 @@
   gEfiNetworkPkgTokenSpaceGuid.PcdPxeTftpWindowSize    ## SOMETIMES_CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv4PXESupport       ## CONSUMES
   gEfiNetworkPkgTokenSpaceGuid.PcdIPv6PXESupport       ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp4DiscoverTimeout                    ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp4DiscoverTryCount                    ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitInitialRetransmissionTime    ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionCount   ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionTime    ## CONSUMES
+  gEfiNetworkPkgTokenSpaceGuid.PcdPxeDhcp6SolicitMaximumRetransmissionDuration ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   UefiPxeBcDxeExtra.uni


### PR DESCRIPTION
# Description

  Add configurable DHCP retransmission and HTTP connection timeout PCDs
  for UEFI PXE and HTTP Boot.

  The change adds PCDs for:

  - PXE and HTTP Boot DHCPv4 Discover retry count and timeout values.
  - PXE and HTTP Boot DHCPv6 Solicit retransmission parameters.
  - HTTP TCP/TLS connection timeout.

  Existing default behavior is preserved. The DHCPv4 timeout array and retry
  count are validated before configuring the DHCP instance.

  Also skip installing the HttpBootDxe driver bindings when both IPv4 and IPv6
  HTTP Boot support PCDs are disabled. This matches the existing
  UefiPxeBcDxe behavior and avoids installing bindings that cannot support a
  controller.
  - [ ] Breaking change?
  - [ ] Impacts security?
  - [ ] Includes tests?


## How This Was Tested

  Manual testing was performed by changing the default values of the new PCDs
  in `NetworkPkg/NetworkPkg.dec`, rebuilding the affected drivers, and booting
  in a network test environment.

  - Set both `PcdIPv4HttpSupport` and `PcdIPv6HttpSupport` to `FALSE` and
    verified that HttpBootDxe did not install its driver bindings.
  - Changed the DHCPv4 Discover retry count and timeout-array PCD defaults.
    With the DHCPv4 server configured not to return an offer, verified from
    packet timestamps that PXE and HTTP Boot used the configured retry count
    and timeout intervals.

  - Changed the DHCPv6 Solicit IRT, MRC, MRT, and MRD PCD defaults. With the
    DHCPv6 server configured not to return an Advertise or Reply, verified that
    PXE and HTTP Boot retransmission behavior followed the configured values.

  - Changed `PcdHttpConnectionTimeout` and used an unreachable HTTP Boot
    endpoint. Verified that the TCP/TLS connection timeout changed accordingly.

  - Restored the original PCD default values and verified that the original
    PXE and HTTP Boot timing behavior was preserved.

## Integration Instructions

  N/A
