### PR TITLE
PrmPkg: Fix typo futhermore -> furthermore in Readme.md

### DIFF
--- a/PrmPkg/Readme.md
+++ b/PrmPkg/Readme.md
@@ -2,7 +2,7 @@
 
 Platform Runtime Mechanism (PRM) introduces the capability of moving platform-specific code out of SMM and into a
 code module that executes within the OS context. Moving this firmware to the OS context provides better transparency
-and mitigates the negative system impact currently accompanied with SMM solutions. Futhermore, the PRM code is
+and mitigates the negative system impact currently accompanied with SMM solutions. Furthermore, the PRM code is
 packaged into modules with well-defined entry points, each representing a specific PRM functionality.
 
 For more details on PRM, refer to the [Platform Runtime Mechanism Specification on uefi.org](https://uefi.org/sites/default/files/resources/Platform%20Runtime%20Mechanism%20-%20with%20legal%20notice.pdf).


### PR DESCRIPTION
# Description

`PrmPkg/Readme.md` misspells "furthermore" as "futhermore" in the section describing the PRM module discovery flow. This corrects the spelling.

The commit message has been reworked to the `PkgName: Description` convention with a body paragraph and `Signed-off-by`, and `BaseTools/Scripts/PatchCheck.py -1` now reports:

```
Checking git commit: 833559b
PrmPkg: Fix typo futhermore -> furthermore in Readme.md
The commit message format passed all checks.
The code passed all checks.
```

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

None of the three apply: this changes one word in a Markdown file. No library class is added or moved, no module changes repository, and no code path is touched, so there is nothing to break in build or boot behavior and no security surface involved.

## How This Was Tested

`BaseTools/Scripts/PatchCheck.py -1` against the commit — commit message format and code checks both pass (output above).

No build was run: the change is confined to `PrmPkg/Readme.md`, which is not consumed by any INF, DSC or FDF, so no firmware image content is affected.

## Integration Instructions

N/A
