### PR TITLE
OvmfPkg/PlatformBootManagerLib: Probe Xen PV disks first

### DIFF
--- a/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
+++ b/OvmfPkg/Library/PlatformBootManagerLib/BdsPlatform.c
@@ -1395,6 +1395,57 @@ PciAcpiInitialization (
   IoOr16 ((PciRead32 (Pmba) & ~BIT0) + 4, BIT0);
 }
 
+STATIC
+EFI_STATUS
+ConnectPciDevice (
+  IN EFI_HANDLE  Handle,
+  IN CHAR16      *ClassStr
+  )
+{
+  EFI_STATUS                Status;
+  EFI_DEVICE_PATH_PROTOCOL  *DevicePath;
+  CHAR16                    *DevPathStr;
+
+  DevicePath = NULL;
+  Status     = gBS->HandleProtocol (
+                      Handle,
+                      &gEfiDevicePathProtocolGuid,
+                      (VOID *)&DevicePath
+                      );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Print Device Path
+  //
+  DevPathStr = ConvertDevicePathToText (DevicePath, FALSE, FALSE);
+  if (DevPathStr != NULL) {
+    DEBUG ((DEBUG_INFO, "Found %s device: %s\n", ClassStr, DevPathStr));
+    FreePool (DevPathStr);
+  }
+
+  return gBS->ConnectController (Handle, NULL, NULL, TRUE);
+}
+
+EFI_STATUS
+EFIAPI
+ConnectRecursivelyIfXenPciDevice (
+  IN EFI_HANDLE           Handle,
+  IN EFI_PCI_IO_PROTOCOL  *Instance,
+  IN PCI_TYPE00           *PciHeader
+  )
+{
+  //
+  // Recognize Xen PCI devices
+  //
+  if (IS_CLASS2 (PciHeader, 0xFF, 0x80)) {
+    return ConnectPciDevice (Handle, L"Xen");
+  }
+
+  return EFI_SUCCESS;
+}
+
 EFI_STATUS
 EFIAPI
 ConnectRecursivelyIfPciMassStorage (
@@ -1403,47 +1454,11 @@ ConnectRecursivelyIfPciMassStorage (
   IN PCI_TYPE00           *PciHeader
   )
 {
-  EFI_STATUS                Status;
-  EFI_DEVICE_PATH_PROTOCOL  *DevicePath;
-  CHAR16                    *DevPathStr;
-
   //
-  // Recognize PCI Mass Storage, and Xen PCI devices
+  // Recognize PCI Mass Storage
   //
-  if (IS_CLASS1 (PciHeader, PCI_CLASS_MASS_STORAGE) ||
-      (XenDetected () && IS_CLASS2 (PciHeader, 0xFF, 0x80)))
-  {
-    DevicePath = NULL;
-    Status     = gBS->HandleProtocol (
-                        Handle,
-                        &gEfiDevicePathProtocolGuid,
-                        (VOID *)&DevicePath
-                        );
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
-
-    //
-    // Print Device Path
-    //
-    DevPathStr = ConvertDevicePathToText (DevicePath, FALSE, FALSE);
-    if (DevPathStr != NULL) {
-      DEBUG ((
-        DEBUG_INFO,
-        "Found %s device: %s\n",
-        (IS_CLASS1 (PciHeader, PCI_CLASS_MASS_STORAGE) ?
-         L"Mass Storage" :
-         L"Xen"
-        ),
-        DevPathStr
-        ));
-      FreePool (DevPathStr);
-    }
-
-    Status = gBS->ConnectController (Handle, NULL, NULL, TRUE);
-    if (EFI_ERROR (Status)) {
-      return Status;
-    }
+  if (IS_CLASS1 (PciHeader, PCI_CLASS_MASS_STORAGE)) {
+    return ConnectPciDevice (Handle, L"Mass Storage");
   }
 
   return EFI_SUCCESS;
@@ -1511,6 +1526,14 @@ VOID
 PlatformBdsRestoreNvVarsFromHardDisk (
   )
 {
+  //
+  // Xen HVM exposes disk through both PV and emulated block device.
+  // Enumerate PV devices first to make the PV one takes precedence.
+  //
+  if (XenDetected ()) {
+    VisitAllPciInstances (ConnectRecursivelyIfXenPciDevice);
+  }
+
   VisitAllPciInstances (ConnectRecursivelyIfPciMassStorage);
   VisitAllInstancesOfProtocol (
     &gEfiSimpleFileSystemProtocolGuid,


### PR DESCRIPTION
# Description
Xen HVM exposes the same disk through both Xen PV and emulated IDE/AHCI controllers. When both device classes are connected in a single PCI traversal, the emulated controller may be connected first, causing OVMF to access the disk through the emulated path.

Probe Xen devices before PCI mass-storage controllers to make PV path takes precedence. Newly resolved HD() short-form paths can then use Xen PV block, avoiding device emulation overhead and improving firmware boot-time disk I/O performance.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

The startup `BdsDxe` message shows HVM linux guest is booted from `PciRoot(0x0)/Pci(0x2,0x0)/VenHw(3d3ca290-b9a5-11e3-b75d-b8ac6f7d65e6,010000ca)` instead of `PciRoot(0x0)/Pci(0x5,0x0)/Sata(0,65535,0)`.

## Integration Instructions

N/A
