### PR TITLE
ShellPkg/Shell: Terminate and separate the ShellOpt command line

### DIFF
--- a/ShellPkg/Application/Shell/ShellParametersProtocol.c
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.c
@@ -298,11 +298,16 @@ CreatePopulateInstallShellParametersProtocol (
   EFI_STATUS                 Status;
   EFI_LOADED_IMAGE_PROTOCOL  *LoadedImage;
   CHAR16                     *FullCommandLine;
+  CHAR16                     *ShellOpt;
+  UINTN                      FullCommandLineSize;
+  UINTN                      LoadOptionsLength;
   UINTN                      Size;
 
-  Size            = 0;
-  FullCommandLine = NULL;
-  LoadedImage     = NULL;
+  Size                = 0;
+  FullCommandLine     = NULL;
+  FullCommandLineSize = 0;
+  LoadedImage         = NULL;
+  ShellOpt            = NULL;
 
   //
   // Assert for valid parameters
@@ -351,37 +356,87 @@ CreatePopulateInstallShellParametersProtocol (
   //
   // Build the full command line
   //
-  Status = SHELL_GET_ENVIRONMENT_VARIABLE (L"ShellOpt", &Size, FullCommandLine);
+  Status = SHELL_GET_ENVIRONMENT_VARIABLE (L"ShellOpt", &Size, ShellOpt);
   if (Status == EFI_BUFFER_TOO_SMALL) {
-    FullCommandLine = AllocateZeroPool (Size + LoadedImage->LoadOptionsSize);
-    if (FullCommandLine == NULL) {
+    //
+    // Variable data is not guaranteed to be NUL-terminated, so allocate room
+    // for a terminator in addition to the returned data size.
+    //
+    ShellOpt = AllocateZeroPool (Size + sizeof (ShellOpt[0]));
+    if (ShellOpt == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }
 
-    Status = SHELL_GET_ENVIRONMENT_VARIABLE (L"ShellOpt", &Size, FullCommandLine);
+    Status = SHELL_GET_ENVIRONMENT_VARIABLE (L"ShellOpt", &Size, ShellOpt);
+    if (EFI_ERROR (Status)) {
+      FreePool (ShellOpt);
+      return Status;
+    }
+
+    //
+    // ShellOpt is a CHAR16 string.  Reject malformed variable data before
+    // indexing the buffer in CHAR16 units.
+    //
+    if ((Size % sizeof (CHAR16)) != 0) {
+      FreePool (ShellOpt);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    //
+    // Use the first NUL as the end of the string.  The zero-initialized byte
+    // following the variable data also terminates a non-NUL-terminated value.
+    //
+    Size = StrLen (ShellOpt) * sizeof (ShellOpt[0]);
   }
 
-  if (Status == EFI_NOT_FOUND) {
+  if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+    return Status;
+  }
+
+  if ((LoadedImage->LoadOptionsSize != 0) || (Size != 0)) {
     //
-    // no parameters via environment... ok
+    // Load options contain the image name at Argv[0], followed by command-line
+    // options.  Append ShellOpt after them and reserve room for a separator and
+    // a NUL terminator.  Load options are not guaranteed to be NUL-terminated.
     //
-  } else {
-    if (EFI_ERROR (Status)) {
-      return (Status);
+    FullCommandLineSize = LoadedImage->LoadOptionsSize + Size +
+                          2 * sizeof (FullCommandLine[0]);
+    FullCommandLine = AllocateZeroPool (FullCommandLineSize);
+    if (FullCommandLine == NULL) {
+      SHELL_FREE_NON_NULL (ShellOpt);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    if (LoadedImage->LoadOptionsSize != 0) {
+      CopyMem (
+        FullCommandLine,
+        LoadedImage->LoadOptions,
+        LoadedImage->LoadOptionsSize
+        );
+    }
+
+    LoadOptionsLength = StrLen (FullCommandLine);
+    if ((LoadOptionsLength != 0) && (Size != 0)) {
+      FullCommandLine[LoadOptionsLength++] = L' ';
+    }
+
+    if (Size != 0) {
+      Status = StrCpyS (
+                 &FullCommandLine[LoadOptionsLength],
+                 FullCommandLineSize / sizeof (FullCommandLine[0]) - LoadOptionsLength,
+                 ShellOpt
+                 );
+      if (EFI_ERROR (Status)) {
+        FreePool (FullCommandLine);
+        FreePool (ShellOpt);
+        return Status;
+      }
     }
   }
 
-  if ((Size == 0) && (LoadedImage->LoadOptionsSize != 0)) {
-    ASSERT (FullCommandLine == NULL);
-    //
-    // Now we need to include a NULL terminator in the size.
-    //
-    Size            = LoadedImage->LoadOptionsSize + sizeof (FullCommandLine[0]);
-    FullCommandLine = AllocateZeroPool (Size);
-  }
+  SHELL_FREE_NON_NULL (ShellOpt);
 
   if (FullCommandLine != NULL) {
-    CopyMem (FullCommandLine, LoadedImage->LoadOptions, LoadedImage->LoadOptionsSize);
     //
     // Populate Argc and Argv
     //


### PR DESCRIPTION
# Description

`CreatePopulateInstallShellParametersProtocol()` allocated the combined
command-line buffer without reserving space for a NUL terminator. Because
neither the `ShellOpt` variable nor image load options are required to carry
their own terminator, `ParseCommandLineToArgs()` could read beyond the
allocation and consume unrelated pool memory as command-line arguments.

When both inputs were present, the image load options were also copied at
offset zero in the `ShellOpt` buffer, overwriting the variable data.

The combined command line must begin with the loaded image options because
they contain the image name expected at `Argv[0]`. `ShellOpt` must follow
them. Reversing this order leaves the image name in a later argument, where
`ProcessCommandLine()` can interpret it as a file to launch recursively.

This change reads `ShellOpt` into a separately NUL-terminated buffer,
validates its `CHAR16` size, normalizes its effective length with `StrLen()`,
and propagates a failure from the second variable read. It then allocates the
combined buffer with room for a separator and terminator, copies the image
load options first, and appends `ShellOpt` with `StrCpyS()`.

Fixes #10549

- [ ] Breaking change?
- [x] Impacts security?
  - Prevents an out-of-bounds pool read. No claim of practical exploitability
    is made.
- [ ] Includes tests?
  - No test code is added; the change was integration-tested with OVMF/QEMU.

## How This Was Tested

Built PR head `2a02a3d75b8b` on master `0ae702f94e12` as OVMF X64 DEBUG
with CLANGDWARF, then booted the resulting `Shell.efi` in QEMU q35. The
non-NUL-terminated `ShellOpt` case was written directly into the variable
store so the original boundary condition was reproduced exactly.

| Case | Input | Result after fix |
|---|---|---|
| T0 | `ShellOpt` absent | Default mapping table, 5-second delay, and `startup.nsh` ran |
| T1 | `-nomap -delay 11`, no NUL | No mapping table, 11-second delay, and `startup.nsh` ran |
| T2 | `-nomap -delay 11`, with NUL | Same behavior as T1 |
| T3 | Set `ShellOpt=-noversion`, then launch `Shell.efi -nostartup -exit` | The nested Shell loaded once, returned to the caller, and the post-return marker ran |

The T3 serial log contains `REVIEW_LAUNCH_NESTED` followed by exactly one
nested `Shell.efi` load and `REVIEW_NESTED_RETURNED`. Across all four final
logs there was no ASSERT, exception, unrecognized argument, or repeated
recursive launch.

Additional checks:

- Current-head clean OVMF X64 DEBUG CLANGDWARF build: passed
- BaseTools test suite: 301 tests passed on the review-fix version
- TianoCore Uncrustify 73.0.11: passed
- `git diff --check`: passed

## Integration Instructions

N/A
