### PR TITLE
UefiCpuPkg/CpuDxe: Gate EFI Memory Attribute Protocol behind a PCD

### DIFF
--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -6,6 +6,8 @@
 
 **/
 
+#include <Library/PcdLib.h>
+
 #include "CpuDxe.h"
 #include "CpuMp.h"
 #include "CpuPageTable.h"
@@ -1031,7 +1033,9 @@ InitializeCpu (
   //
   // Install EFI memory attribute Protocol
   //
-  InstallEfiMemoryAttributeProtocol (mCpuHandle);
+  if (PcdGetBool (PcdProduceMemoryAttributeProtocol)) {
+    InstallEfiMemoryAttributeProtocol (mCpuHandle);
+  }
 
   //
   // Refresh GCD memory space map according to MTRR value.

--- a/UefiCpuPkg/CpuDxe/CpuDxe.inf
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.inf
@@ -75,7 +75,7 @@
 
 [Protocols]
   gEfiCpuArchProtocolGuid                       ## PRODUCES
-  gEfiMemoryAttributeProtocolGuid               ## PRODUCES
+  gEfiMemoryAttributeProtocolGuid               ## SOMETIMES_PRODUCES
   gEfiMpServiceProtocolGuid                     ## PRODUCES
   gEfiSmmBase2ProtocolGuid                      ## SOMETIMES_CONSUMES
 
@@ -94,6 +94,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdTdxSharedBitMask                    ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList              ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize                    ## CONSUMES
+  gUefiCpuPkgTokenSpaceGuid.PcdProduceMemoryAttributeProtocol           ## CONSUMES
 
 [Pcd.LoongArch64]
   gUefiCpuPkgTokenSpaceGuid.PcdLoongArchExceptionVectorBaseAddress      ## CONSUMES

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -289,6 +289,18 @@
   # @Prompt Configure max mapping address in page table before Temp Ram Exit.
   gUefiCpuPkgTokenSpaceGuid.PcdMaxMappingAddressBeforeTempRamExit|0xFFFFFFFFFFFFFFFF|UINT64|0x30002008
 
+  ## Indicates whether CpuDxe produces the EFI Memory Attribute Protocol.
+  #  Platforms that hand off page tables from an earlier boot stage (e.g. a
+  #  coreboot/UEFI payload) may map memory with coarse or mixed attributes that
+  #  the protocol implementation cannot describe accurately. Because DxeCore
+  #  consults the protocol in CoreFreePages(), an inaccurate GetMemoryAttributes()
+  #  result causes freed pages to be leaked. Such platforms can set this to FALSE
+  #  to keep the protocol unpublished.<BR><BR>
+  #   TRUE  - CpuDxe installs gEfiMemoryAttributeProtocolGuid.<BR>
+  #   FALSE - CpuDxe does not install the protocol.<BR>
+  # @Prompt Produce the EFI Memory Attribute Protocol.
+  gUefiCpuPkgTokenSpaceGuid.PcdProduceMemoryAttributeProtocol|TRUE|BOOLEAN|0x30002009
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## This value is the CPU Local APIC base address, which aligns the address on a 4-KByte boundary.
   # @Prompt Configure base address of CPU Local APIC

--- a/UefiPayloadPkg/UefiPayloadPkg.dsc
+++ b/UefiPayloadPkg/UefiPayloadPkg.dsc
@@ -669,6 +669,13 @@
   ## Whether allows PCI RB to allocate DMA memory above 4GB
   gUefiPayloadPkgTokenSpaceGuid.PcdPciAllocateMemoryAbove4GB|FALSE
 
+!if $(BOOTLOADER) == "COREBOOT"
+  # Do not publish the EFI Memory Attribute Protocol: the page tables handed off
+  # by coreboot use coarse/mixed attributes that CpuDxe cannot report accurately,
+  # which would cause DxeCore CoreFreePages() to leak freed pages.
+  gUefiCpuPkgTokenSpaceGuid.PcdProduceMemoryAttributeProtocol|FALSE
+!endif
+
 [PcdsFixedAtBuild.AARCH64]
   # System Memory Base -- fixed at 0x4000_0000
   gArmTokenSpaceGuid.PcdSystemMemoryBase|0x40000000


### PR DESCRIPTION
# Description

DxeCore CoreFreePages() consults gEfiMemoryAttributeProtocolGuid and leaks freed pages when GetMemoryAttributes() returns EFI_NO_MAPPING or reports read-only/read-protect attributes for a freed page. CpuDxe builds the protocol from the active page tables. Platforms that inherit coarse or mixed mappings from an earlier boot stage may not describe every region accurately, so publishing the protocol causes permanent leaks.

Add PcdProduceMemoryAttributeProtocol (default TRUE) and gate InstallEfiMemoryAttributeProtocol() on it so platforms can opt out without reverting the protocol implementation.

UefiPayloadPkg: when BOOTLOADER is COREBOOT, set the PCD to FALSE. coreboot hands off page tables with coarse/mixed attributes that CpuDxe cannot report accurately. Leaving the protocol published causes DxeCore to leak pages throughout payload boot. Other bootloaders (e.g. Slim Bootloader) keep the default TRUE unless they have the same handoff limitation.


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

build/boot edk2 as a coreboot payload on multpile boards

## Integration Instructions

N/A