### PR TITLE
UefiCpuPkg/CpuExceptionHandlerLib: Follow AAPCS in exception handler

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/AArch64/ExceptionSupport.S
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/AArch64/ExceptionSupport.S
@@ -236,6 +236,10 @@ VECTOR_TABLE(ExceptionHandlersStart, EXCEPTION_VECTOR)
 
 ASM_PFX(CommonExceptionEntry):
 
+  // Follow AAPCS: push frame record
+  stp      x29, x30, [sp,#-0x10]!
+  mov      x29, sp
+
   EL1_OR_EL2(x1)
 1:mrs      x2, elr_el1   // Exception Link Register
   mrs      x3, spsr_el1  // Saved Processor Status Register 32bit
@@ -274,8 +278,9 @@ ASM_PFX(CommonExceptionEntry):
   stp      q30, q31, [x28, #0x1e0]
 
   // x0 still holds the exception type.
-  // Set x1 to point to the top of our struct on the Stack
-  mov      x1, sp
+
+  // Set x1 to point to the top of our struct on the Stack, skipping the frame record.
+  add      x1, sp, #0x10
 
 // CommonCExceptionHandler (
 //   IN     EFI_EXCEPTION_TYPE           ExceptionType,   R0
@@ -287,6 +292,9 @@ ASM_PFX(CommonExceptionEntry):
   // For now we spin in the handler if we received an abort of some kind.
   // We do not try to recover.
   bl       ASM_PFX(CommonCExceptionHandler) // Call exception handler
+
+  // Pop frame record; restore SP to saved register context.
+  add      sp, sp, #0x10
 
   // Pop as many GP regs as we can before entering the critical section below
   ldp      x2,  x3,  [sp, #0x10]


### PR DESCRIPTION

# Description

`CommonExceptionEntry()` calls `CommonCExceptionHandler()` without first establishing a frame record, violating the Arch64 AAPCS calling convention. As a result, when a synchronous exception occurs in a DXE module, stack
unwinding stops at `CommonExceptionEntry()` and fails to reconstruct the interrupted DXE call chain.

This patch adds a frame record in `CommonExceptionEntry()` and adjusts stack handling accordingly, making the exception handler compliant with the Arch64 AAPCS and enabling reliable call stack reconstruction for crash analysis.

**Before fix — call stack stops at exception handler boundary:**

```
-000|CpuDeadLoop()
-001|DebugAssert(FileName = ?, LineNumber = ?, Description = ?)
-002|DefaultExceptionHandler(ExceptionType = ?, SystemContext = ...)
-003|CommonCExceptionHandler(ExceptionType = 0, SystemContext = ...)
-004|CommonExceptionEntry(asm)
---|end of frame
```

Unwinding stops at `CommonExceptionEntry()`. The interrupted DXE module,
its entry point, and the entire boot call chain are not visible.

**After fix — full call stack reconstructed through exception handler:**

```
-000|CpuDeadLoop()
-001|DebugAssert(FileName = ?, LineNumber = ?, Description = ?)
-002|DefaultExceptionHandler(ExceptionType = ?, SystemContext = ...)
-003|CommonCExceptionHandler(ExceptionType = 0, SystemContext = ...)
-004|CommonExceptionEntry(asm)
-005|SampleDxeInitialize(ImageHandle = ?, SystemTable = ?)
-006|ProcessModuleEntryPointList(ImageHandle = ?, SystemTable = ?)
-007|_ModuleEntryPoint(ImageHandle = ?, SystemTable = ?)
...
-017|CEntryPoint(StackBase = ?, StackSize = ?)
-018|__ModuleEntryPoint(asm)
---|end of frame
```

The complete call chain from the faulting DXE module all the way back to firmware entry is now visible.

This change has no effect on runtime behavior. All registers are saved and restored correctly, the exception context is passed correctly to the C handler, and the stack is balanced.

**Known Limitation :**
This only fixes the CommonExceptionEntry() link in the chain. The final hop from CommonExceptionEntry()'s frame record back into the interrupted function's own frame is still just the x29 value captured at exception time. If the exception was taken while the interrupted function's prologue or epilogue was still executing, that frame record may be incomplete or already torn down, and FP-chain unwinding can produce an incorrect or truncated backtrace for that last frame.


- [ ] Breaking change?
  - N/A
- [ ] Impacts security?
  - N/A
- [ ] Includes tests?
  - N/A

## How This Was Tested

Tested on a Qualcomm AArch64 platform by triggering a crash and analyzing the resulting dump in a simulator to successfully reconstruct the complete call stack.

## Integration Instructions

N/A