### PR TITLE
ArmPkg/Library: remove FFA_ERROR() return for FFA_SEND_DIRECT_MSG_REQ(v2) for StandaloneMm

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -55,6 +55,35 @@ STATIC EFI_EVENT  mSetVirtualAddressMapEvent;
 STATIC EFI_HANDLE  mMmCommunicateHandle;
 
 /**
+  Convert SmcMmRet value to EFI_STATUS.
+
+  @param[in] SmcMmRet              Mm return code
+
+  @retval EFI_SUCCESS
+  @retval Others                   Error status correspond to SmcMmRet
+
+**/
+STATIC
+EFI_STATUS
+SmcMmRetToEfiStatus (
+  IN UINTN  SmcMmRet
+  )
+{
+  switch ((UINT32)SmcMmRet) {
+    case ARM_SMC_MM_RET_SUCCESS:
+      return EFI_SUCCESS;
+    case ARM_SMC_MM_RET_INVALID_PARAMS:
+      return EFI_INVALID_PARAMETER;
+    case ARM_SMC_MM_RET_DENIED:
+      return EFI_ACCESS_DENIED;
+    case ARM_SMC_MM_RET_NO_MEMORY:
+      return EFI_OUT_OF_RESOURCES;
+    default:
+      return EFI_ACCESS_DENIED;
+  }
+}
+
+/**
   Send mm communicate request via FF-A.
 
   @retval EFI_SUCCESS
@@ -101,36 +130,7 @@ SendFfaMmCommunicate (
     Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (CommunicateArgs.Header.x1), 0x00, &CommunicateArgs);
   }
 
-  return Status;
-}
-
-/**
-  Convert SmcMmRet value to EFI_STATUS.
-
-  @param[in] SmcMmRet              Mm return code
-
-  @retval EFI_SUCCESS
-  @retval Others                   Error status correspond to SmcMmRet
-
-**/
-STATIC
-EFI_STATUS
-SmcMmRetToEfiStatus (
-  IN UINTN  SmcMmRet
-  )
-{
-  switch ((UINT32)SmcMmRet) {
-    case ARM_SMC_MM_RET_SUCCESS:
-      return EFI_SUCCESS;
-    case ARM_SMC_MM_RET_INVALID_PARAMS:
-      return EFI_INVALID_PARAMETER;
-    case ARM_SMC_MM_RET_DENIED:
-      return EFI_ACCESS_DENIED;
-    case ARM_SMC_MM_RET_NO_MEMORY:
-      return EFI_OUT_OF_RESOURCES;
-    default:
-      return EFI_ACCESS_DENIED;
-  }
+  return SmcMmRetToEfiStatus (CommunicateArgs.Arg1);
 }
 
 /**

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
@@ -30,6 +30,35 @@
 STATIC UINT16  mStMmPartId;
 
 /**
+  Convert SmcMmRet value to EFI_STATUS.
+
+  @param[in] SmcMmRet              Mm return code
+
+  @retval EFI_SUCCESS
+  @retval Others                   Error status correspond to SmcMmRet
+
+**/
+STATIC
+EFI_STATUS
+SmcMmRetToEfiStatus (
+  IN UINTN  SmcMmRet
+  )
+{
+  switch ((UINT32)SmcMmRet) {
+    case ARM_SMC_MM_RET_SUCCESS:
+      return EFI_SUCCESS;
+    case ARM_SMC_MM_RET_INVALID_PARAMS:
+      return EFI_INVALID_PARAMETER;
+    case ARM_SMC_MM_RET_DENIED:
+      return EFI_ACCESS_DENIED;
+    case ARM_SMC_MM_RET_NO_MEMORY:
+      return EFI_OUT_OF_RESOURCES;
+    default:
+      return EFI_ACCESS_DENIED;
+  }
+}
+
+/**
   Check mm communication compatibility when use SPM_MM.
 
 **/
@@ -221,36 +250,7 @@ SendFfaMmCommunicate (
     Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (CommunicateArgs.Header.x1), 0x00, &CommunicateArgs);
   }
 
-  return Status;
-}
-
-/**
-  Convert SmcMmRet value to EFI_STATUS.
-
-  @param[in] SmcMmRet              Mm return code
-
-  @retval EFI_SUCCESS
-  @retval Others                   Error status correspond to SmcMmRet
-
-**/
-STATIC
-EFI_STATUS
-SmcMmRetToEfiStatus (
-  IN UINTN  SmcMmRet
-  )
-{
-  switch ((UINT32)SmcMmRet) {
-    case ARM_SMC_MM_RET_SUCCESS:
-      return EFI_SUCCESS;
-    case ARM_SMC_MM_RET_INVALID_PARAMS:
-      return EFI_INVALID_PARAMETER;
-    case ARM_SMC_MM_RET_DENIED:
-      return EFI_ACCESS_DENIED;
-    case ARM_SMC_MM_RET_NO_MEMORY:
-      return EFI_OUT_OF_RESOURCES;
-    default:
-      return EFI_ACCESS_DENIED;
-  }
+  return SmcMmRetToEfiStatus (CommunicateArgs.Arg1);
 }
 
 /**

--- a/ArmPkg/Drivers/StandaloneMmCpu/EventHandle.c
+++ b/ArmPkg/Drivers/StandaloneMmCpu/EventHandle.c
@@ -30,17 +30,8 @@ MmFoundationEntryRegister (
   IN EFI_MM_ENTRY_POINT                   MmEntryPoint
   );
 
-//
-// On ARM platforms every event is expected to have a GUID associated with
-// it. It will be used by the MM Entry point to find the handler for the
-// event. It will either be populated in a EFI_MM_COMMUNICATE_HEADER by the
-// caller of the event (e.g. MM_COMMUNICATE SMC) or by the CPU driver
-// (e.g. during an asynchronous event). In either case, this context is
-// maintained in single global variable because StandaloneMm is UP-migratable
-// (which means it cannot run concurrently)
-//
-STATIC EFI_MM_COMMUNICATE_HEADER     *mGuidedEventContext = NULL;
-STATIC CONST ARM_MM_HANDLER_CONTEXT  *mMmHandlerContext   = NULL;
+EFI_MM_COMMUNICATE_HEADER  *mGuidedEventContext    = NULL;
+UINT64                     mGuidedEventContextSize = 0;
 
 EFI_MM_CONFIGURATION_PROTOCOL  mMmConfig = {
   0,
@@ -51,7 +42,8 @@ EDKII_PI_MM_CPU_DRIVER_EP_PROTOCOL  mPiMmCpuDriverEpProtocol = {
   PiMmStandaloneMmCpuDriverEntry
 };
 
-STATIC EFI_MM_ENTRY_POINT  mMmEntryPoint = NULL;
+STATIC EFI_MM_ENTRY_POINT            mMmEntryPoint      = NULL;
+STATIC CONST ARM_MM_HANDLER_CONTEXT  *mMmHandlerContext = NULL;
 
 /**
   The PI Standalone MM entry point for the CPU driver.
@@ -76,6 +68,8 @@ PiMmStandaloneMmCpuDriverEntry (
   UINTN                 CommBufferSize;
 
   Status = EFI_SUCCESS;
+
+  ASSERT (mGuidedEventContext != NULL);
 
   // Perform parameter validation.
   if ((MmHandlerContext == NULL) || (CommBufferAddr == (UINTN)NULL)) {
@@ -104,18 +98,6 @@ PiMmStandaloneMmCpuDriverEntry (
 
   // Now that the secure world can see the normal world buffer, allocate
   // memory to copy the communication buffer to the secure world.
-  Status = mMmst->MmAllocatePool (
-                    EfiRuntimeServicesData,
-                    CommBufferSize,
-                    (VOID **)&mGuidedEventContext
-                    );
-
-  if (EFI_ERROR (Status)) {
-    mGuidedEventContext = NULL;
-    DEBUG ((DEBUG_ERROR, "%a: Mem alloc failed\n", __func__));
-    return Status;
-  }
-
   CopyMem (mGuidedEventContext, (CONST VOID *)CommBufferAddr, CommBufferSize);
   mMmHandlerContext = MmHandlerContext;
 
@@ -136,11 +118,10 @@ PiMmStandaloneMmCpuDriverEntry (
 
   // Free the memory allocation done earlier and reset the per-cpu context
   CopyMem ((VOID *)CommBufferAddr, (CONST VOID *)mGuidedEventContext, CommBufferSize);
+  ZeroMem (mGuidedEventContext, mGuidedEventContextSize);
 
-  Status = mMmst->MmFreePool ((VOID *)mGuidedEventContext);
   ASSERT_EFI_ERROR (Status);
-  mGuidedEventContext = NULL;
-  mMmHandlerContext   = NULL;
+  mMmHandlerContext = NULL;
 
   return Status;
 }

--- a/ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.c
+++ b/ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.c
@@ -11,6 +11,7 @@
 
 #include <Base.h>
 #include <Pi/PiMmCis.h>
+#include <Library/ArmStandaloneMmCoreEntryPoint.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/HobLib.h>
@@ -55,11 +56,47 @@ StandaloneMmCpuInitialize (
   IN EFI_MM_SYSTEM_TABLE  *SystemTable   // not actual systemtable
   )
 {
-  EFI_STATUS  Status;
-  EFI_HANDLE  DispatchHandle;
+  EFI_STATUS                      Status;
+  EFI_HANDLE                      DispatchHandle;
+  EFI_HOB_GUID_TYPE               *GuidHob;
+  EFI_MMRAM_DESCRIPTOR            *NsCommBuffer;
+  EFI_MMRAM_DESCRIPTOR            *SecureCommBuffer;
+  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *MmramRangesHob;
 
   ASSERT (SystemTable != NULL);
   mMmst = SystemTable;
+
+  //
+  // gEfiStandaloneMmNonSecureBufferGuid GuidHob and
+  // gEfiMmPeiMmramMemoryReservedGuid GuidHob are already verified in
+  // ArmStandlaoneMmCoreEntryPoint. Therefore, it's enough ASSERT().
+  //
+  GuidHob = GetFirstGuidHob (&gEfiStandaloneMmNonSecureBufferGuid);
+  ASSERT (GuidHob != NULL);
+  NsCommBuffer = GET_GUID_HOB_DATA (GuidHob);
+
+  GuidHob = GetFirstGuidHob (&gEfiMmPeiMmramMemoryReserveGuid);
+  ASSERT (GuidHob != NULL);
+  MmramRangesHob   = GET_GUID_HOB_DATA (GuidHob);
+  SecureCommBuffer = &MmramRangesHob->Descriptor[MMRAM_DESC_IDX_SECURE_SHARED_BUFFER];
+
+  mGuidedEventContextSize = sizeof (MISC_MM_COMMUNICATE_BUFFER);
+  mGuidedEventContextSize = MAX (NsCommBuffer->PhysicalSize, mGuidedEventContextSize);
+  mGuidedEventContextSize = MAX (SecureCommBuffer->PhysicalSize, mGuidedEventContextSize);
+
+  // Allocate memory to copy the communication buffer to the secure world.
+  Status = mMmst->MmAllocatePool (
+                    EfiRuntimeServicesData,
+                    mGuidedEventContextSize,
+                    (VOID **)&mGuidedEventContext
+                    );
+  if (EFI_ERROR (Status)) {
+    mGuidedEventContext = NULL;
+    DEBUG ((DEBUG_ERROR, "%a: Mem alloc failed\n", __func__));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  ZeroMem (mGuidedEventContext, mGuidedEventContextSize);
 
   // publish the MM config protocol so the MM core can register its entry point
   Status = mMmst->MmInstallProtocolInterface (
@@ -69,7 +106,7 @@ StandaloneMmCpuInitialize (
                     &mMmConfig
                     );
   if (EFI_ERROR (Status)) {
-    return Status;
+    goto ErrorHandler;
   }
 
   // Install  entry point of this CPU driver to allow
@@ -82,7 +119,7 @@ StandaloneMmCpuInitialize (
                     &mPiMmCpuDriverEpProtocol
                     );
   if (EFI_ERROR (Status)) {
-    return Status;
+    goto ErrorHandler;
   }
 
   // register the root MMI handler
@@ -92,8 +129,12 @@ StandaloneMmCpuInitialize (
                     &DispatchHandle
                     );
   if (EFI_ERROR (Status)) {
-    return Status;
+    goto ErrorHandler;
   }
 
+  return EFI_SUCCESS;
+
+ErrorHandler:
+  mMmst->MmFreePool ((VOID *)mGuidedEventContext);
   return Status;
 }

--- a/ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.h
+++ b/ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.h
@@ -31,6 +31,18 @@ extern EFI_MM_CPU_PROTOCOL  mMmCpuState;
 //
 extern EFI_MM_CONFIGURATION_PROTOCOL  mMmConfig;
 
+//
+// On ARM platforms every event is expected to have a GUID associated with
+// it. It will be used by the MM Entry point to find the handler for the
+// event. It will either be populated in a EFI_MM_COMMUNICATE_HEADER by the
+// caller of the event (e.g. MM_COMMUNICATE SMC) or by the CPU driver
+// (e.g. during an asynchronous event). In either case, this context is
+// maintained in single global variable because StandaloneMm is UP-migratable
+// (which means it cannot run concurrently)
+//
+extern EFI_MM_COMMUNICATE_HEADER  *mGuidedEventContext;
+extern UINT64                     mGuidedEventContextSize;
+
 /**
   The PI Standalone MM entry point for the CPU driver.
 

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
@@ -780,47 +780,94 @@ SetEventCompleteSvcArgs (
   if (CommProtocol == CommProtocolFfa) {
     FfaMsgInfo = CommData;
 
-    if (EFI_ERROR (Status)) {
-      EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_ERROR;
-
+    /*
+     * Once StandaloneMm is entered via FFA_SEND_DIRECT_MSG/MSGv2, it must
+     * return via FFA_SEND_DIRECT_RESP/RESPv2.
+     *
+     * For ServiceTypeMmCommunication, protocol errors are returned through
+     * the communication buffer, so the handler itself should return
+     * EFI_SUCCESS (See the MmiMange()). There are, however, a few failure
+     * cases outside the handler, such as when no matching service handler
+     * is found. In such cases, FFA_SEND_DIRECT_RESP/RESPv2 can be
+     * constructed as follows:
+     *
+     *  - FFA_SEND_DIRECT_RESP:
+     *    x0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP
+     *    x1 = Source/Dest Partition Id.
+     *    x2 = 0x00
+     *    x3 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE
+     *    x4 = ARM_SPM_MM_RET_*
+     *
+     *  - FFA_SEND_DIRECT_RESPv2:
+     *    x0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP
+     *    x1 = Source/Dest Partition Id.
+     *    x2 = 0x00 (SBZ)
+     *    x3 = 0x00 (SBZ)
+     *    x4 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE
+     *    x5 = ARM_SPM_MM_RET_*
+     *
+     * For ServiceTypeMisc, however, the response, including any protocol
+     * error code and arguments, is returned directly through FfaArgs.
+     * Therefore, the handler is responsible for constructing FfaArgs and
+     * should return EFI_SUCCESS.
+     *
+     * The SPMC does not forward requests for unknown services to StandaloneMm,
+     * and StandaloneMm is not initialized if any service handler fails to
+     * register. Therefore, a failure reported by a ServiceTypeMisc handler
+     * is unexpected.
+     *
+     * In such a case, there is no generic way to construct FfaArgs for
+     * FFA_SEND_DIRECT_RESP/RESPv2. Call CpuDeadLoop() rather than returning
+     * an invalid response.
+     */
+    if (FfaMsgInfo->DirectMsgVersion == DirectMsgV1) {
       /*
-       * StandaloneMm is secure instance. So set as 0x00.
+       * DirectMsgV1 is only used for ServiceTypeMmCommunication
        */
-      EventCompleteSvcArgs->Arg1 = 0x00;
-      EventCompleteSvcArgs->Arg2 = EfiStatusToFfaStatus (Status);
+      EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP;
+      EventCompleteSvcArgs->Arg3 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE;
+      EventCompleteSvcArgs->Arg4 = EfiStatusToSpmMmStatus (Status);
     } else {
-      if (FfaMsgInfo->DirectMsgVersion == DirectMsgV1) {
-        EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP;
-        EventCompleteSvcArgs->Arg3 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE;
-      } else {
-        EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP2;
+      EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP2;
 
-        if (FfaMsgInfo->ServiceType == ServiceTypeMisc) {
-          EventCompleteSvcArgs->Arg4  = mMiscMmCommunicateBuffer->FfaArgs.Arg4;
-          EventCompleteSvcArgs->Arg5  = mMiscMmCommunicateBuffer->FfaArgs.Arg5;
-          EventCompleteSvcArgs->Arg6  = mMiscMmCommunicateBuffer->FfaArgs.Arg6;
-          EventCompleteSvcArgs->Arg7  = mMiscMmCommunicateBuffer->FfaArgs.Arg7;
-          EventCompleteSvcArgs->Arg8  = mMiscMmCommunicateBuffer->FfaArgs.Arg8;
-          EventCompleteSvcArgs->Arg9  = mMiscMmCommunicateBuffer->FfaArgs.Arg9;
-          EventCompleteSvcArgs->Arg10 = mMiscMmCommunicateBuffer->FfaArgs.Arg10;
-          EventCompleteSvcArgs->Arg11 = mMiscMmCommunicateBuffer->FfaArgs.Arg11;
-          EventCompleteSvcArgs->Arg12 = mMiscMmCommunicateBuffer->FfaArgs.Arg12;
-          EventCompleteSvcArgs->Arg13 = mMiscMmCommunicateBuffer->FfaArgs.Arg13;
-          EventCompleteSvcArgs->Arg14 = mMiscMmCommunicateBuffer->FfaArgs.Arg14;
-          EventCompleteSvcArgs->Arg15 = mMiscMmCommunicateBuffer->FfaArgs.Arg15;
-          EventCompleteSvcArgs->Arg16 = mMiscMmCommunicateBuffer->FfaArgs.Arg16;
-          EventCompleteSvcArgs->Arg17 = mMiscMmCommunicateBuffer->FfaArgs.Arg17;
+      if (FfaMsgInfo->ServiceType == ServiceTypeMisc) {
+        /*
+         * See above comment.
+         */
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "Error: ServiceTypeMisc, Status: %r\n", Status));
+          ASSERT (0);
+          CpuDeadLoop ();
         }
-      }
 
-      /*
-       * Swap source & dest partition id.
-       */
-      EventCompleteSvcArgs->Arg1 = PACK_PARTITION_ID_INFO (
-                                     FfaMsgInfo->DestPartId,
-                                     FfaMsgInfo->SourcePartId
-                                     );
+        EventCompleteSvcArgs->Arg4  = mMiscMmCommunicateBuffer->FfaArgs.Arg4;
+        EventCompleteSvcArgs->Arg5  = mMiscMmCommunicateBuffer->FfaArgs.Arg5;
+        EventCompleteSvcArgs->Arg6  = mMiscMmCommunicateBuffer->FfaArgs.Arg6;
+        EventCompleteSvcArgs->Arg7  = mMiscMmCommunicateBuffer->FfaArgs.Arg7;
+        EventCompleteSvcArgs->Arg8  = mMiscMmCommunicateBuffer->FfaArgs.Arg8;
+        EventCompleteSvcArgs->Arg9  = mMiscMmCommunicateBuffer->FfaArgs.Arg9;
+        EventCompleteSvcArgs->Arg10 = mMiscMmCommunicateBuffer->FfaArgs.Arg10;
+        EventCompleteSvcArgs->Arg11 = mMiscMmCommunicateBuffer->FfaArgs.Arg11;
+        EventCompleteSvcArgs->Arg12 = mMiscMmCommunicateBuffer->FfaArgs.Arg12;
+        EventCompleteSvcArgs->Arg13 = mMiscMmCommunicateBuffer->FfaArgs.Arg13;
+        EventCompleteSvcArgs->Arg14 = mMiscMmCommunicateBuffer->FfaArgs.Arg14;
+        EventCompleteSvcArgs->Arg15 = mMiscMmCommunicateBuffer->FfaArgs.Arg15;
+        EventCompleteSvcArgs->Arg16 = mMiscMmCommunicateBuffer->FfaArgs.Arg16;
+        EventCompleteSvcArgs->Arg17 = mMiscMmCommunicateBuffer->FfaArgs.Arg17;
+      } else {
+        // ServiceTypeMmCommunication
+        EventCompleteSvcArgs->Arg4 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE;
+        EventCompleteSvcArgs->Arg5 = EfiStatusToSpmMmStatus (Status);
+      }
     }
+
+    /*
+     * Swap source & dest partition id.
+     */
+    EventCompleteSvcArgs->Arg1 = PACK_PARTITION_ID_INFO (
+                                   FfaMsgInfo->DestPartId,
+                                   FfaMsgInfo->SourcePartId
+                                   );
   } else {
     EventCompleteSvcArgs->Arg0 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE;
     EventCompleteSvcArgs->Arg1 = EfiStatusToSpmMmStatus (Status);


### PR DESCRIPTION
# Description
    
There is a known issue [0] where the SPMC repeatedly re-enters
Standalone MM with FFA_ERROR after Standalone MM returns FFA_ERROR
because it failed to locate an MMI handler for an MM communication
request.
    
Although the FF-A specification does not currently clarify this
behavior, it is expected to be updated. Once Standalone MM is entered
through FFA_MSG_SEND_DIRECT_REQ or FFA_MSG_SEND_DIRECT_REQ2, it must
return through FFA_MSG_SEND_DIRECT_RESP or FFA_MSG_SEND_DIRECT_RESP2,
respectively.
    
Therefore, do not return FFA_ERROR after Standalone MM has been entered
through a direct request.
    
Standalone MM handles two types of services received through direct
requests: ServiceTypeMmCommunication and ServiceTypeMisc.
    
For ServiceTypeMmCommunication, protocol errors are returned through
the communication buffer, so the handler itself should return
EFI_SUCCESS. However, failures may occur outside the handler, such as
when no matching MMI handler can be found. In these cases, construct the
direct response as follows:
    
  - FFA_MSG_SEND_DIRECT_RESP:
      x0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP
      x1 = Source/destination partition IDs
      x2 = 0x00
      x3 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE
      x4 = ARM_SPM_MM_RET_*
    
  - FFA_MSG_SEND_DIRECT_RESP2:
      x0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP2
      x1 = Source/destination partition IDs
      x2 = 0x00 (SBZ)
      x3 = 0x00 (SBZ)
      x4 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE
      x5 = ARM_SPM_MM_RET_*
    
Although this convention is not formally documented, it has been used
since edk2 commit 388dfe02fb9a ("StandaloneMmPkg: Add option to use...").
    
For ServiceTypeMisc, the handler returns the complete response,
including any protocol-specific error code and arguments, directly
through FfaArgs. The handler is therefore responsible for constructing
FfaArgs and should return EFI_SUCCESS.
    
All ServiceTypeMisc handlers are registered during Standalone MM
initialization, and initialization fails if any handler cannot be
registered. A failure returned by a ServiceTypeMisc handler is therefore
unexpected.
    
There is no generic way to construct FfaArgs for a direct response in
this situation. Call CpuDeadLoop() instead of returning an invalid
response including small fixes.

Resolve: https://github.com/tianocore/edk2/issues/12646#issuecomment-5523596676 [0]

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Tested on FVP RevC with SPMC_AT_EL3.

## Integration Instructions

N/A

