### PR TITLE
BaseTools: WindowsVsToolChain: Filter vs vars on specific vc

### DIFF
--- a/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
+++ b/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
@@ -93,7 +93,7 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 shell_env = shell_environment.GetEnvironment()
                 # Use the tools lib to determine the correct values for the vars that interest us.
                 vs_vars = locate_tools.QueryVcVariables(
-                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="vs2019")
+                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="vs2019", vc_version=vc_ver)
                 for (k, v) in vs_vars.items():
                     shell_env.set_shell_var(k, v)
 
@@ -165,7 +165,7 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 shell_env = shell_environment.GetEnvironment()
                 # Use the tools lib to determine the correct values for the vars that interest us.
                 vs_vars = locate_tools.QueryVcVariables(
-                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="VS2022")
+                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="VS2022", vc_version=vc_ver)
                 for (k, v) in vs_vars.items():
                     shell_env.set_shell_var(k, v)
 
@@ -237,7 +237,7 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 shell_env = shell_environment.GetEnvironment()
                 # Use the tools lib to determine the correct values for the vars that interest us.
                 vs_vars = locate_tools.QueryVcVariables(
-                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="VS2026")
+                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="VS2026", vc_version=vc_ver)
                 for (k, v) in vs_vars.items():
                     shell_env.set_shell_var(k, v)
 
@@ -444,6 +444,9 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 self.Logger.critical(
                     "Failed to find VC tools.  Might need to check for VS install")
                 return vc_ver
-            vc_ver = os.listdir(p2)[-1].strip()  # get last in list
-            self.Logger.debug("Found VC Tool version is %s" % vc_ver)
+            dirs = os.listdir(p2)
+            if len(dirs) > 1:
+                self.Logger.debug(f"Multiple VC versions found: [{', '.join(dirs)}]. Using {dirs[-1]}")
+            vc_ver = dirs[-1].strip()  # get last in list
+            self.Logger.debug(f"Found VC Tool version is {vc_ver}")
         return vc_ver


### PR DESCRIPTION
# Description

Filters the extra vs vars gathered via QueryVcVariables() to specifically be the ones associated with the vc version set in the same plugin. This is to prevent the version compiler version differing from the version of any included .c / .h files that are made available through the vs vars such as LIB, INCLUDE, etc.

Additionally logs a message when multiple vc versions are detected on the system and specifically which vc version is being used.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Actively being used in fork

## Integration Instructions

N/A
