### PR TITLE
NetworkPkg/IScsiDxe: avoid BufferSize reuse in IScsiFormRouteConfig

### DIFF
--- a/NetworkPkg/IScsiDxe/IScsiConfig.c
+++ b/NetworkPkg/IScsiDxe/IScsiConfig.c
@@ -3156,6 +3156,7 @@ IScsiFormRouteConfig (
   CHAR8                        *InitiatorName;
   UINT8                        *AttemptList;
   UINTN                        BufferSize;
+  UINTN                        IfrBufferSize;
   UINTN                        OffSet;
   UINTN                        Index;
   UINTN                        Index2;
@@ -3194,14 +3195,14 @@ IScsiFormRouteConfig (
   //
   // Convert <ConfigResp> to buffer data by helper function ConfigToBlock().
   //
-  BufferSize = sizeof (ISCSI_CONFIG_IFR_NVDATA);
-  Status     = gHiiConfigRouting->ConfigToBlock (
-                                    gHiiConfigRouting,
-                                    Configuration,
-                                    (UINT8 *)IfrNvData,
-                                    &BufferSize,
-                                    Progress
-                                    );
+  IfrBufferSize = sizeof (ISCSI_CONFIG_IFR_NVDATA);
+  Status        = gHiiConfigRouting->ConfigToBlock (
+                                       gHiiConfigRouting,
+                                       Configuration,
+                                       (UINT8 *)IfrNvData,
+                                       &IfrBufferSize,
+                                       Progress
+                                       );
   if (EFI_ERROR (Status)) {
     goto Exit;
   }


### PR DESCRIPTION
IScsiFormRouteConfig() allocated InitiatorName with ISCSI_NAME_MAX_SIZE, then reused BufferSize for ConfigToBlock(), overwriting it with sizeof(ISCSI_CONFIG_IFR_NVDATA). The else path later passed that inflated size to gIScsiInitiatorName.Get(), so an oversized I_NAME NVRAM variable could overflow the 224-byte heap buffer via GetVariable.

Use a separate IfrBufferSize for ConfigToBlock() so BufferSize remains the InitiatorName allocation size for Get().

# Description

`IScsiFormRouteConfig()` allocated `InitiatorName` with `ISCSI_NAME_MAX_SIZE` (224 bytes) and stored that size in `BufferSize`. It then reused `BufferSize` for `ConfigToBlock()`, which overwrote it with `sizeof(ISCSI_CONFIG_IFR_NVDATA)`.

On the later `else` path, that inflated size was passed to `gIScsiInitiatorName.Get()`. An oversized `I_NAME` NVRAM variable could then overflow the 224-byte heap buffer through `GetVariable`.

This change introduces a separate `IfrBufferSize` for `ConfigToBlock()`, so `BufferSize` stays the `InitiatorName` allocation size used by `Get()`.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Code review of `IScsiFormRouteConfig()` in `NetworkPkg/IScsiDxe/IScsiConfig.c`. Confirmed `BufferSize` remains `ISCSI_NAME_MAX_SIZE` for `gIScsiInitiatorName.Get()`, and `ConfigToBlock()` uses `IfrBufferSize` instead.
No new unit or integration tests were added.

## Integration Instructions

NA
