### PR TITLE
NetworkPkg/Ip6Dxe: validate IP6 config NVRAM record bounds

### DIFF
--- a/NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c
+++ b/NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c
@@ -357,6 +357,9 @@ Ip6ConfigReadConfigData (
   UINTN                   Index;
   IP6_CONFIG_DATA_RECORD  DataRecord;
   CHAR8                   *Data;
+  UINTN                   RecordArraySize;
+
+  Variable = NULL;
 
   //
   // Try to read the configuration variable.
@@ -394,7 +397,44 @@ Ip6ConfigReadConfigData (
     }
 
     //
-    // Get the IAID we use.
+    // Validate the header and DataRecord array fit in the returned buffer
+    // before using DataRecordCount as a loop bound.
+    //
+    if (VarSize < OFFSET_OF (IP6_CONFIG_VARIABLE, DataRecord)) {
+      goto Error;
+    }
+
+    RecordArraySize = VarSize - OFFSET_OF (IP6_CONFIG_VARIABLE, DataRecord);
+    if ((UINTN)Variable->DataRecordCount > RecordArraySize / sizeof (IP6_CONFIG_DATA_RECORD)) {
+      goto Error;
+    }
+
+    for (Index = 0; Index < Variable->DataRecordCount; Index++) {
+      CopyMem (&DataRecord, &Variable->DataRecord[Index], sizeof (DataRecord));
+
+      if ((UINT32)DataRecord.DataType >= Ip6ConfigDataTypeMaximum) {
+        goto Error;
+      }
+
+      DataItem = &Instance->DataItem[DataRecord.DataType];
+      if (DATA_ATTRIB_SET (DataItem->Attribute, DATA_ATTRIB_SIZE_FIXED) &&
+          (DataItem->DataSize != DataRecord.DataSize)
+          )
+      {
+        continue;
+      }
+
+      if ((DataRecord.Offset > VarSize) ||
+          (DataRecord.DataSize > VarSize - DataRecord.Offset))
+      {
+        goto Error;
+      }
+    }
+
+    //
+    // Apply records only after the entire variable has been validated so a
+    // later corrupt record cannot leave Instance->DataItem[] half-updated
+    // before Error: deletes the variable and returns EFI_NOT_FOUND.
     //
     Instance->IaId = Variable->IaId;
 
@@ -415,12 +455,7 @@ Ip6ConfigReadConfigData (
       if (!DATA_ATTRIB_SET (DataItem->Attribute, DATA_ATTRIB_SIZE_FIXED)) {
         //
         // This data item has variable length data.
-        // Check that the length is contained within the variable before allocating.
         //
-        if (DataRecord.DataSize > VarSize - DataRecord.Offset) {
-          goto Error;
-        }
-
         DataItem->Data.Ptr = AllocatePool (DataRecord.DataSize);
         if (DataItem->Data.Ptr == NULL) {
           //


### PR DESCRIPTION
Check that DataRecordCount and each record Offset/DataSize fit in the variable before use. Apply IaId and records only after the whole blob validates so a later failure cannot persist a partial config.

# Description

`Ip6ConfigReadConfigData()` trusted `DataRecordCount`, `Offset`, and `DataSize` from the IP6 config NVRAM variable without checking that the header and record array fit in the returned buffer. A truncated or crafted variable could walk `DataRecord[]` or the payload out of bounds. `Offset`/`DataSize` were only checked later, after `IaId` was already written, so a later failure could leave a partial config before the error path deleted the variable.

This change:

- Rejects the variable if the header or `DataRecord` array does not fit in `VarSize`.
- Caps `DataRecordCount` so it cannot exceed the array that is actually present.
- Checks each record’s `Offset`/`DataSize` against `VarSize` before any apply.
- Sets `Instance->IaId` and copies records only after the whole blob validates, so a later corrupt record cannot leave `IaId` or `Instance->DataItem[]` half-updated.

Checksum failures and these bound failures share one `Error:` path: free the buffer, delete the bad variable, return `EFI_NOT_FOUND`.

This is a buffer over-read / untrusted-NVRAM bounds fix. It does not change crypto, protocols, or boot/build behavior.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [x] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Code review of `Ip6ConfigReadConfigData()` in `NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c`. Confirmed:

- `DataRecordCount` is checked against the size of the `DataRecord` array in the variable.
- Each record `Offset`/`DataSize` is checked against `VarSize` before use.
- `IaId` and records are applied only after the validation pass succeeds.
- Corrupt variables still take the existing delete-and-`EFI_NOT_FOUND` fallback.

No new unit or integration tests were added.

## Integration Instructions

N/A
