### PR TITLE
BaseTools/FMMT: Return non-zero exit status on failure

### DIFF
--- a/BaseTools/Source/Python/FMMT/FMMT.py
+++ b/BaseTools/Source/Python/FMMT/FMMT.py
@@ -155,6 +155,7 @@ def main():
             parser.print_help()
     except Exception as e:
         print(e)
+        status = 1
 
     return status
 

--- a/BaseTools/Tests/TestFmmtExit.py
+++ b/BaseTools/Tests/TestFmmtExit.py
@@ -1,0 +1,55 @@
+## @file
+# Tests for FMMT CLI exit status.
+#
+# Copyright (c) 2026, Zhaoqi Xu <lzy00419@outlook.com>. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+_BASETOOLS = Path(__file__).resolve().parent.parent
+_PYTHON_SRC = _BASETOOLS / 'Source' / 'Python'
+_FMMT_DIR = _PYTHON_SRC / 'FMMT'
+_FMMT_PY = _FMMT_DIR / 'FMMT.py'
+
+
+def _fmmt_env():
+    env = os.environ.copy()
+    extra = os.pathsep.join((str(_PYTHON_SRC), str(_FMMT_DIR)))
+    env['PYTHONPATH'] = extra + os.pathsep + env.get('PYTHONPATH', '')
+    return env
+
+
+class TestFmmtExit(unittest.TestCase):
+    def test_view_missing_file_exits_nonzero(self):
+        result = subprocess.run(
+            [sys.executable, str(_FMMT_PY), '-v', 'not-a-file'],
+            env=_fmmt_env(),
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            msg='FMMT -v not-a-file must fail: stdout=%r stderr=%r' % (
+                result.stdout, result.stderr),
+        )
+        combined = result.stdout + result.stderr
+        self.assertIn('Invalid inputfile', combined)
+
+    def test_help_exits_zero(self):
+        result = subprocess.run(
+            [sys.executable, str(_FMMT_PY), '-h'],
+            env=_fmmt_env(),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

FMMT catches exceptions from operations such as `FMMT -v not-a-file`, prints the error, and then returns status 0. Callers and scripts that check the process exit code treat a failed operation as success.

Set `status = 1` in the exception handler so a failed FMMT operation exits non-zero.

Fixes https://github.com/tianocore/edk2/issues/12178

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Reproduced the issue with PYTHONPATH pointing at `BaseTools/Source/Python` and `BaseTools/Source/Python/FMMT`:

```
python BaseTools/Source/Python/FMMT/FMMT.py -v not-a-file
echo %ERRORLEVEL%
```

Before this change the command printed `Process Failed: Invalid inputfile!` and `%ERRORLEVEL%` was 0. After the change `%ERRORLEVEL%` is 1.

Regression tests:

```
python BaseTools/Tests/TestFmmtExit.py -v
python BaseTools/Scripts/PatchCheck.py -1
```

Both passed locally on Windows (Python 3.14.3).

## Integration Instructions

N/A
