### PR TITLE
ArmPkg/ArmGicDxe: Fix GIC version detection under Apple's HVF

### DIFF
--- a/ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.c
+++ b/ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.c
@@ -32,7 +32,12 @@ GicV3Supported (
   // feature is implemented on the CPU. This is also convenient as our GICv3
   // driver requires SRE. If only Memory mapped access is available we try to
   // drive the GIC as a v2.
-  if (ArmHasGicSystemRegisters ()) {
+  //
+  // Some platforms present a functional GICv3 even though ID_AA64PFR0_EL1.GIC
+  // returns 0. This includes QEMU on Apple's HVF, where the host CPU has an AIC
+  // rather than a GIC, and the ID registers are passed through unmodified. We
+  // must therefore also check PcdGicRedistributorsBase to determine support.
+  if (ArmHasGicSystemRegisters () || (PcdGet64 (PcdGicRedistributorsBase) != 0)) {
     // Make sure System Register access is enabled (SRE). This depends on the
     // higher privilege level giving us permission, otherwise we will either
     // cause an exception here, or the write doesn't stick in which case we need

--- a/ArmPkg/Drivers/ArmGicDxe/ArmGicV2Dxe.inf
+++ b/ArmPkg/Drivers/ArmGicDxe/ArmGicV2Dxe.inf
@@ -46,6 +46,7 @@
 [Pcd.common]
   gArmTokenSpaceGuid.PcdGicDistributorBase
   gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
+  gArmTokenSpaceGuid.PcdGicRedistributorsBase
 
 [Depex]
   gEfiCpuArchProtocolGuid


### PR DESCRIPTION
# Description

Some platforms present a functional GICv3 even though ID_AA64PFR0_EL1.GIC returns 0. This includes QEMU on Apple's HVF, where the host CPU has an AIC rather than a GIC, and the ID registers are passed through unmodified. We must therefore also check `PcdGicRedistributorsBase` to determine support.

This has been broken since 8edd5fd6d3dfb21fe077427029f1e705cfbcb7a1 when the check changed from the device tree to the CPU register in this case.

Without this fix, it fell back to GICv2, which doesn't work on HVF, resulting in a freeze. Before c558a3b18b45348670e00bc3e7644d39c701fce3, a Synchronous Exception was displayed instead.

Note that I independently determined that switching the check from device tree to CPU register is what broke this, but I relied on AI to explain why it broke and to provide the fix.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?

## How This Was Tested

Manually tested on a mac-m4.metal Amazon EC2 instance running macOS Tahoe 26.6.1 with QEMU 11.1.1 from Homebrew.

## Integration Instructions

N/A

CC @ardbiesheuvel 