### PR TITLE
BaseTools/FirmwareStorageFormat: Fix FV ext entry struct factory functions

### DIFF
--- a/BaseTools/Source/Python/FirmwareStorageFormat/FvHeader.py
+++ b/BaseTools/Source/Python/FirmwareStorageFormat/FvHeader.py
@@ -80,7 +80,7 @@ def Refine_FV_EXT_ENTRY_OEM_TYPE_Header(nums: int) -> EFI_FIRMWARE_VOLUME_EXT_EN
             ('TypeMask',             c_uint32),
             ('Types',                ARRAY(GUID, nums))
         ]
-    return EFI_FIRMWARE_VOLUME_EXT_ENTRY_OEM_TYPE(Structure)
+    return EFI_FIRMWARE_VOLUME_EXT_ENTRY_OEM_TYPE
 
 class EFI_FIRMWARE_VOLUME_EXT_ENTRY_GUID_TYPE_0(Structure):
     _fields_ = [
@@ -102,7 +102,7 @@ def Refine_FV_EXT_ENTRY_GUID_TYPE_Header(nums: int) -> EFI_FIRMWARE_VOLUME_EXT_E
             ('FormatType',           GUID),
             ('Data',                 ARRAY(c_uint8, nums))
         ]
-    return EFI_FIRMWARE_VOLUME_EXT_ENTRY_GUID_TYPE(Structure)
+    return EFI_FIRMWARE_VOLUME_EXT_ENTRY_GUID_TYPE
 
 class EFI_FIRMWARE_VOLUME_EXT_ENTRY_USED_SIZE_TYPE(Structure):
     _fields_ = [


### PR DESCRIPTION
# Description

The Refine_FV_EXT_ENTRY_OEM_TYPE_Header() and Refine_FV_EXT_ENTRY_GUID_TYPE_Header() functions incorrectly return an instantiation attempt of the local class with `Structure` as an argument (e.g., `return ClassName(Structure)`) instead of returning the class itself (e.g., `return ClassName`).

This causes FMMT to fail with:
  "expected EFI_FIRMWARE_VOLUME_EXT_ENTRY instance, got _ctypes.PyCStructType"

When processing FVs that contain ext header entries of type 0x01 (OEM Type) or type 0x02 (GUID Type, used for FV UI Name when FvNameString = TRUE).

Fix by returning the class directly, matching the pattern used by Refine_FV_Header() which correctly returns the class for subsequent .from_buffer_copy() calls.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Add `FvNameString = TRUE` in FDF file to add an FV Extended Header with the UI Name of the FV.  The use of the FMMT tool on the FV then fails with an error.

After this change is applied, the FMMT tool can run correctly.

## Integration Instructions

N/A
