### PR TITLE
CryptoPkg: Fix memcpy alias prototype to match the aliasee

### DIFF
--- a/CryptoPkg/Library/IntrinsicLib/CopyMem.c
+++ b/CryptoPkg/Library/IntrinsicLib/CopyMem.c
@@ -29,9 +29,9 @@ __memcpy (
 __attribute__ ((__alias__ ("__memcpy")))
 void *
 memcpy (
-  void          *dest,
-  const void    *src,
-  unsigned int  count
+  void        *dest,
+  const void  *src,
+  size_t      count
   );
 
 #else


### PR DESCRIPTION
The memcpy alias in IntrinsicLib declares its count parameter as unsigned int while the aliasee __memcpy uses size_t; on 64-bit
targets these are different widths. clang 23 diagnoses it through -Wattribute-alias, and warnings-as-errors builds fail 
(seen building OVMF with the CLANGDWARF toolchain in Yocto):

     ```
     CopyMem.c:29:17: warning: alias and aliasee have different types
     'void *(void *, const void *, unsigned int)' and
     'void *(void *, const void *, size_t)' [-Wattribute-alias]
     ```

Declare the alias with size_t so both signatures agree.

cc @jyao1 @liyi77 @Flickdm 