### PR TITLE
ShellPkg/AcpiView: Added ACPI hardware ID validation

### DIFF
--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.c
@@ -3,6 +3,7 @@
 
   Copyright (c) 2016 - 2024, Arm Limited. All rights reserved.
   Copyright (c) 2022, AMD Incorporated. All rights reserved.
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -669,6 +670,109 @@ ValidateReservedBits (
 
   ByteLength = (Length + 7) >> 3;
   ValidateReserved (Ptr, ByteLength, Context);
+}
+
+/**
+  This function checks whether a field holds a valid PNP ID.
+
+  A PNP ID is 7 bytes long, of the form "AAA####" where 'A' is
+  uppercase letter and '#' is hexadecimal number. 8th byte
+  should be NULL terminator.
+
+  @param [in] Id      Pointer to the start of the field data.
+
+  @retval TRUE        The field holds a valid PNP ID.
+  @retval FALSE       The field does not hold a valid PNP ID.
+**/
+BOOLEAN
+EFIAPI
+IsPnpId (
+  IN CONST CHAR8  *Id
+  )
+{
+  UINTN  Index;
+
+  if ((Id == NULL) || (Id[7] != '\0')) {
+    return FALSE;
+  }
+
+  for (Index = 0; Index < 3; Index++) {
+    if ((Id[Index] < 'A') || (Id[Index] > 'Z')) {
+      return FALSE;
+    }
+  }
+
+  for (Index = 3; Index < 7; Index++) {
+    if (((Id[Index] < '0') || (Id[Index] > '9')) &&
+        ((Id[Index] < 'A') || (Id[Index] > 'F')))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  This function checks whether a field holds a valid ACPI ID.
+
+  An ACPI ID is 8 bytes long, of the form "NNNN####" where
+  'N' is restricted to uppercase letters and decimal digits and
+  '#' is hexadecimal number.
+
+  @param [in] Id      Pointer to the start of the field data.
+
+  @retval TRUE        The field holds a valid ACPI ID.
+  @retval FALSE       The field does not hold a valid ACPI ID.
+**/
+BOOLEAN
+EFIAPI
+IsAcpiId (
+  IN CONST CHAR8  *Id
+  )
+{
+  UINTN  Index;
+
+  if (Id == NULL) {
+    return FALSE;
+  }
+
+  for (Index = 0; Index < 4; Index++) {
+    if (((Id[Index] < 'A') || (Id[Index] > 'Z')) &&
+        ((Id[Index] < '0') || (Id[Index] > '9')))
+    {
+      return FALSE;
+    }
+  }
+
+  for (Index = 4; Index < 8; Index++) {
+    if (((Id[Index] < '0') || (Id[Index] > '9')) &&
+        ((Id[Index] < 'A') || (Id[Index] > 'F')))
+    {
+      return FALSE;
+    }
+  }
+
+  return TRUE;
+}
+
+/**
+  This function checks whether a field holds a valid hardware ID.
+
+  A hardware ID can be either PNP ID or ACPI ID.
+
+  @param [in] Id      Pointer to the start of the field data.
+
+  @retval TRUE        The field holds a valid hardware ID.
+  @retval FALSE       The field does not hold a valid hardware ID.
+**/
+BOOLEAN
+EFIAPI
+IsHardwareId (
+  IN CONST CHAR8  *Id
+  )
+{
+  return (IsPnpId (Id) || IsAcpiId (Id));
 }
 
 /**

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/AcpiParser.h
@@ -4,6 +4,7 @@
   Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
   Copyright (c) 2016 - 2024, Arm Limited. All rights reserved.
   Copyright (C) 2022 - 2026, Advanced Micro Devices, Inc. All rights reserved.
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -295,6 +296,58 @@ ValidateReservedBits (
   IN UINT8   *Ptr,
   IN UINT32  Length,
   IN VOID    *Context
+  );
+
+/**
+  This function checks whether a field holds a valid PNP ID.
+
+  A PNP ID is 7 bytes long, of the form "AAA####" where 'A' is
+  uppercase letter and '#' is hexadecimal number. 8th byte
+  should be NULL terminator.
+
+  @param [in] Id      Pointer to the start of the field data.
+
+  @retval TRUE        The field holds a valid PNP ID.
+  @retval FALSE       The field does not hold a valid PNP ID.
+**/
+BOOLEAN
+EFIAPI
+IsPnpId (
+  IN CONST CHAR8  *Id
+  );
+
+/**
+  This function checks whether a field holds a valid ACPI ID.
+
+  An ACPI ID is 8 bytes long, of the form "NNNN####" where
+  'N' is restricted to uppercase letters and decimal digits and
+  '#' is hexadecimal number.
+
+  @param [in] Id      Pointer to the start of the field data.
+
+  @retval TRUE        The field holds a valid ACPI ID.
+  @retval FALSE       The field does not hold a valid ACPI ID.
+**/
+BOOLEAN
+EFIAPI
+IsAcpiId (
+  IN CONST CHAR8  *Id
+  );
+
+/**
+  This function checks whether a field holds a valid hardware ID.
+
+  A hardware ID can be either PNP ID or ACPI ID.
+
+  @param [in] Id      Pointer to the start of the field data.
+
+  @retval TRUE        The field holds a valid hardware ID.
+  @retval FALSE       The field does not hold a valid hardware ID.
+**/
+BOOLEAN
+EFIAPI
+IsHardwareId (
+  IN CONST CHAR8  *Id
   );
 
 /**


### PR DESCRIPTION
# Description

Hardware ID, ACPI ID and PNP ID are a standard format of bytes defined in ACPI spec. Adding helper functions to check if a sequence of bytes are either of these, so that these can be used in acpiview command for any field validations.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

## Integration Instructions

N/A