### PR TITLE
.github/workflows/upl-build.yml: Drop FIT_BUILD=TRUE

### DIFF
--- a/.github/workflows/upl-build.yml
+++ b/.github/workflows/upl-build.yml
@@ -21,7 +21,9 @@ jobs:
         python-version: ['3.12']
         tool-chain: ['VS2026']
         target: ['DEBUG']
-        extra-build-args: ['FIT_BUILD=TRUE', 'FIT_BUILD=FALSE']
+        # 'FIT_BUILD=TRUE' is not passed since the FIT build depends on fdtlib and that currently
+        # fails to compile when the wheel is built during pip installation.
+        extra-build-args: ['FIT_BUILD=FALSE']
     name: Build UPL VS2026
     uses: ./.github/workflows/BuildPlatform.yml
     with:
@@ -43,7 +45,9 @@ jobs:
         python-version: ['3.12']
         tool-chain: ['GCC']
         target: ['DEBUG']
-        extra-build-args: ['FIT_BUILD=TRUE', 'FIT_BUILD=FALSE']
+        # 'FIT_BUILD=TRUE' is not passed since the FIT build depends on fdtlib and that currently
+        # fails to compile when the wheel is built during pip installation.
+        extra-build-args: ['FIT_BUILD=FALSE']
     name: Build UPL GCC
     uses: ./.github/workflows/BuildPlatform.yml
     with:


### PR DESCRIPTION
# Description

The FIT build relies upon the fdtlib library and pyfdtlib currently fails to compile when the wheel is built during pip installation.

To allow clean post-merge CI results (this triggers on a master push), the FIT build is disabled here. The fdtlib import is conditionally included based on whether a FIT build is requested.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- PR status checks
- Run UPL build manually against the branch

## Integration Instructions

- N/A