### PR TITLE
MdeModulePkg/SetupBrowserDxe: Sync ordered lists before action callback

### DIFF
--- a/MdeModulePkg/Universal/SetupBrowserDxe/Presentation.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/Presentation.c
@@ -2063,6 +2063,31 @@ ProcessCallBackFunction (
     return EFI_SUCCESS;
   }
 
+  //
+  // When processing CHANGED for an action opcode (e.g., "Commit Changes and Exit"),
+  // sync ordered list values to Storage first. Action opcodes can trigger form submit;
+  // ordered lists use separate BufferValue that must be synced before the callback
+  // runs HiiGetBrowserData. Only run for action opcodes to avoid affecting menu
+  // navigation (GOTO/REFRESH).
+  //
+  if ((Action == EFI_BROWSER_ACTION_CHANGED) &&
+      (Question != NULL) &&
+      (Question->Operand == EFI_IFR_ACTION_OP))
+  {
+    Link = GetFirstNode (&Form->StatementListHead);
+    while (!IsNull (&Form->StatementListHead, Link)) {
+      Statement = FORM_BROWSER_STATEMENT_FROM_LINK (Link);
+      Link      = GetNextNode (&Form->StatementListHead, Link);
+
+      if ((Statement->Operand == EFI_IFR_ORDERED_LIST_OP) &&
+          (Statement->Storage != NULL) &&
+          (Statement->BufferValue != NULL))
+      {
+        SetQuestionValue (FormSet, Form, Statement, GetSetValueWithEditBuffer);
+      }
+    }
+  }
+
   Link = GetFirstNode (&Form->StatementListHead);
   while (!IsNull (&Form->StatementListHead, Link)) {
     Statement = FORM_BROWSER_STATEMENT_FROM_LINK (Link);


### PR DESCRIPTION
# Description

When the user selects an EFI_IFR_ACTION_OP (for example Commit Changes and Exit), SetupBrowser may submit the form and invoke the driver's callback before ordered-list question values are copied from their edit buffer into storage. HiiGetBrowserData() in the callback then sees stale list ordering and the submitted configuration is wrong.

Sync all ordered-list values to storage on EFI_BROWSER_ACTION_CHANGED for action opcodes only. Only run for action opcodes to avoid affecting menu navigation (GOTO/REFRESH).


## How This Was Tested

build/boot edk2 as coreboot payload on multiple devices.

## Integration Instructions

N/A
