### PR TITLE
BaseTools/FMMT: Honor -c config file path

### DIFF
--- a/BaseTools/Source/Python/FMMT/FMMT.py
+++ b/BaseTools/Source/Python/FMMT/FMMT.py
@@ -51,11 +51,10 @@ class FMMT():
     def __init__(self) -> None:
         pass
 
-    def SetConfigFilePath(self, configfilepath:str) -> str:
+    def SetConfigFilePath(self, configfilepath:str) -> None:
         os.environ['FmmtConfPath'] = os.path.abspath(configfilepath)
 
-    def SetDestPath(self, inputfile:str) -> str:
-        os.environ['FmmtConfPath'] = ''
+    def SetDestPath(self, inputfile:str) -> None:
         self.dest_path = os.path.dirname(os.path.abspath(inputfile))
         old_env = os.environ['PATH']
         os.environ['PATH'] = self.dest_path + os.pathsep + old_env

--- a/BaseTools/Source/Python/FMMT/core/GuidTools.py
+++ b/BaseTools/Source/Python/FMMT/core/GuidTools.py
@@ -108,8 +108,8 @@ class GUIDTools:
         self.tooldef = dict()
 
     def SetConfigFile(self) -> None:
-        if os.environ['FmmtConfPath']:
-            self.tooldef_file = os.path.join(os.environ['FmmtConfPath'], 'FmmtConf.ini')
+        if os.environ.get('FmmtConfPath'):
+            self.tooldef_file = os.environ['FmmtConfPath']
         else:
             PathList = os.environ['PATH'].split(os.pathsep)
             for CurrentPath in PathList:

--- a/BaseTools/Tests/TestFmmtConfig.py
+++ b/BaseTools/Tests/TestFmmtConfig.py
@@ -1,0 +1,81 @@
+## @file
+# Tests for FMMT -c / FmmtConf.ini path handling.
+#
+# Copyright (c) 2026, Zhaoqi Xu <lzy00419@outlook.com>. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_BASETOOLS = Path(__file__).resolve().parent.parent
+_PYTHON_SRC = _BASETOOLS / 'Source' / 'Python'
+_FMMT_DIR = _PYTHON_SRC / 'FMMT'
+
+for _p in (str(_FMMT_DIR), str(_PYTHON_SRC)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from FMMT.FMMT import FMMT
+from core.GuidTools import GUIDTools
+
+
+class TestFmmtConfig(unittest.TestCase):
+    def setUp(self):
+        self._old_conf = os.environ.get('FmmtConfPath')
+        self._old_path = os.environ.get('PATH')
+        os.environ.pop('FmmtConfPath', None)
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if self._old_conf is None:
+            os.environ.pop('FmmtConfPath', None)
+        else:
+            os.environ['FmmtConfPath'] = self._old_conf
+        if self._old_path is None:
+            os.environ.pop('PATH', None)
+        else:
+            os.environ['PATH'] = self._old_path
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_set_dest_path_preserves_config_file(self):
+        cfg = os.path.join(self.tmpdir, 'CustomFmmtConf.ini')
+        with open(cfg, 'w') as f:
+            f.write('# empty\n')
+        dummy_input = os.path.join(self.tmpdir, 'input.fd')
+        with open(dummy_input, 'wb') as f:
+            f.write(b'\0')
+
+        fmmt = FMMT()
+        fmmt.SetConfigFilePath(cfg)
+        fmmt.SetDestPath(dummy_input)
+        self.assertEqual(os.environ.get('FmmtConfPath'), os.path.abspath(cfg))
+
+    def test_set_config_file_uses_file_path_not_directory(self):
+        cfg = os.path.join(self.tmpdir, 'CustomFmmtConf.ini')
+        with open(cfg, 'w') as f:
+            f.write(
+                'a31280ad-481e-41b6-95e8-127f4c984779 TIANO UniqueTestToolXYZ\n'
+            )
+        os.environ['FmmtConfPath'] = os.path.abspath(cfg)
+
+        tools = GUIDTools()
+        tools.SetConfigFile()
+        self.assertEqual(tools.tooldef_file, os.path.abspath(cfg))
+
+        tools.LoadingTools()
+        commands = [item.command for item in tools.tooldef.values()]
+        self.assertIn('UniqueTestToolXYZ', commands)
+
+    def test_set_config_file_without_env_does_not_raise(self):
+        os.environ.pop('FmmtConfPath', None)
+        tools = GUIDTools()
+        tools.SetConfigFile()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

`FMMT -c` is documented as a path to a `FmmtConf.ini` file, but the provided file was ignored.

Two bugs caused that:

1. `SetDestPath()` overwrote `FmmtConfPath` with an empty string after `-c` had stored the path.
2. `GUIDTools.SetConfigFile()` treated `FmmtConfPath` as a directory and appended `FmmtConf.ini`, so a file path such as `C:\Code\FmmtConf.ini` became `C:\Code\FmmtConf.ini\FmmtConf.ini`.

FMMT then fell back to the default config.

Keep the `-c` path across `SetDestPath()`, use it as the config file, and look up the environment variable with `os.environ.get()` so omitting `-c` still falls back to PATH search.

Fixes https://github.com/tianocore/edk2/issues/12179

This is independent of stale #12175 (approved, then auto-closed).

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Ran:

```
python BaseTools/Tests/TestFmmtConfig.py -v
python BaseTools/Scripts/PatchCheck.py -1
```

Both passed locally on Windows (Python 3.14.3). The tests cover:

- `SetConfigFilePath()` followed by `SetDestPath()` keeps the `-c` file path
- `SetConfigFile()` uses that path as the config file (not as a directory)
- `LoadingTools()` reads a custom ini
- omitting `FmmtConfPath` does not raise `KeyError`

## Integration Instructions

N/A
