### PR TITLE
OvmfPkg: Enable PCI UFS boot support

### DIFF
--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -4427,7 +4427,7 @@ ScsiDiskFuaMode (
   UINT8       HostAdapterStatus;
   UINT8       TargetStatus;
   UINT8       SenseDataLength;
-  UINT8       Buffer[CACHE_MODE_PAGE_LEN];
+  UINT8       *Buffer;
   UINT32      BufferLength;
   EFI_STATUS  ReturnStatus;
   BOOLEAN     DpoFua;
@@ -4437,6 +4437,12 @@ ScsiDiskFuaMode (
   BufferLength    = CACHE_MODE_PAGE_LEN;
   DpoFua          = TRUE;
   WriteCaching    = TRUE;
+  Buffer          = AllocateAlignedBuffer (ScsiDiskDevice, BufferLength);
+  if (Buffer == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (Buffer, BufferLength);
   //
   // Execute Mode Sense Command here to get the support of FUA
   // through Mode page. FUA support locates in Mode parameter
@@ -4460,6 +4466,7 @@ ScsiDiskFuaMode (
     //
     // Mode Sense Command fails
     //
+    FreeAlignedBuffer (Buffer, CACHE_MODE_PAGE_LEN);
     return EFI_DEVICE_ERROR;
   }
 
@@ -4471,6 +4478,7 @@ ScsiDiskFuaMode (
     //
     // Return page is not right
     //
+    FreeAlignedBuffer (Buffer, CACHE_MODE_PAGE_LEN);
     return EFI_DEVICE_ERROR;
   }
 
@@ -4497,6 +4505,7 @@ ScsiDiskFuaMode (
   }
 
   ScsiDiskDevice->FuaMode = DpoFua || WriteCaching;
+  FreeAlignedBuffer (Buffer, CACHE_MODE_PAGE_LEN);
 
   return EFI_SUCCESS;
 }

--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -36,6 +36,8 @@
   DEFINE SOURCE_DEBUG_ENABLE     = FALSE
   DEFINE CC_MEASUREMENT_ENABLE   = TRUE
   DEFINE DEBUG_TO_MEM            = FALSE
+  # Allow OVMF to enumerate and boot from PCI UFS logical units.
+  DEFINE UFS_ENABLE              = TRUE
 
 !include OvmfPkg/Include/Dsc/OvmfTpmDefines.dsc.inc
 
@@ -987,6 +989,10 @@
   MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
   MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
   MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+!if $(UFS_ENABLE) == TRUE
+  MdeModulePkg/Bus/Pci/UfsPciHcDxe/UfsPciHcDxe.inf
+  MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruDxe.inf
+!endif
   MdeModulePkg/Bus/Pci/CxlDxe/CxlDxe.inf
   MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
   MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf

--- a/OvmfPkg/OvmfPkgX64.fdf
+++ b/OvmfPkg/OvmfPkgX64.fdf
@@ -244,6 +244,10 @@ INF  MdeModulePkg/Bus/Pci/SataControllerDxe/SataControllerDxe.inf
 INF  MdeModulePkg/Bus/Ata/AtaAtapiPassThru/AtaAtapiPassThru.inf
 INF  MdeModulePkg/Bus/Ata/AtaBusDxe/AtaBusDxe.inf
 INF  MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+!if $(UFS_ENABLE) == TRUE
+INF  MdeModulePkg/Bus/Pci/UfsPciHcDxe/UfsPciHcDxe.inf
+INF  MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruDxe.inf
+!endif
 INF  MdeModulePkg/Bus/Pci/CxlDxe/CxlDxe.inf
 INF  MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
 INF  MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf


### PR DESCRIPTION
# Description

Enable OVMF X64 to enumerate and boot from logical units attached to PCI UFS host controllers.

Add `UfsPciHcDxe` and `UfsPassThruDxe` to the OVMF X64 platform description and firmware volume. UFS support is controlled by the `UFS_ENABLE` build option and is enabled by default.

`UfsPassThruDxe` requires data buffers to satisfy the alignment advertised through `EFI_EXT_SCSI_PASS_THRU_PROTOCOL`. The caching mode page buffer used by `ScsiDiskFuaMode()` was previously allocated on the stack and was therefore not guaranteed to meet that requirement. Allocate it using the existing aligned-buffer helper and release it on all return paths.

Together, these changes allow `ScsiDiskDxe` to query UFS logical units successfully and make them available as boot devices in OVMF.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

```
qemu-system-x86_64 \
  -machine q35 \
  -m 2G \
  -drive if=pflash,format=raw,readonly=on,file=Build/OvmfX64/DEBUG_GCC/FV/OVMF_CODE.fd \
  -drive if=pflash,format=raw,file=/tmp/OVMF_VARS.fd \
  -drive if=none,format=raw,id=ufs-disk,file=/path/to/bootable.img \
  -device ufs,id=ufs0,serial=ufs0 \
  -device ufs-lu,bus=ufs0,drive=ufs-disk,lun=0 \
  -serial stdio \
  -display none
```

## Integration Instructions

N/A
