### PR TITLE
UefiCpuPkg: Do not hang on spurious external interrupts in SMM

### DIFF
--- a/MdeModulePkg/Include/Library/CpuExceptionHandlerLib.h
+++ b/MdeModulePkg/Include/Library/CpuExceptionHandlerLib.h
@@ -13,6 +13,7 @@
 #include <Protocol/Cpu.h>
 
 #define X86_CPU_INTERRUPT_NUM  256
+#define X86_CPU_EXCEPTION_NUM  32
 
 /**
   Initializes all CPU exceptions entries and provides the default exception handlers.

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
@@ -65,6 +65,7 @@
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize
 
@@ -80,6 +81,7 @@
   BaseLib
   DebugLib
   MemoryAllocationLib
+  PcdLib
   PeCoffGetEntryPointLib
   PrintLib
   SerialPortLib

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuExceptionHandlerLib.inf
@@ -49,6 +49,7 @@
   HobLib
   LocalApicLib
   MemoryAllocationLib
+  PcdLib
   PeCoffGetEntryPointLib
   PrintLib
   SerialPortLib
@@ -56,6 +57,7 @@
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard    # CONSUMES
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList
 

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiDxeSmmCpuException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiDxeSmmCpuException.c
@@ -8,7 +8,30 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Library/DebugLib.h>
 #include <Library/CcExitLib.h>
+#include <Library/PcdLib.h>
 #include "CpuExceptionCommon.h"
+
+/**
+  Return TRUE if an unhandled vector should be treated as a fatal CPU fault.
+
+  Intel defines vectors 0-31 as CPU exceptions and 32-255 as external
+  interrupts.  After expanding the SMM IDT to 256 entries, spurious hardware
+  interrupts (for example ExtINT/IRQ0 on vector 32 left enabled by coreboot)
+  must not hang the system.  Stack cookie violations use
+  PcdStackCookieExceptionVector (default 0x42) and remain fatal.
+**/
+STATIC
+BOOLEAN
+IsFatalUnhandledVector (
+  IN EFI_EXCEPTION_TYPE  ExceptionType
+  )
+{
+  if (ExceptionType < X86_CPU_EXCEPTION_NUM) {
+    return TRUE;
+  }
+
+  return (BOOLEAN)(ExceptionType == FixedPcdGet8 (PcdStackCookieExceptionVector));
+}
 
 /**
   Internal worker function for common exception handler.
@@ -134,7 +157,7 @@ CommonExceptionHandlerWorker (
       (ExternalInterruptHandler[ExceptionType] != NULL))
   {
     (ExternalInterruptHandler[ExceptionType])(ExceptionType, SystemContext);
-  } else if (ExceptionType < X86_CPU_INTERRUPT_NUM) {
+  } else if (IsFatalUnhandledVector (ExceptionType)) {
     //
     // Get Spinlock to display CPU information
     //

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
@@ -48,6 +48,7 @@
   CcExitLib
   DebugLib
   LocalApicLib
+  PcdLib
   PeCoffGetEntryPointLib
   PrintLib
   SerialPortLib
@@ -55,6 +56,7 @@
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize
 


### PR DESCRIPTION
# Description

After expanding the SMM IDT to 256 entries, vectors 32-255 are treated as external interrupts. If platform firmware leaves legacy PIC interrupts enabled (for example ExtINT/IRQ0 on vector 32), an interrupt with no registered handler previously fell through to the "unhandled exception" path and hung the system in a dead loop.

Treat CPU exceptions (vectors 0-31) as fatal. All other unhandled vectors are external interrupts that can be ignored when no handler is installed, matching typical OS behavior for spurious IRQs.

StackCheckLib reports cookie violations on PcdStackCookieExceptionVector (default 0x42), which lies in the external-interrupt range. That vector must remain fatal; consume the PCD so IsFatalUnhandledVector() can treat it like a CPU exception without treating all of 32-255 as fatal.

- [ ] Breaking change
- [ ] Impacts security
- [ ] Includes tests

## How This Was Tested

build/boot edk2 as coreboot payload on google/link board (Intel Ivybridge platform). board hung without PR, now boots

## Integration Instructions

N/A