### PR TITLE
NetworkPkg/ArpDxe: Fix Coverity null-deref and integer overflow

### DIFF
--- a/NetworkPkg/ArpDxe/ArpImpl.c
+++ b/NetworkPkg/ArpDxe/ArpImpl.c
@@ -1097,6 +1097,7 @@ ArpSendFrame (
   if (Packet == NULL) {
     DEBUG ((DEBUG_ERROR, "ArpSendFrame: Allocate memory for Packet failed.\n"));
     ASSERT (Packet != NULL);
+    goto CLEAN_EXIT;
   }
 
   TmpPtr = Packet;
@@ -1606,7 +1607,7 @@ ArpFindCacheEntry (
   //
   // Allocate buffer to copy the found entries.
   //
-  FindData = AllocatePool (FoundCount * FoundEntryLength);
+  FindData = AllocatePool ((UINTN)FoundCount * FoundEntryLength);
   if (FindData == NULL) {
     DEBUG ((DEBUG_ERROR, "ArpFindCacheEntry: Failed to allocate memory.\n"));
     Status = EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
This PR fixes two Coverity-reported defects in NetworkPkg/ArpDxe/ArpImpl.c.

## Changes

### ArpSendFrame - null pointer dereference

When AllocatePool returns NULL for the ARP frame buffer, the function
logs an error and calls ASSERT (Packet != NULL). In release builds where
ASSERT compiles to a no-op, execution falls through and immediately
dereferences the NULL Packet pointer via TmpPtr = Packet.

Add goto CLEAN_EXIT after the assert so the function exits safely
when the allocation fails.

### ArpFindCacheEntry - integer overflow before widening

AllocatePool is called with FoundCount * FoundEntryLength where both
FoundCount and FoundEntryLength are UINT32. On a 64-bit build the
result must be widened to UINTN, but the multiplication is performed in
32-bit arithmetic first, which can overflow. Cast FoundCount to UINTN
so the multiplication is performed at pointer width.

## Cc

Cc: Saloni Kasbekar <saloni.kasbekar@intel.com>
Cc: Zachary Clark-williams <zachary.clark-williams@intel.com>
Cc: Mike Beaton <mjsbeaton@gmail.com>

Signed-off-by: Abuthahir M <abuthahirm@ami.com>