### PR TITLE
UefiPayloadPkg/UefiPayloadEntry: Fix use of uninitialized memory

### DIFF
--- a/UefiPayloadPkg/Include/Library/BlParseLib.h
+++ b/UefiPayloadPkg/Include/Library/BlParseLib.h
@@ -68,7 +68,7 @@ ParseMemoryInfo (
 /**
   Acquire SMBIOS table from bootloader.
 
-  @param  SmbiosTable           Pointer to the system table info
+  @param  SmBiosEntryPoint          Pointer to the SMBIOS structure.
 
   @retval RETURN_SUCCESS            Successfully find out the tables.
   @retval RETURN_NOT_FOUND          Failed to find the tables.
@@ -77,7 +77,7 @@ ParseMemoryInfo (
 RETURN_STATUS
 EFIAPI
 ParseSmbiosTable (
-  OUT UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *SmbiosTable
+  OUT UINT64 *SmBiosEntryPoint
   );
 
 /**

--- a/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
+++ b/UefiPayloadPkg/Library/CbParseLib/CbParseLib.c
@@ -411,7 +411,7 @@ ParseMemoryInfo (
 /**
   Acquire SMBIOS table from coreboot.
 
-  @param  SmbiosTable               Pointer to the SMBIOS table info.
+  @param  SmBiosEntryPoint          Pointer to the SMBIOS structure.
 
   @retval RETURN_SUCCESS            Successfully find out the tables.
   @retval RETURN_NOT_FOUND          Failed to find the tables.
@@ -420,19 +420,23 @@ ParseMemoryInfo (
 RETURN_STATUS
 EFIAPI
 ParseSmbiosTable (
-  OUT UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *SmbiosTable
+  OUT UINT64 *SmBiosEntryPoint
   )
 {
   EFI_STATUS  Status;
   VOID        *MemTable;
   UINT32      MemTableSize;
 
+  if (SmBiosEntryPoint == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
   Status = ParseCbMemTable (SIGNATURE_32 ('T', 'B', 'M', 'S'), &MemTable, &MemTableSize);
   if (EFI_ERROR (Status)) {
     return EFI_NOT_FOUND;
   }
 
-  SmbiosTable->SmBiosEntryPoint = (UINT64)(UINTN)MemTable;
+  *SmBiosEntryPoint = (UINT64)(UINTN)MemTable;
 
   return RETURN_SUCCESS;
 }

--- a/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
+++ b/UefiPayloadPkg/Library/SblParseLib/SblParseLib.c
@@ -113,7 +113,7 @@ ParseMemoryInfo (
 /**
   Acquire SMBIOS table from slim bootloader.
 
-  @param  SmbiosTable           Pointer to the SMBIOS table info.
+  @param  SmBiosEntryPoint          Pointer to the SMBIOS structure.
 
   @retval RETURN_SUCCESS            Successfully find out the tables.
   @retval RETURN_NOT_FOUND          Failed to find the tables.
@@ -122,18 +122,21 @@ ParseMemoryInfo (
 RETURN_STATUS
 EFIAPI
 ParseSmbiosTable (
-  OUT UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *SmbiosTable
+  OUT UINT64 *SmBiosEntryPoint
   )
 {
   UNIVERSAL_PAYLOAD_SMBIOS_TABLE  *TableInfo;
 
+  if (SmBiosEntryPoint == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
   TableInfo = (UNIVERSAL_PAYLOAD_SMBIOS_TABLE *)GetGuidHobDataFromSbl (&gUniversalPayloadSmbiosTableGuid);
   if (TableInfo == NULL) {
     ASSERT (FALSE);
     return RETURN_NOT_FOUND;
   }
 
-  SmbiosTable->SmBiosEntryPoint = TableInfo->SmBiosEntryPoint;
+  *SmBiosEntryPoint = TableInfo->SmBiosEntryPoint;
 
   return RETURN_SUCCESS;
 }

--- a/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UefiPayloadEntry.c
@@ -350,6 +350,7 @@ BuildHobFromBl (
   EFI_PEI_GRAPHICS_DEVICE_INFO_HOB  *NewGfxDeviceInfo;
   UNIVERSAL_PAYLOAD_SMBIOS_TABLE    *SmBiosTableHob;
   UNIVERSAL_PAYLOAD_ACPI_TABLE      *AcpiTableHob;
+  UINT64                            SmBiosEntryPoint;
 
   //
   // First find TOLUD
@@ -415,14 +416,15 @@ BuildHobFromBl (
   //
   // Create SmBios table Hob
   //
-  SmBiosTableHob = BuildGuidHob (&gUniversalPayloadSmbiosTableGuid, sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE));
-  ASSERT (SmBiosTableHob != NULL);
-  SmBiosTableHob->Header.Revision = UNIVERSAL_PAYLOAD_SMBIOS_TABLE_REVISION;
-  SmBiosTableHob->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE);
-  DEBUG ((DEBUG_INFO, "Create smbios table gUniversalPayloadSmbiosTableGuid guid hob\n"));
-  Status = ParseSmbiosTable (SmBiosTableHob);
+  Status = ParseSmbiosTable (&SmBiosEntryPoint);
   if (!EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "Detected Smbios Table at 0x%lx\n", SmBiosTableHob->SmBiosEntryPoint));
+    DEBUG ((DEBUG_INFO, "Detected Smbios Table at 0x%lx\n", SmBiosEntryPoint));
+    SmBiosTableHob = BuildGuidHob (&gUniversalPayloadSmbiosTableGuid, sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE));
+    ASSERT (SmBiosTableHob != NULL);
+    SmBiosTableHob->Header.Revision = UNIVERSAL_PAYLOAD_SMBIOS_TABLE_REVISION;
+    SmBiosTableHob->Header.Length   = sizeof (UNIVERSAL_PAYLOAD_SMBIOS_TABLE);
+    SmBiosTableHob->SmBiosEntryPoint = SmBiosEntryPoint;
+    DEBUG ((DEBUG_INFO, "Create smbios table gUniversalPayloadSmbiosTableGuid guid hob\n"));
   }
 
   //


### PR DESCRIPTION
# Description

ParseSmbiosTable() wrote through its output pointer before validating the handoff HOB. When no SMBIOS table was present, UefiPayloadEntry still created the SMBIOS GUID HOB using uninitialized stack data.

Change ParseSmbiosTable() to take a pointer to UINT64, validate inputs, and only build the SMBIOS table HOB after a successful parse.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

build/boot edk2 as coreboot payload on qemu with SMBIOS tables disabled in coreboot

## Integration Instructions

N/A