### PR TITLE
UefiCpuPkg: Gate AP exception stacks on PcdCpuStackGuard

### DIFF
--- a/UefiCpuPkg/CpuDxe/CpuDxe.inf
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.inf
@@ -89,6 +89,7 @@
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPteMemoryEncryptionAddressOrMask    ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask               ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask    ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTdxSharedBitMask                    ## CONSUMES

--- a/UefiCpuPkg/CpuDxe/CpuMp.c
+++ b/UefiCpuPkg/CpuDxe/CpuMp.c
@@ -763,7 +763,9 @@ InitializeMpExceptionHandlers (
   //
   // Setup stack switch for Stack Guard feature and separate AP GDTs.
   //
-  InitializeMpExceptionStackSwitchHandlers ();
+  if (PcdGetBool (PcdCpuStackGuard)) {
+    InitializeMpExceptionStackSwitchHandlers ();
+  }
 }
 
 /**

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.c
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.c
@@ -89,6 +89,10 @@ InitializeMpExceptionStackSwitchHandlers (
   EFI_STATUS                      Status;
   UINT8                           *Buffer;
 
+  if (!PcdGetBool (PcdCpuStackGuard)) {
+    return;
+  }
+
   Status = MpInitLibGetNumberOfProcessors (&NumberOfProcessors, NULL);
   ASSERT_EFI_ERROR (Status);
 


### PR DESCRIPTION
# Description

Commit e67f405713 ("UefiCpuPkg/CpuDxe: Initialize stack switch for MP") always runs InitializeMpExceptionStackSwitchHandlers(), which copies the current GDT, appends a TSS, and reloads GDTR/TR via ArchSetupExceptionStack().

Platforms with PcdCpuStackGuard set to FALSE (including UefiPayloadPkg defaults) do not enable stack guard and should not rewrite the GDT during CpuDxe MP init. On payload platforms this unconditional path faults during early CpuDxe and can cause repeated resets before DXE finishes loading.

Restore gating on PcdCpuStackGuard in CpuDxe and CpuMpPei, and consume the PCD again from CpuDxe.inf.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

build/boot edk2 as coreboot payload on multiple boards

## Integration Instructions

N/A