### PR TITLE
ShellPkg/AcpiView: Added acpiview support for RISC-V MADT

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi66.h
+++ b/MdePkg/Include/IndustryStandard/Acpi66.h
@@ -5,6 +5,7 @@
   Copyright (c) 2019 - 2024, ARM Ltd. All rights reserved.<BR>
   Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
   Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.<BR>
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -811,18 +812,19 @@ typedef struct {
 
 #define EFI_ACPI_6_6_IMSIC_STRUCTURE_VERSION  1
 
-#define IMSIC_MIN_NUM_IDS            63
-#define IMSIC_MAX_NUM_IDS            2047
-#define IMSIC_MIN_NUM_GUEST_IDS      63
-#define IMSIC_MAX_NUM_GUEST_IDS      2047
-#define IMSIC_MIN_GUEST_INDEX_BITS   0
-#define IMSIC_MAX_GUEST_INDEX_BITS   7
-#define IMSIC_MIN_HART_INDEX_BITS    0
-#define IMSIC_MAX_HART_INDEX_BITS    15
-#define IMSIC_MIN_GROUP_INDEX_BITS   0
-#define IMSIC_MAX_GROUP_INDEX_BITS   7
-#define IMSIC_MIN_GROUP_INDEX_SHIFT  0
-#define IMSIC_MAX_GROUP_INDEX_SHIFT  55
+#define IMSIC_MIN_NUM_IDS                       63
+#define IMSIC_MAX_NUM_IDS                       2047
+#define IMSIC_MIN_NUM_GUEST_IDS                 63
+#define IMSIC_MAX_NUM_GUEST_IDS                 2047
+#define IMSIC_MIN_GUEST_INDEX_BITS              0
+#define IMSIC_MAX_GUEST_INDEX_BITS              7
+#define IMSIC_MIN_HART_INDEX_BITS               0
+#define IMSIC_MAX_HART_INDEX_BITS               15
+#define IMSIC_MIN_GROUP_INDEX_BITS              0
+#define IMSIC_MAX_GROUP_INDEX_BITS              7
+#define IMSIC_MIN_GROUP_INDEX_SHIFT             0
+#define IMSIC_MIN_GROUP_INDEX_SHIFT_WITH_APLIC  24
+#define IMSIC_MAX_GROUP_INDEX_SHIFT             55
 
 ///
 /// RISC-V APLIC
@@ -843,6 +845,8 @@ typedef struct {
 
 #define EFI_ACPI_6_6_APLIC_STRUCTURE_VERSION  1
 
+#define APLIC_MAX_EXT_INT_SOURCES  1023
+
 ///
 /// RISC-V PLIC
 ///
@@ -861,6 +865,8 @@ typedef struct {
 } EFI_ACPI_6_6_PLIC_STRUCTURE;
 
 #define EFI_ACPI_6_6_PLIC_STRUCTURE_VERSION  1
+
+#define PLIC_MAX_EXT_INT_SOURCES  1023
 
 ///
 /// Smart Battery Description Table (SBST)

--- a/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Madt/MadtParser.c
+++ b/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Madt/MadtParser.c
@@ -4,6 +4,7 @@
   Copyright (c) 2016 - 2024, Arm Limited. All rights reserved.
   Copyright (c) 2022, AMD Incorporated. All rights reserved.
   Copyright (c) 2024, Loongson Technology Corporation Limited. All rights reserved.
+  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Reference(s):
@@ -24,6 +25,7 @@
 STATIC CONST UINT8                   *MadtInterruptControllerType;
 STATIC CONST UINT8                   *MadtInterruptControllerLength;
 STATIC ACPI_DESCRIPTION_HEADER_INFO  AcpiHdrInfo;
+STATIC BOOLEAN                       mMadtHasRiscVAplic;
 
 /**
   This function validates the System Vector Base in the GICD.
@@ -486,6 +488,645 @@ STATIC CONST ACPI_PARSER  LpcPic[] = {
 };
 
 /**
+  This function validates the RISC-V INTC Flags.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateIntcFlags (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  UINT32  Flags;
+
+  Flags = *(UINT32 *)Ptr;
+  if (((Flags & EFI_ACPI_6_6_RINTC_FLAG_ENABLE) != 0) &&
+      ((Flags & EFI_ACPI_6_6_RINTC_FLAG_ONLINE_CAPABLE) != 0))
+  {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V INTC Online Capable flag must be zero when "
+      L"Enabled flag is set."
+      );
+  }
+}
+
+STATIC CONST ACPI_PARSER  RiscVIntcFlags[] = {
+  { L"Enabled",        1,  0, L"%d", NULL, NULL, NULL,                 NULL },
+  { L"Online Capable", 1,  1, L"%d", NULL, NULL, NULL,                 NULL },
+  { L"Reserved",       30, 2, L"%d", NULL, NULL, ValidateReservedBits, NULL }
+};
+
+/**
+  This function traces RISC-V INTC Flags fields.
+  If no format string is specified the Format must be NULL.
+
+  @param [in] Format  Optional format string for tracing the data.
+  @param [in] Ptr     Pointer to the start of the buffer.
+  @param [in] Length  Length of the field.
+**/
+STATIC
+VOID
+EFIAPI
+DumpRiscVIntcFlags (
+  IN CONST CHAR16  *Format OPTIONAL,
+  IN UINT8         *Ptr,
+  IN UINT32        Length
+  )
+{
+  if (Format != NULL) {
+    Print (Format, *(UINT32 *)Ptr);
+    return;
+  }
+
+  Print (L"0x%X\n", *(UINT32 *)Ptr);
+  ParseAcpiBitFields (
+    TRUE,
+    2,
+    NULL,
+    Ptr,
+    4,
+    PARSER_PARAMS (RiscVIntcFlags)
+    );
+}
+
+/**
+  An ACPI_PARSER array describing the RISC-V INTC Structure.
+**/
+STATIC CONST ACPI_PARSER  RiscVIntc[] = {
+  { L"Type",                             1, 0,  L"0x%x",  NULL,               NULL, NULL, NULL },
+  { L"Length",                           1, 1,  L"%d",    NULL,               NULL, NULL, NULL },
+  { L"Version",                          1, 2,  L"0x%x",  NULL,               NULL, NULL, NULL },
+  { L"Reserved",                         1, 3,  NULL,     DumpReserved,
+    NULL, ValidateReserved, NULL },
+  { L"Flags",                            4, 4,  NULL,     DumpRiscVIntcFlags,
+    NULL, ValidateIntcFlags, NULL },
+  { L"Hart ID",                          8, 8,  L"0x%lx", NULL,               NULL, NULL, NULL },
+  { L"ACPI Processor UID",               4, 16, L"0x%x",  NULL,               NULL, NULL, NULL },
+  { L"External Interrupt Controller ID", 4, 20, L"0x%x",  NULL,               NULL, NULL, NULL },
+  { L"IMSIC Base Address",               8, 24, L"0x%lx", NULL,               NULL, NULL, NULL },
+  { L"IMSIC Size",                       4, 32, L"0x%x",  NULL,               NULL, NULL, NULL }
+};
+
+/**
+  This function validates the number of supervisor interrupt identities
+  supported by the RISC-V IMSIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateImsicNumSupervisorIds (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  UINT16  NumIds;
+
+  NumIds = *(UINT16 *)Ptr;
+  if ((NumIds < IMSIC_MIN_NUM_IDS) ||
+      (NumIds > IMSIC_MAX_NUM_IDS) ||
+      (((NumIds + 1) % 64) != 0))
+  {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V IMSIC Number of Supervisor Interrupt Identities "
+      L"must be between %d and %d, and one less than a multiple of 64. "
+      L"Value = %d.",
+      IMSIC_MIN_NUM_IDS,
+      IMSIC_MAX_NUM_IDS,
+      NumIds
+      );
+  }
+}
+
+/**
+  This function validates the number of guest interrupt identities supported
+  by the RISC-V IMSIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateImsicNumGuestIds (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  UINT16  NumGuestIds;
+
+  NumGuestIds = *(UINT16 *)Ptr;
+  if ((NumGuestIds != 0) &&
+      ((NumGuestIds < IMSIC_MIN_NUM_GUEST_IDS) ||
+       (NumGuestIds > IMSIC_MAX_NUM_GUEST_IDS) ||
+       (((NumGuestIds + 1) % 64) != 0)))
+  {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V IMSIC Number of Guest Interrupt Identities "
+      L"must be 0, or between %d and %d and one less than a multiple "
+      L"of 64. Value = %d.",
+      IMSIC_MIN_NUM_GUEST_IDS,
+      IMSIC_MAX_NUM_GUEST_IDS,
+      NumGuestIds
+      );
+  }
+}
+
+/**
+  This function validates an 8-bit RISC-V IMSIC field against a min/max range.
+
+  @param [in] NameStr   String describing the ACPI table field.
+  @param [in] Value     Field value.
+  @param [in] MinValue  Minimum valid value.
+  @param [in] MaxValue  Maximum valid value.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateImsicUint8Range (
+  IN CONST CHAR16  *NameStr,
+  IN UINT8         Value,
+  IN UINT8         MinValue,
+  IN UINT8         MaxValue
+  )
+{
+  if ((Value < MinValue) ||
+      (Value > MaxValue))
+  {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V IMSIC %s must be between %d and %d. Value = %d.",
+      NameStr,
+      MinValue,
+      MaxValue,
+      Value
+      );
+  }
+}
+
+/**
+  This function validates the guest index bits supported by the RISC-V IMSIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateImsicGuestIndexBits (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  ValidateImsicUint8Range (
+    L"Guest Index Bits",
+    *Ptr,
+    IMSIC_MIN_GUEST_INDEX_BITS,
+    IMSIC_MAX_GUEST_INDEX_BITS
+    );
+}
+
+/**
+  This function validates the hart index bits supported by the RISC-V IMSIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateImsicHartIndexBits (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  ValidateImsicUint8Range (
+    L"Hart Index Bits",
+    *Ptr,
+    IMSIC_MIN_HART_INDEX_BITS,
+    IMSIC_MAX_HART_INDEX_BITS
+    );
+}
+
+/**
+  This function validates the group index bits supported by the RISC-V IMSIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateImsicGroupIndexBits (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  ValidateImsicUint8Range (
+    L"Group Index Bits",
+    *Ptr,
+    IMSIC_MIN_GROUP_INDEX_BITS,
+    IMSIC_MAX_GROUP_INDEX_BITS
+    );
+}
+
+/**
+  This function validates the group index shift supported by the RISC-V IMSIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateImsicGroupIndexShift (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  UINT8         GroupIndexShift;
+  UINT8         MinValue;
+  CONST CHAR16  *AplicMessage;
+
+  GroupIndexShift = *Ptr;
+  if (mMadtHasRiscVAplic) {
+    MinValue     = IMSIC_MIN_GROUP_INDEX_SHIFT_WITH_APLIC;
+    AplicMessage = L" when an APLIC structure is present";
+  } else {
+    MinValue     = IMSIC_MIN_GROUP_INDEX_SHIFT;
+    AplicMessage = L"";
+  }
+
+  if ((GroupIndexShift < MinValue) ||
+      (GroupIndexShift > IMSIC_MAX_GROUP_INDEX_SHIFT))
+  {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V IMSIC Group Index Shift must be between %d "
+      L"and %d%s. Value = %d.",
+      MinValue,
+      IMSIC_MAX_GROUP_INDEX_SHIFT,
+      AplicMessage,
+      GroupIndexShift
+      );
+  }
+}
+
+STATIC CONST ACPI_PARSER  RiscVImsicFlags[] = {
+  { L"Reserved", 32, 0, L"%d", NULL, NULL, ValidateReservedBits, NULL }
+};
+
+/**
+  This function traces RISC-V IMSIC Flags fields.
+  If no format string is specified the Format must be NULL.
+
+  @param [in] Format  Optional format string for tracing the data.
+  @param [in] Ptr     Pointer to the start of the buffer.
+  @param [in] Length  Length of the field.
+**/
+STATIC
+VOID
+EFIAPI
+DumpRiscVImsicFlags (
+  IN CONST CHAR16  *Format OPTIONAL,
+  IN UINT8         *Ptr,
+  IN UINT32        Length
+  )
+{
+  if (Format != NULL) {
+    Print (Format, *(UINT32 *)Ptr);
+    return;
+  }
+
+  Print (L"0x%X\n", *(UINT32 *)Ptr);
+  ParseAcpiBitFields (
+    TRUE,
+    2,
+    NULL,
+    Ptr,
+    4,
+    PARSER_PARAMS (RiscVImsicFlags)
+    );
+}
+
+/**
+  An ACPI_PARSER array describing the RISC-V IMSIC Structure.
+**/
+STATIC CONST ACPI_PARSER  RiscVImsic[] = {
+  { L"Type",                            1, 0,  L"0x%x", NULL,                NULL, NULL, NULL },
+  { L"Length",                          1, 1,  L"%d",   NULL,                NULL, NULL, NULL },
+  { L"Version",                         1, 2,  L"0x%x", NULL,                NULL, NULL, NULL },
+  { L"Reserved",                        1, 3,  NULL,    DumpReserved,
+    NULL, ValidateReserved, NULL },
+  { L"Flags",                           4, 4,  NULL,    DumpRiscVImsicFlags,
+    NULL, NULL, NULL },
+  { L"No. of Supervisor Interrupt Ids", 2, 8,  L"%d",   NULL,                NULL,
+    ValidateImsicNumSupervisorIds, NULL },
+  { L"No. of Guest Interrupt Ids",      2, 10, L"%d",   NULL,                NULL,
+    ValidateImsicNumGuestIds, NULL },
+  { L"Guest Index Bits",                1, 12, L"%d",   NULL,                NULL,
+    ValidateImsicGuestIndexBits, NULL },
+  { L"Hart Index Bits",                 1, 13, L"%d",   NULL,                NULL,
+    ValidateImsicHartIndexBits, NULL },
+  { L"Group Index Bits",                1, 14, L"%d",   NULL,                NULL,
+    ValidateImsicGroupIndexBits, NULL },
+  { L"Group Index Shift",               1, 15, L"%d",   NULL,                NULL,
+    ValidateImsicGroupIndexShift, NULL }
+};
+
+/**
+  This function validates a Hardware ID supported by a RISC-V interrupt
+  controller.
+
+  @param [in] Ptr            Pointer to the start of the field data.
+  @param [in] ControllerName Name of the interrupt controller.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateRiscVHardwareId (
+  IN UINT8         *Ptr,
+  IN CONST CHAR16  *ControllerName
+  )
+{
+  if (Ptr == NULL) {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V %s Hardware ID pointer is NULL.",
+      ControllerName
+      );
+    return;
+  }
+
+  if (!IsAcpiId ((CONST CHAR8 *)Ptr)) {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V %s Hardware ID must be a valid ACPI ID "
+      L"in the form NNNN####, where N is an uppercase letter or a "
+      L"digit ('0'-'9') and # is an uppercase hexadecimal digit. "
+      L"Value = %c%c%c%c%c%c%c%c.",
+      ControllerName,
+      Ptr[0],
+      Ptr[1],
+      Ptr[2],
+      Ptr[3],
+      Ptr[4],
+      Ptr[5],
+      Ptr[6],
+      Ptr[7]
+      );
+  }
+}
+
+/**
+  This function validates the Hardware ID supported by the RISC-V APLIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateRiscVAplicHardwareId (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  ValidateRiscVHardwareId (Ptr, L"APLIC");
+}
+
+/**
+  This function validates the number of external interrupts supported by the
+  RISC-V APLIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateRiscVAplicNumSources (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  UINT16  NumSources;
+
+  NumSources = *(UINT16 *)Ptr;
+  if ((NumSources == 0) || (NumSources > APLIC_MAX_EXT_INT_SOURCES)) {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V APLIC Total External Interrupt Sources Supported "
+      L"must be between 1 and %d. Value = %d.",
+      APLIC_MAX_EXT_INT_SOURCES,
+      NumSources
+      );
+  }
+}
+
+STATIC CONST ACPI_PARSER  RiscVAplicFlags[] = {
+  { L"Reserved", 32, 0, L"%d", NULL, NULL, ValidateReservedBits, NULL }
+};
+
+/**
+  This function traces RISC-V APLIC Flags fields.
+  If no format string is specified the Format must be NULL.
+
+  @param [in] Format  Optional format string for tracing the data.
+  @param [in] Ptr     Pointer to the start of the buffer.
+  @param [in] Length  Length of the field.
+**/
+STATIC
+VOID
+EFIAPI
+DumpRiscVAplicFlags (
+  IN CONST CHAR16  *Format OPTIONAL,
+  IN UINT8         *Ptr,
+  IN UINT32        Length
+  )
+{
+  if (Format != NULL) {
+    Print (Format, *(UINT32 *)Ptr);
+    return;
+  }
+
+  Print (L"0x%X\n", *(UINT32 *)Ptr);
+  ParseAcpiBitFields (
+    TRUE,
+    2,
+    NULL,
+    Ptr,
+    4,
+    PARSER_PARAMS (RiscVAplicFlags)
+    );
+}
+
+/**
+  An ACPI_PARSER array describing the RISC-V APLIC Structure.
+**/
+STATIC CONST ACPI_PARSER  RiscVAplic[] = {
+  { L"Type",                          1, 0,  L"0x%x",  NULL,                NULL, NULL, NULL },
+  { L"Length",                        1, 1,  L"%d",    NULL,                NULL, NULL, NULL },
+  { L"Version",                       1, 2,  L"0x%x",  NULL,                NULL, NULL, NULL },
+  { L"APLIC ID",                      1, 3,  L"0x%x",  NULL,                NULL, NULL, NULL },
+  { L"Flags",                         4, 4,  NULL,     DumpRiscVAplicFlags,
+    NULL, NULL, NULL },
+  { L"Hardware ID",                   8, 8,  NULL,     Dump8Chars,
+    NULL, ValidateRiscVAplicHardwareId, NULL },
+  { L"Number of IDCs",                2, 16, L"%d",    NULL,                NULL, NULL, NULL },
+  { L"External Interrupts Supported", 2, 18, L"%d",    NULL,                NULL,
+    ValidateRiscVAplicNumSources, NULL },
+  { L"Global System Interrupt Base",  4, 20, L"0x%x",  NULL,                NULL, NULL, NULL },
+  { L"APLIC Address",                 8, 24, L"0x%lx", NULL,                NULL, NULL, NULL },
+  { L"APLIC Size",                    4, 32, L"0x%x",  NULL,                NULL, NULL, NULL }
+};
+
+/**
+  This function validates the Hardware ID supported by the RISC-V PLIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateRiscVPlicHardwareId (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  ValidateRiscVHardwareId (Ptr, L"PLIC");
+}
+
+/**
+  This function validates the number of external interrupts supported by the
+  RISC-V PLIC.
+
+  @param [in] Ptr     Pointer to the start of the field data.
+  @param [in] Length  Length of the field.
+  @param [in] Context Pointer to context specific information e.g. this
+                      could be a pointer to the ACPI table header.
+**/
+STATIC
+VOID
+EFIAPI
+ValidateRiscVPlicNumSources (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN VOID    *Context
+  )
+{
+  UINT16  NumSources;
+
+  NumSources = *(UINT16 *)Ptr;
+  if ((NumSources == 0) || (NumSources > PLIC_MAX_EXT_INT_SOURCES)) {
+    IncrementErrorCount ();
+    Print (
+      L"\nERROR: RISC-V PLIC Total External Interrupt Sources Supported "
+      L"must be between 1 and %d. Value = %d.",
+      PLIC_MAX_EXT_INT_SOURCES,
+      NumSources
+      );
+  }
+}
+
+STATIC CONST ACPI_PARSER  RiscVPlicFlags[] = {
+  { L"Reserved", 32, 0, L"%d", NULL, NULL, ValidateReservedBits, NULL }
+};
+
+/**
+  This function traces RISC-V PLIC Flags fields.
+  If no format string is specified the Format must be NULL.
+
+  @param [in] Format  Optional format string for tracing the data.
+  @param [in] Ptr     Pointer to the start of the buffer.
+  @param [in] Length  Length of the field.
+**/
+STATIC
+VOID
+EFIAPI
+DumpRiscVPlicFlags (
+  IN CONST CHAR16  *Format OPTIONAL,
+  IN UINT8         *Ptr,
+  IN UINT32        Length
+  )
+{
+  if (Format != NULL) {
+    Print (Format, *(UINT32 *)Ptr);
+    return;
+  }
+
+  Print (L"0x%X\n", *(UINT32 *)Ptr);
+  ParseAcpiBitFields (
+    TRUE,
+    2,
+    NULL,
+    Ptr,
+    4,
+    PARSER_PARAMS (RiscVPlicFlags)
+    );
+}
+
+/**
+  An ACPI_PARSER array describing the RISC-V PLIC Structure.
+**/
+STATIC CONST ACPI_PARSER  RiscVPlic[] = {
+  { L"Type",                          1, 0,  L"0x%x",  NULL,               NULL, NULL, NULL },
+  { L"Length",                        1, 1,  L"%d",    NULL,               NULL, NULL, NULL },
+  { L"Version",                       1, 2,  L"0x%x",  NULL,               NULL, NULL, NULL },
+  { L"PLIC ID",                       1, 3,  L"0x%x",  NULL,               NULL, NULL, NULL },
+  { L"Hardware ID",                   8, 4,  NULL,     Dump8Chars,
+    NULL, ValidateRiscVPlicHardwareId, NULL },
+  { L"External Interrupts Supported", 2, 12, L"%d",    NULL,               NULL,
+    ValidateRiscVPlicNumSources, NULL },
+  { L"Max Priority",                  2, 14, L"%d",    NULL,               NULL, NULL, NULL },
+  { L"Flags",                         4, 16, NULL,     DumpRiscVPlicFlags,
+    NULL, NULL, NULL },
+  { L"PLIC Size",                     4, 20, L"0x%x",  NULL,               NULL, NULL, NULL },
+  { L"PLIC Address",                  8, 24, L"0x%lx", NULL,               NULL, NULL, NULL },
+  { L"Global System Interrupt Base",  4, 32, L"0x%x",  NULL,               NULL, NULL, NULL }
+};
+
+/**
   An ACPI_PARSER array describing the ACPI MADT Table.
 **/
 STATIC CONST ACPI_PARSER  MadtParser[] = {
@@ -504,6 +1145,54 @@ STATIC CONST ACPI_PARSER  MadtInterruptControllerHeaderParser[] = {
     NULL },
   { L"Reserved", 2, 2, NULL, NULL, NULL,                                    NULL, NULL }
 };
+
+/**
+  Check whether a MADT interrupt controller structure type is present.
+
+  @param [in] Ptr     Pointer to the start of the interrupt controller list.
+  @param [in] Length  Length of the interrupt controller list.
+  @param [in] Type    Interrupt controller structure type.
+
+  @retval TRUE   The interrupt controller structure type is present.
+  @retval FALSE  The interrupt controller structure type is not present.
+**/
+STATIC
+BOOLEAN
+MadtHasInterruptController (
+  IN UINT8   *Ptr,
+  IN UINT32  Length,
+  IN UINT8   Type
+  )
+{
+  UINT32  Offset;
+  UINT8   InterruptControllerLength;
+
+  if (Ptr == NULL) {
+    return FALSE;
+  }
+
+  Offset = 0;
+  while (Offset < Length) {
+    if ((Length - Offset) < 2) {
+      return FALSE;
+    }
+
+    if (Ptr[Offset] == Type) {
+      return TRUE;
+    }
+
+    InterruptControllerLength = Ptr[Offset + 1];
+    if ((InterruptControllerLength == 0) ||
+        (InterruptControllerLength > (Length - Offset)))
+    {
+      return FALSE;
+    }
+
+    Offset += InterruptControllerLength;
+  }
+
+  return FALSE;
+}
 
 /**
   This function parses the ACPI MADT table.
@@ -553,6 +1242,11 @@ ParseAcpiMadt (
              PARSER_PARAMS (MadtParser)
              );
   InterruptContollerPtr = Ptr + Offset;
+  mMadtHasRiscVAplic    = MadtHasInterruptController (
+                            InterruptContollerPtr,
+                            AcpiTableLength - Offset,
+                            EFI_ACPI_6_6_APLIC
+                            );
 
   while (Offset < AcpiTableLength) {
     // Parse Interrupt Controller Structure to obtain Length.
@@ -819,6 +1513,58 @@ ParseAcpiMadt (
           InterruptContollerPtr,
           *MadtInterruptControllerLength,
           PARSER_PARAMS (LpcPic)
+          );
+        break;
+      }
+
+      case EFI_ACPI_6_6_RINTC:
+      {
+        ParseAcpi (
+          TRUE,
+          2,
+          "RISC-V INTC",
+          InterruptContollerPtr,
+          *MadtInterruptControllerLength,
+          PARSER_PARAMS (RiscVIntc)
+          );
+        break;
+      }
+
+      case EFI_ACPI_6_6_IMSIC:
+      {
+        ParseAcpi (
+          TRUE,
+          2,
+          "RISC-V IMSIC",
+          InterruptContollerPtr,
+          *MadtInterruptControllerLength,
+          PARSER_PARAMS (RiscVImsic)
+          );
+        break;
+      }
+
+      case EFI_ACPI_6_6_APLIC:
+      {
+        ParseAcpi (
+          TRUE,
+          2,
+          "RISC-V APLIC",
+          InterruptContollerPtr,
+          *MadtInterruptControllerLength,
+          PARSER_PARAMS (RiscVAplic)
+          );
+        break;
+      }
+
+      case EFI_ACPI_6_6_PLIC:
+      {
+        ParseAcpi (
+          TRUE,
+          2,
+          "RISC-V PLIC",
+          InterruptContollerPtr,
+          *MadtInterruptControllerLength,
+          PARSER_PARAMS (RiscVPlic)
           );
         break;
       }


### PR DESCRIPTION
The new parser support covers RISC-V RINTC, IMSIC, APLIC and PLIC structures.

# Description

The new parser support covers RISC-V RINTC, IMSIC, APLIC and PLIC structures.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

acpiview

## Integration Instructions

N/A