### PR TITLE
UefiPayloadPkg/PciPlatformDxe: Fix BAR restore leak and uninit CodeType

### DIFF
--- a/UefiPayloadPkg/PciPlatformDxe/PciPlatformDxe.c
+++ b/UefiPayloadPkg/PciPlatformDxe/PciPlatformDxe.c
@@ -211,7 +211,9 @@ PciGetPciRom (
   AllOnes &= 0xFFFFF800;
   if ((AllOnes == 0) || (AllOnes == 0xFFFFF800)) {
     DEBUG ((DEBUG_VERBOSE, "%a: No Option ROM found\n", __func__));
-    return EFI_NOT_FOUND;
+    Status = EFI_NOT_FOUND;
+    RomBar = Buffer;
+    goto RestoreBar;
   }
 
   *RomSize = (~AllOnes) + 1;
@@ -248,6 +250,7 @@ PciGetPciRom (
   FirstCheck        = TRUE;
   LegacyImageLength = 0;
   RomImageSize      = 0;
+  CodeType          = 0;
 
   //
   // Expect to find a PCI ROM header at offset 0.


### PR DESCRIPTION
## Description

PciGetPciRom() sized the expansion ROM BAR by writing all ones and reading back the decode window. When no option ROM was present it returned early without restoring the BAR or closing the PciIo protocol, leaving the BAR modified and a protocol open reference leaked.

Route the no-ROM case through the shared RestoreBar/CloseAndReturn cleanup path. Initialize CodeType before the legacy image scan; it was previously assigned only for PC-AT images but read unconditionally during length fixup.

- [ ] Breaking change
- [ ] Impacts security
- [ ] Includes tests

## How This Was Tested

N/A

## Integration Instructions

N/A