### PR TITLE
pylibfdt Changes to Unblock CI

### DIFF
--- a/.azurepipelines/templates/pr-gate-build-job.yml
+++ b/.azurepipelines/templates/pr-gate-build-job.yml
@@ -85,15 +85,18 @@ jobs:
         Build.Pkgs: 'SecurityPkg'
         Build.Targets: 'DEBUG,RELEASE,NO-TARGET'
         Build.Archlist: ${{ parameters.arch_list }}
-      TARGET_UEFIPAYLOAD_IA32_X64:
-        Build.Pkgs: 'UefiPayloadPkg'
-        Build.Targets: 'DEBUG,RELEASE,NO-TARGET'
-        Build.Archlist: 'IA32,X64'
-      ${{ if eq(parameters.tool_chain_tag, 'GCC') }}:
-        TARGET_UEFIPAYLOAD_AARCH64_GCC_ONLY:
-          Build.Pkgs: 'UefiPayloadPkg'
-          Build.Targets: 'DEBUG,RELEASE,NO-TARGET'
-          Build.Archlist: 'AARCH64'
+        # UefiPayloadPkg is removed since its build depends on pylibfdt which currently fails to
+        # install. These can be re-enabled when a long-term solution is found where the risk of
+        # breaking the build is mitigated.
+      # TARGET_UEFIPAYLOAD_IA32_X64:
+      #   Build.Pkgs: 'UefiPayloadPkg'
+      #   Build.Targets: 'DEBUG,RELEASE,NO-TARGET'
+      #   Build.Archlist: 'IA32,X64'
+      # ${{ if eq(parameters.tool_chain_tag, 'GCC') }}:
+      #   TARGET_UEFIPAYLOAD_AARCH64_GCC_ONLY:
+      #     Build.Pkgs: 'UefiPayloadPkg'
+      #     Build.Targets: 'DEBUG,RELEASE,NO-TARGET'
+      #     Build.Archlist: 'AARCH64'
       ${{ if or(eq(parameters.tool_chain_tag, 'GCC'), startsWith(parameters.tool_chain_tag, 'VS')) }}:
         TARGET_PLATFORMS:
           # For Platforms only check code. Leave it to Platform CI

--- a/.github/workflows/upl-build.yml
+++ b/.github/workflows/upl-build.yml
@@ -31,7 +31,6 @@ jobs:
       tool-chain: ${{ matrix.tool-chain }}
       target: ${{ matrix.target }}
       extra-build-args: ${{ matrix.extra-build-args }}
-      extra-pip-requirements: 'pefile pylibfdt'
       extra-artifact-path: |
         Build/**/*.elf
         Build/**/*.fit
@@ -54,7 +53,6 @@ jobs:
       tool-chain: ${{ matrix.tool-chain }}
       target: ${{ matrix.target }}
       extra-build-args: ${{ matrix.extra-build-args }}
-      extra-pip-requirements: 'pefile pylibfdt'
       extra-setup-cmd: 'sudo dnf install -y llvm clang llvm-libs llvm-devel lldb'
       extra-artifact-path: |
         Build/**/*.elf

--- a/.github/workflows/upl-build.yml
+++ b/.github/workflows/upl-build.yml
@@ -8,10 +8,15 @@
 ##
 name: UPL Build
 
+# The push trigger is disabled since the UefiPayloadPkg build depends on pylibfdt which
+# currently fails to install. workflow_dispatch is left as that still allows the workflow
+# to be run manually. It also allows the workflow to be excluded from automatic triggers
+# at the workflow level instead of at the job level which would require more changes in
+# the file.
 on:
   workflow_dispatch:
-  push:
-    branches: ['master']
+  # push:
+  #   branches: ['master']
 
 jobs:
   build_vs2026:

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -17,5 +17,4 @@ edk2-pytool-extensions~=0.31.0
 antlr4-python3-runtime==4.13.2
 lcov-cobertura==2.1.1
 regex==2026.5.9
-pylibfdt==1.7.2.post1
 pefile


### PR DESCRIPTION
# Description

Changes to prevent edk2 CI from being broken due to a pip dependency.

We could wait until a new pylibfdt release, but given the current impact,
this PR provides an option to unblock CI until that release is made. There
is also concern about the probability of this happening again as noted in
https://github.com/tianocore/edk2/issues/13020. 

That serves as a tracking issue for UefiPayloadPkg maintainers to follow up
on the temporary changes made in this PR. When ready, these commits can simply
be reverted:

- https://github.com/tianocore/edk2/pull/13014/changes/072faa426a74ef09136c08bfbef8a32802f2233a
- https://github.com/tianocore/edk2/pull/13014/changes/76f3a227f7772cf98c98165c1ad8ba6b7f0dff9c

---

**.github/workflows/upl-build.yml: Remove redundant pip requirements**

This currently passes `pefile pylibfdt` to BuildPlatform.yml. However,
those are included in the same pip installation step that installs
the from pip-requirements.txt. This removes them so the dependency
details can be maintained in one place which is pip-requirements.txt.

This also allows local pip installation to install the same versions
installed in CI.

---

**.github/workflows/upl-build.yml: Disable the PR trigger**

Temporarily disabled the pull_request trigger to prevent the UPL build
from being blocked by the pylibfdt dependency which is currently
failing during pip install. It happens to work in GitHub runners at
the moment but that is only because the GitHub workflows cache pip
dependencies. That is not a stable option to depend on .

---

**.azurepipelines/templates/pr-gate-build-job.yml: Disable UefiPayloadPkg**

UefiPayloadPkg depends on pylibfdt which currently fails to install.

This change temporarily disables the UefiPayloadPkg build in the PR
gate build job to unblock edk2 CI.

---

**pip-requirements.txt: Remove pylibfdt**

pylibfdt currently fails to install. The pre-built wheel files are not
published and it fails to build from source due to having a floating
dependency on the swig package (specified in pylibfdt's pyproject.toml
file).

swig 4.5.0 was released on August 22, 2026 and removed support for
Python 2 APIs still being referenced in pylibfdt. These APIs were
already routing to the Python 3 APIs, but it is still a build break.

Originally, pip-requirements.txt was updated to have a direct git
dependency on the libfdt code in the upstream DTC repostiory.
However, there were concerns about building from source in different
environments with a preference to, at least temporarily, remove the
dependency until a sustainable solution can be found.

---

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Local pip installation with: `pip install -r .\pip-requirements.txt --upgrade --force-reinstall --no-cache-dir --no-binary=pylibfdt --verbose`
- PR status checks

## Integration Instructions

- N/A