### PR TITLE
NetworkPkg/Ip4Dxe: validate IP4 config NVRAM record bounds

### DIFF
--- a/NetworkPkg/Ip4Dxe/Ip4Config2Impl.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Impl.c
@@ -197,6 +197,9 @@ Ip4Config2ReadConfigData (
   UINTN                    Index;
   IP4_CONFIG2_DATA_RECORD  DataRecord;
   CHAR8                    *Data;
+  UINTN                    RecordArraySize;
+
+  Variable = NULL;
 
   //
   // Try to read the configuration variable.
@@ -229,25 +232,50 @@ Ip4Config2ReadConfigData (
     if (EFI_ERROR (Status) || ((UINT16)(~NetblockChecksum ((UINT8 *)Variable, (UINT32)VarSize)) != 0)) {
       //
       // GetVariable still error or the variable is corrupted.
-      // Fall back to the default value.
       //
-      FreePool (Variable);
-
-      //
-      // Remove the problematic variable and return EFI_NOT_FOUND, a new
-      // variable will be set again.
-      //
-      gRT->SetVariable (
-             VarName,
-             &gEfiIp4Config2ProtocolGuid,
-             IP4_CONFIG2_VARIABLE_ATTRIBUTE,
-             0,
-             NULL
-             );
-
-      return EFI_NOT_FOUND;
+      goto Error;
     }
 
+    //
+    // Validate the header and DataRecord array fit in the returned buffer
+    // before using DataRecordCount as a loop bound.
+    //
+    if (VarSize < OFFSET_OF (IP4_CONFIG2_VARIABLE, DataRecord)) {
+      goto Error;
+    }
+
+    RecordArraySize = VarSize - OFFSET_OF (IP4_CONFIG2_VARIABLE, DataRecord);
+    if ((UINTN)Variable->DataRecordCount > RecordArraySize / sizeof (IP4_CONFIG2_DATA_RECORD)) {
+      goto Error;
+    }
+
+    for (Index = 0; Index < Variable->DataRecordCount; Index++) {
+      CopyMem (&DataRecord, &Variable->DataRecord[Index], sizeof (DataRecord));
+
+      if ((UINT32)DataRecord.DataType >= Ip4Config2DataTypeMaximum) {
+        goto Error;
+      }
+
+      DataItem = &Instance->DataItem[DataRecord.DataType];
+      if (DATA_ATTRIB_SET (DataItem->Attribute, DATA_ATTRIB_SIZE_FIXED) &&
+          (DataItem->DataSize != DataRecord.DataSize)
+          )
+      {
+        continue;
+      }
+
+      if ((DataRecord.Offset > VarSize) ||
+          (DataRecord.DataSize > VarSize - DataRecord.Offset))
+      {
+        goto Error;
+      }
+    }
+
+    //
+    // Apply records only after the entire variable has been validated so a
+    // later corrupt record cannot leave Instance->DataItem[] half-updated
+    // before Error: deletes the variable and returns EFI_NOT_FOUND.
+    //
     for (Index = 0; Index < Variable->DataRecordCount; Index++) {
       CopyMem (&DataRecord, &Variable->DataRecord[Index], sizeof (DataRecord));
 
@@ -287,6 +315,28 @@ Ip4Config2ReadConfigData (
   }
 
   return Status;
+
+Error:
+  //
+  // Fall back to the default value.
+  //
+  if (Variable != NULL) {
+    FreePool (Variable);
+  }
+
+  //
+  // Remove the problematic variable and return EFI_NOT_FOUND, a new
+  // variable will be set again.
+  //
+  gRT->SetVariable (
+         VarName,
+         &gEfiIp4Config2ProtocolGuid,
+         IP4_CONFIG2_VARIABLE_ATTRIBUTE,
+         0,
+         NULL
+         );
+
+  return EFI_NOT_FOUND;
 }
 
 /**


### PR DESCRIPTION
Check that DataRecordCount and each record Offset/DataSize fit in the variable before use. Apply records only after the whole blob validates so a later failure cannot persist a partial config.

# Description

`Ip4Config2ReadConfigData()` trusted `DataRecordCount`, `Offset`, and `DataSize` from the IP4 config NVRAM variable without checking that they fit in the returned buffer. A truncated or crafted variable could walk the `DataRecord` array or payload out of bounds.

This change:

- Rejects the variable if the header or `DataRecord` array does not fit in `VarSize`.
- Caps `DataRecordCount` so it cannot exceed the array that is actually present.
- Checks each record’s `Offset`/`DataSize` against `VarSize` before any copy.
- Applies records only after the whole blob validates, so a later corrupt record cannot leave `Instance->DataItem[]` half-updated before the error path deletes the variable.

Checksum failures and these bound failures share one `Error:` path: free the buffer, delete the bad variable, return `EFI_NOT_FOUND`.

This is a buffer over-read / untrusted-NVRAM bounds fix. It does not change crypto, protocols, or boot/build behavior.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Code review of `Ip4Config2ReadConfigData()` in `NetworkPkg/Ip4Dxe/Ip4Config2Impl.c`. Confirmed:

- `DataRecordCount` is checked against the size of the `DataRecord` array in the variable.
- Each record `Offset`/`DataSize` is checked against `VarSize` before use.
- Records are applied only after the validation pass succeeds.
- Corrupt variables still take the existing delete-and-`EFI_NOT_FOUND` fallback.

No new unit or integration tests were added.

## Integration Instructions

N/A
