### PR TITLE
EmulatorPkg: Resolve multi library class implementations

### DIFF
--- a/EmulatorPkg/EmulatorPkg.dsc
+++ b/EmulatorPkg/EmulatorPkg.dsc
@@ -396,7 +396,7 @@
     <LibraryClasses>
       DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
       SerialPortLib|EmulatorPkg/Library/DxeEmuStdErrSerialPortLib/DxeEmuStdErrSerialPortLib.inf
-      DxeEmuLib|EmulatorPkg/Library/DxeEmuLib/DxeEmuLib.inf
+      EmuThunkLib|EmulatorPkg/Library/DxeEmuLib/DxeEmuLib.inf
       NULL|MdeModulePkg/Library/DxeCrc32GuidedSectionExtractLib/DxeCrc32GuidedSectionExtractLib.inf
       NULL|MdeModulePkg/Library/LzmaCustomDecompressLib/LzmaCustomDecompressLib.inf
   }

--- a/EmulatorPkg/Library/DxeEmuLib/DxeEmuLib.inf
+++ b/EmulatorPkg/Library/DxeEmuLib/DxeEmuLib.inf
@@ -17,8 +17,7 @@
   FILE_GUID                      = 31479AFD-B06F-4E4A-863B-A8F7E7710778
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = EmuThunkLib
-
+  LIBRARY_CLASS                  = EmuThunkLib|DXE_CORE DXE_RUNTIME_DRIVER DXE_DRIVER UEFI_DRIVER
   CONSTRUCTOR                    = DxeEmuLibConstructor
 
 

--- a/EmulatorPkg/Library/ThunkPpiList/ThunkPpiList.inf
+++ b/EmulatorPkg/Library/ThunkPpiList/ThunkPpiList.inf
@@ -15,7 +15,7 @@
   FILE_GUID                      = 465FDE84-E8B0-B04B-A843-A03F68F617A9
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = MemoryAllocationLib|SEC BASE USER_DEFINED
+  LIBRARY_CLASS                  = ThunkPpiList
 
 [Sources]
   ThunkPpiList.c

--- a/EmulatorPkg/Library/ThunkProtocolList/ThunkProtocolList.inf
+++ b/EmulatorPkg/Library/ThunkProtocolList/ThunkProtocolList.inf
@@ -14,7 +14,7 @@
   FILE_GUID                      = 7833616E-AE0D-594F-870C-80E68682D587
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = MemoryAllocationLib|BASE SEC USER_DEFINED
+  LIBRARY_CLASS                  = ThunkProtocolList
 
 [Sources]
   ThunkProtocolList.c


### PR DESCRIPTION
# Description

Add multiple library class entries for libraries that implement more than library classes.

Issue:

```
Active Platform          = /home/khaalid/Documents/edk2/EmulatorPkg/EmulatorPkg.dsc
build...
/home/khaalid/Documents/edk2/EmulatorPkg/EmulatorPkg.dsc(190): warning: /home/khaalid/Documents/edk2/EmulatorPkg/Library/ThunkPpiList/ThunkPpiList.inf does not support LIBRARY_CLASS ThunkPpiList
build...
/home/khaalid/Documents/edk2/EmulatorPkg/EmulatorPkg.dsc(191): warning: /home/khaalid/Documents/edk2/EmulatorPkg/Library/ThunkProtocolList/ThunkProtocolList.inf does not support LIBRARY_CLASS ThunkProtocolList
build...
/home/khaalid/Documents/edk2/EmulatorPkg/EmulatorPkg.dsc(399): warning: /home/khaalid/Documents/edk2/EmulatorPkg/Library/DxeEmuLib/DxeEmuLib.inf does not support LIBRARY_CLASS DxeEmuLib
.^C 
```
- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Build test run and observed warnings above

## Integration Instructions

N/A
