### PR TITLE
MdeModulePkg: Variable: Log Reclaim() completion status

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -20,6 +20,7 @@ Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015-2018 Hewlett Packard Enterprise Development LP<BR>
 Copyright (c) Microsoft Corporation.<BR>
 Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -818,6 +819,7 @@ Done:
     Status = DoneStatus;
   }
 
+  DEBUG ((DEBUG_INFO, "[Variable]: Completed Reclaim process with Status = %r.\n", Status));
   return Status;
 }
 


### PR DESCRIPTION
Adds a DEBUG_INFO message when Reclaim() finishes so platform boot logs show whether reclaim ran and what status it returned. This makes it easier to distinguish reclaims impact on boot measurements.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
Boot test on AMD platform.

## Integration Instructions

N/A