### PR TITLE
EmulatorPkg/Sec: Align stack before ZeroMem call to prevent seg fault

### DIFF
--- a/EmulatorPkg/Sec/X64/SwitchRam.nasm
+++ b/EmulatorPkg/Sec/X64/SwitchRam.nasm
@@ -63,9 +63,9 @@ ASM_PFX(SecTemporaryRamSupport):
   ; ZeroMem (TemporaryMemoryBase /* rcx */, CopySize /* rdx */);
   mov     rcx, rdx
   mov     rdx, r9
-  sub     rsp, 0x28     ; Allocate register spill area & 16-byte align stack
+  sub     rsp, 0x20     ; Allocate register spill area & 16-byte align stack
   call    ZeroMem
-  add     rsp, 0x28
+  add     rsp, 0x20
 
   ; This data comes off the NEW stack
   pop     rbp


### PR DESCRIPTION
# Description

After SecTemporaryRamSupport restores its saved registers and moves RSP to permanent memory, the stack is 16-byte aligned. The existing 0x28-byte allocation for the ZeroMem call adds an unnecessary 8-byte padding slot and leaves RSP misaligned immediately before the call.

Reserve only the 32-byte EFIAPI register spill area for ZeroMem. This preserves 16-byte stack alignment at the call site while providing the required home space to the callee.

https://github.com/tianocore/edk2/pull/12244 causes the X64 GCC and CLANG tools to generate a prologue in InternalMemZeroMem() that requires a 16-byte aligned stack. With the previous stack allocation, that prologue can execute with an incorrectly aligned stack. Without this change, a seg fault is generated when SecTemporaryRamSupport calls ZeroMem.

The earlier CopyMem call continues to require its 0x28-byte allocation because its preceding stack state differs.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Before this change, seg fault observed in Linux environments for X64 GCC, GCCNOLTO, and CLANGDWARF builds of EmulatorPkg.  No issues were observed on Linux IA32 builds or Windows builds.

After this change, the seg faults were no longer observed.  Verified EmulatorPkg boot for Linux X64 GCC, GCCNOLTO, and CLANGDWARF for DEBUG, RELEASE, and NOOPT.

## Integration Instructions

N/A