### PR TITLE
Py remove pylibfdt dependency

### DIFF
--- a/.github/workflows/upl-build.yml
+++ b/.github/workflows/upl-build.yml
@@ -31,7 +31,6 @@ jobs:
       tool-chain: ${{ matrix.tool-chain }}
       target: ${{ matrix.target }}
       extra-build-args: ${{ matrix.extra-build-args }}
-      extra-pip-requirements: 'pefile pylibfdt'
       extra-artifact-path: |
         Build/**/*.elf
         Build/**/*.fit
@@ -54,7 +53,6 @@ jobs:
       tool-chain: ${{ matrix.tool-chain }}
       target: ${{ matrix.target }}
       extra-build-args: ${{ matrix.extra-build-args }}
-      extra-pip-requirements: 'pefile pylibfdt'
       extra-setup-cmd: 'sudo dnf install -y llvm clang llvm-libs llvm-devel lldb'
       extra-artifact-path: |
         Build/**/*.elf

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -17,5 +17,4 @@ edk2-pytool-extensions~=0.31.0
 antlr4-python3-runtime==4.13.2
 lcov-cobertura==2.1.1
 regex==2026.5.9
-pylibfdt==1.7.2.post1
 pefile


### PR DESCRIPTION
# Description

Remove pylibfdt and redundant pip requirements

pylibfdt currently fails to install. The pre-built wheel files are not published and it fails to build from source due to having a floating dependency on the swig package (specified in pylibfdt's pyproject.toml file).

swig 4.5.0 was released on August 22, 2026 and removed support for Python 2 APIs still being referenced in pylibfdt. These APIs were already routing to the Python 3 APIs, but it is still a build break.

Originally, pip-requirements.txt was updated to have a direct git dependency on the libfdt code in the upstream DTC repostiory. However, there were concerns about building from source in different environments with a preference to, at least temporarily, remove the dependency until a sustainable solution can be found.

This currently passes `pefile pylibfdt` to BuildPlatform.yml. However, those are included in the same pip installation step that installs the from pip-requirements.txt. This removes them so the dependency details can be maintained in one place which is pip-requirements.txt.

This also allows local pip installation to install the same versions installed in CI.

## How This Was Tested

Verify that edk2 CI passes with the removal of pylibfdt.  

## Integration Instructions

N/A
