### PR TITLE
BaseTools/GenFds: Honor FDF section macro scope

### DIFF
--- a/BaseTools/Source/Python/GenFds/FdfParser.py
+++ b/BaseTools/Source/Python/GenFds/FdfParser.py
@@ -484,6 +484,148 @@ class FdfParser:
         elif len(ItemList) > 0:
             self._CurSection = [ItemList[0], 'DUMMY', TAB_COMMON]
 
+    def _IsTokenAtStartOfLine(self):
+        TokenStart = self.CurrentOffsetWithinLine - len(self._Token)
+        return not "".join(self._CurrentLine()[:TokenStart]).strip()
+
+    def _GetPreprocessorMacroValue(self, Macro, LocalMacroDict = None):
+        if LocalMacroDict is None:
+            return self._GetMacroValue(Macro)
+
+        MacroValue = GlobalData.gPlatformDefines.get(Macro)
+        CommonMacros = LocalMacroDict.get((TAB_COMMON, TAB_COMMON, TAB_COMMON))
+        if CommonMacros and Macro in CommonMacros:
+            MacroValue = CommonMacros[Macro]
+        SectionMacros = LocalMacroDict.get(tuple(self._CurSection))
+        if SectionMacros and Macro in SectionMacros:
+            MacroValue = SectionMacros[Macro]
+        if Macro in GlobalData.gGlobalDefines:
+            MacroValue = GlobalData.gGlobalDefines[Macro]
+        if Macro in GlobalData.gCommandLineDefines:
+            MacroValue = GlobalData.gCommandLineDefines[Macro]
+        return MacroValue
+
+    @staticmethod
+    def _MergeConditionalMacroDict(TargetMacroDict, SourceMacroDict):
+        for Scope, Macros in SourceMacroDict.items():
+            TargetMacroDict.setdefault(Scope, {}).update(Macros)
+
+    @staticmethod
+    def _GetConditionalMacroDict(MacroDict, IfList):
+        ConditionalMacroDict = {
+            Scope: Macros.copy() for Scope, Macros in MacroDict.items()
+        }
+        for Item in IfList:
+            FdfParser._MergeConditionalMacroDict(ConditionalMacroDict, Item[3])
+        return ConditionalMacroDict
+
+    def _ExpandPreprocessorMacros(
+        self,
+        Text,
+        LocalMacroDict = None,
+        RequireDefined = False,
+    ):
+        ResolvedMacros = {}
+        ActiveMacros = set()
+        ExpansionStack = [[None, Text, 0]]
+
+        while ExpansionStack:
+            Macro, ExpandedText, PreIndex = ExpansionStack[-1]
+            StartPos = ExpandedText.find('$(', PreIndex)
+            EndPos = ExpandedText.find(')', StartPos + 2)
+            if StartPos == -1 or EndPos == -1:
+                ExpansionStack.pop()
+                if Macro is None:
+                    return ExpandedText
+                ActiveMacros.remove(Macro)
+                ResolvedMacros[Macro] = ExpandedText
+                continue
+
+            NestedMacro = ExpandedText[StartPos + 2:EndPos]
+            if NestedMacro in ResolvedMacros:
+                MacroValue = ResolvedMacros[NestedMacro]
+                ExpansionStack[-1][1] = (
+                    ExpandedText[:StartPos] + MacroValue + ExpandedText[EndPos + 1:]
+                )
+                ExpansionStack[-1][2] = StartPos + len(MacroValue)
+                continue
+
+            MacroValue = self._GetPreprocessorMacroValue(NestedMacro, LocalMacroDict)
+            if MacroValue is None:
+                if RequireDefined:
+                    raise Warning(
+                        "The Macro %s is not defined" % NestedMacro,
+                        self.FileName,
+                        self.CurrentLineNumber,
+                    )
+                ExpansionStack[-1][2] = EndPos + 1
+                continue
+
+            if NestedMacro in ActiveMacros:
+                raise Warning(
+                    "Cyclic macro expansion",
+                    self.FileName,
+                    self.CurrentLineNumber,
+                )
+            ActiveMacros.add(NestedMacro)
+            ExpansionStack.append([NestedMacro, MacroValue, 0])
+
+        return Text
+
+    def _RejectMacroGeneratedDirective(self, LocalMacroDict = None):
+        OriginalLine = "".join(self._CurrentLine())
+        ExpandedLine = self._ExpandPreprocessorMacros(OriginalLine, LocalMacroDict)
+
+        OriginalTokens = OriginalLine.lstrip().split(maxsplit=1)
+        ExpandedTokens = ExpandedLine.lstrip().split(maxsplit=1)
+        OriginalToken = OriginalTokens[0].lower() if OriginalTokens else ''
+        ExpandedToken = ExpandedTokens[0].lower() if ExpandedTokens else ''
+        Directives = {
+            TAB_DEFINE.lower(),
+            'set',
+            TAB_INCLUDE,
+            TAB_IF,
+            TAB_IF_DEF,
+            TAB_IF_N_DEF,
+            TAB_ELSE_IF,
+            TAB_ELSE,
+            TAB_END_IF,
+            TAB_ERROR.lower(),
+        }
+        OriginalIsDirective = (
+            OriginalToken.startswith(TAB_SECTION_START) or OriginalToken in Directives
+        )
+        ExpandedIsDirective = (
+            ExpandedToken.startswith(TAB_SECTION_START) or ExpandedToken in Directives
+        )
+        if not OriginalIsDirective and ExpandedIsDirective:
+            raise Warning(
+                "macro expansion cannot generate a section header or preprocessing directive",
+                self.FileName,
+                self.CurrentLineNumber,
+            )
+
+    def _TryParseSectionHeader(self):
+        if (
+            not self._Token.startswith(TAB_SECTION_START)
+            or not self._IsTokenAtStartOfLine()
+        ):
+            return False
+
+        Header = self._Token
+        if not Header.endswith(TAB_SECTION_END):
+            RemainingLine = "".join(self._CurrentLine()[self.CurrentOffsetWithinLine:])
+            EndOffset = RemainingLine.find(TAB_SECTION_END)
+            if EndOffset == -1:
+                raise Warning.ExpectedBracketClose(self.FileName, self.CurrentLineNumber)
+            Header += RemainingLine[:EndOffset + 1]
+            self.CurrentOffsetWithinLine += EndOffset + 1
+
+        if Header.find('$(') != -1:
+            raise Warning("macro cannot be used in section header", self.FileName, self.CurrentLineNumber)
+        self._SectionHeaderParser(Header)
+        return True
+
     ## PreprocessFile() method
     #
     #   Preprocess file contents, replace comments with spaces.
@@ -558,44 +700,123 @@ class FdfParser:
     def PreprocessIncludeFile(self):
       # nested include support
         Processed = False
+        self._CurSection = []
         MacroDict = {}
+        PcdDict = {}
+        RegionLayoutLine = 0
+        IfList = []
         while self._GetNextToken():
 
-            if self._Token == TAB_DEFINE:
+            AtLineStart = self._IsTokenAtStartOfLine()
+            if AtLineStart and self._Token in {TAB_IF_DEF, TAB_IF_N_DEF, TAB_IF}:
+                ConditionalMacroDict = self._GetConditionalMacroDict(MacroDict, IfList)
+                DirectiveLine = self.CurrentLineNumber
+                CondLabel = self._Token
+                Expression = self._GetExpression()
+                if CondLabel == TAB_IF:
+                    ConditionSatisfied = self._EvaluateConditional(
+                        Expression,
+                        DirectiveLine,
+                        'eval',
+                        LocalMacroDict=ConditionalMacroDict,
+                        LocalPcdDict=PcdDict,
+                    )
+                else:
+                    ConditionSatisfied = self._EvaluateConditional(
+                        Expression,
+                        DirectiveLine,
+                        'in',
+                        LocalMacroDict=ConditionalMacroDict,
+                        LocalPcdDict=PcdDict,
+                    )
+                    if CondLabel == TAB_IF_N_DEF:
+                        ConditionSatisfied = not ConditionSatisfied
+                IfList.append([None, ConditionSatisfied, ConditionSatisfied, {}])
+                continue
+
+            if AtLineStart and self._Token in {TAB_ELSE_IF, TAB_ELSE}:
+                if not IfList:
+                    raise Warning("Missing !if statement", self.FileName, self.CurrentLineNumber)
+                if IfList[-1][1] and len(IfList) > 1:
+                    self._MergeConditionalMacroDict(IfList[-2][3], IfList[-1][3])
+                IfList[-1][3] = {}
+                ConditionalMacroDict = self._GetConditionalMacroDict(MacroDict, IfList)
+                if IfList[-1][1] or IfList[-1][2]:
+                    IfList[-1][1] = False
+                else:
+                    ConditionSatisfied = True
+                    if self._Token == TAB_ELSE_IF:
+                        Expression = self._GetExpression()
+                        ConditionSatisfied = self._EvaluateConditional(
+                            Expression,
+                            self.CurrentLineNumber,
+                            'eval',
+                            LocalMacroDict=ConditionalMacroDict,
+                            LocalPcdDict=PcdDict,
+                        )
+                    IfList[-1][1] = ConditionSatisfied
+                    IfList[-1][2] = ConditionSatisfied
+                continue
+
+            if AtLineStart and self._Token == TAB_END_IF:
+                if not IfList:
+                    raise Warning("Missing !if statement", self.FileName, self.CurrentLineNumber)
+                CompletedIf = IfList.pop()
+                if CompletedIf[1] and IfList:
+                    self._MergeConditionalMacroDict(IfList[-1][3], CompletedIf[3])
+                continue
+
+            Active = self._GetIfListCurrentItemStat(IfList)
+            if Active and AtLineStart and self._Token.startswith('$('):
+                ConditionalMacroDict = self._GetConditionalMacroDict(MacroDict, IfList)
+                self._RejectMacroGeneratedDirective(ConditionalMacroDict)
+            if Active and self._TryParseSectionHeader():
+                continue
+
+            if AtLineStart and self._Token == TAB_DEFINE:
                 if not self._GetNextToken():
                     raise Warning.Expected("Macro name", self.FileName, self.CurrentLineNumber)
                 Macro = self._Token
                 if not self._IsToken(TAB_EQUAL_SPLIT):
                     raise Warning.ExpectedEquals(self.FileName, self.CurrentLineNumber)
                 Value = self._GetExpression()
-                MacroDict[Macro] = Value
+                if Active:
+                    TargetMacroDict = MacroDict
+                else:
+                    TargetMacroDict = IfList[-1][3]
+                TargetMacroDict.setdefault(tuple(self._CurSection), {})[Macro] = Value
 
-            elif self._Token == TAB_INCLUDE:
+            elif AtLineStart and self._Token == 'SET':
+                if not Active:
+                    continue
+                PcdPair = self._GetNextPcdSettings()
+                PcdName = "%s.%s" % (PcdPair[1], PcdPair[0])
+                if not self._IsToken(TAB_EQUAL_SPLIT):
+                    raise Warning.ExpectedEquals(self.FileName, self.CurrentLineNumber)
+                Value = self._GetExpression()
+                ConditionalMacroDict = self._GetConditionalMacroDict(MacroDict, IfList)
+                Value = self._EvaluateConditional(
+                    Value,
+                    self.CurrentLineNumber,
+                    'eval',
+                    True,
+                    ConditionalMacroDict,
+                    PcdDict,
+                )
+                PcdDict[PcdName] = Value
+
+            elif AtLineStart and self._Token == TAB_INCLUDE:
+                ConditionalMacroDict = self._GetConditionalMacroDict(MacroDict, IfList)
                 Processed = True
                 IncludeLine = self.CurrentLineNumber
                 IncludeOffset = self.CurrentOffsetWithinLine - len(TAB_INCLUDE)
                 if not self._GetNextToken():
                     raise Warning.Expected("include file name", self.FileName, self.CurrentLineNumber)
-                IncFileName = self._Token
-                PreIndex = 0
-                StartPos = IncFileName.find('$(', PreIndex)
-                EndPos = IncFileName.find(')', StartPos+2)
-                while StartPos != -1 and EndPos != -1:
-                    Macro = IncFileName[StartPos+2: EndPos]
-                    MacroVal = self._GetMacroValue(Macro)
-                    if not MacroVal:
-                        if Macro in MacroDict:
-                            MacroVal = MacroDict[Macro]
-                    if MacroVal is not None:
-                        IncFileName = IncFileName.replace('$(' + Macro + ')', MacroVal, 1)
-                        if MacroVal.find('$(') != -1:
-                            PreIndex = StartPos
-                        else:
-                            PreIndex = StartPos + len(MacroVal)
-                    else:
-                        raise Warning("The Macro %s is not defined" %Macro, self.FileName, self.CurrentLineNumber)
-                    StartPos = IncFileName.find('$(', PreIndex)
-                    EndPos = IncFileName.find(')', StartPos+2)
+                IncFileName = self._ExpandPreprocessorMacros(
+                    self._Token,
+                    ConditionalMacroDict,
+                    True,
+                )
 
                 IncludedFile = NormPath(IncFileName)
                 #
@@ -631,6 +852,17 @@ class FdfParser:
 
                 CurrentLine = self.CurrentLineNumber
                 CurrentOffset = self.CurrentOffsetWithinLine
+                if IncFileProfile.FileLinesList:
+                    CurrentProfile = self.Profile
+                    try:
+                        self.Profile = IncFileProfile
+                        self._StringToList()
+                        self.PreprocessFile()
+                        # Remove the EOF sentinel before inserting these lines into the parent.
+                        IncFileProfile.FileLinesList[-1] = IncFileProfile.FileLinesList[-1][:-1]
+                    finally:
+                        self.Profile = CurrentProfile
+                        self.Rewind(CurrentLine, CurrentOffset)
                 # list index of the insertion, note that line number is 'CurrentLine + 1'
                 InsertAtLine = CurrentLine
                 ParentProfile = GetParentAtLine (CurrentLine)
@@ -659,10 +891,20 @@ class FdfParser:
                 TempList = list(self.Profile.FileLinesList[IncludeLine - 1])
                 TempList.insert(IncludeOffset, TAB_COMMENT_SPLIT)
                 self.Profile.FileLinesList[IncludeLine - 1] = ''.join(TempList)
+            elif not IfList:
+                ConditionalMacroDict = self._GetConditionalMacroDict(MacroDict, IfList)
+                RegionLayoutLine = self._CollectRegionPcd(
+                    PcdDict,
+                    RegionLayoutLine,
+                    ConditionalMacroDict,
+                )
             if Processed: # Nested and back-to-back support
                 self.Rewind(DestLine = IncFileProfile.InsertStartLineNumber - 1)
                 Processed = False
+        if IfList:
+            raise Warning("Missing !endif", self.FileName, self.CurrentLineNumber)
         # Preprocess done.
+        self._CurSection = []
         self.Rewind()
 
     @staticmethod
@@ -675,6 +917,29 @@ class FdfParser:
                 return False
 
         return True
+
+    def _CollectRegionPcd(self, PcdDict, RegionLayoutLine, LocalMacroDict = None):
+        if self.CurrentLineNumber <= RegionLayoutLine:
+            return RegionLayoutLine
+        CurrentLine = self.Profile.FileLinesList[self.CurrentLineNumber - 1]
+        if LocalMacroDict is not None:
+            CurrentLine = self._ExpandPreprocessorMacros(CurrentLine, LocalMacroDict)
+        SetPcd = ShortcutPcdPattern.match(CurrentLine)
+        if SetPcd:
+            PcdDict[SetPcd.group('name')] = SetPcd.group('value')
+            return self.CurrentLineNumber
+        RegionSize = RegionSizePattern.match(CurrentLine)
+        if not RegionSize:
+            return self.CurrentLineNumber
+        if self.CurrentLineNumber >= len(self.Profile.FileLinesList):
+            return self.CurrentLineNumber + 1
+        NextLine = self.Profile.FileLinesList[self.CurrentLineNumber]
+        RegionSizeGuid = RegionSizeGuidPattern.match(NextLine)
+        if not RegionSizeGuid:
+            return self.CurrentLineNumber + 1
+        PcdDict[RegionSizeGuid.group('base')] = RegionSize.group('base')
+        PcdDict[RegionSizeGuid.group('size')] = RegionSize.group('size')
+        return self.CurrentLineNumber + 1
 
     ## PreprocessConditionalStatement() method
     #
@@ -689,42 +954,24 @@ class FdfParser:
         RegionLayoutLine = 0
         ReplacedLine = -1
         while self._GetNextToken():
+            AtLineStart = self._IsTokenAtStartOfLine()
             # Determine section name and the location dependent macro
             if self._GetIfListCurrentItemStat(IfList):
-                if self._Token.startswith(TAB_SECTION_START):
-                    Header = self._Token
-                    if not self._Token.endswith(TAB_SECTION_END):
-                        self._SkipToToken(TAB_SECTION_END)
-                        Header += self._SkippedChars
-                    if Header.find('$(') != -1:
-                        raise Warning("macro cannot be used in section header", self.FileName, self.CurrentLineNumber)
-                    self._SectionHeaderParser(Header)
+                if AtLineStart and self._Token.startswith('$('):
+                    self._RejectMacroGeneratedDirective()
+                if self._TryParseSectionHeader():
                     continue
                 # Replace macros except in RULE section or out of section
                 elif self._CurSection and ReplacedLine != self.CurrentLineNumber:
                     ReplacedLine = self.CurrentLineNumber
                     self._UndoToken()
                     CurLine = self.Profile.FileLinesList[ReplacedLine - 1]
-                    PreIndex = 0
-                    StartPos = CurLine.find('$(', PreIndex)
-                    EndPos = CurLine.find(')', StartPos+2)
-                    while StartPos != -1 and EndPos != -1 and self._Token not in {TAB_IF_DEF, TAB_IF_N_DEF, TAB_IF, TAB_ELSE_IF}:
-                        MacroName = CurLine[StartPos+2: EndPos]
-                        MacroValue = self._GetMacroValue(MacroName)
-                        if MacroValue is not None:
-                            CurLine = CurLine.replace('$(' + MacroName + ')', MacroValue, 1)
-                            if MacroValue.find('$(') != -1:
-                                PreIndex = StartPos
-                            else:
-                                PreIndex = StartPos + len(MacroValue)
-                        else:
-                            PreIndex = EndPos + 1
-                        StartPos = CurLine.find('$(', PreIndex)
-                        EndPos = CurLine.find(')', StartPos+2)
+                    if self._Token not in {TAB_IF_DEF, TAB_IF_N_DEF, TAB_IF, TAB_ELSE_IF}:
+                        CurLine = self._ExpandPreprocessorMacros(CurLine)
                     self.Profile.FileLinesList[ReplacedLine - 1] = CurLine
                     continue
 
-            if self._Token == TAB_DEFINE:
+            if AtLineStart and self._Token == TAB_DEFINE:
                 if self._GetIfListCurrentItemStat(IfList):
                     if not self._CurSection:
                         raise Warning("macro cannot be defined in Rule section or out of section", self.FileName, self.CurrentLineNumber)
@@ -739,7 +986,7 @@ class FdfParser:
                     Value = self._GetExpression()
                     self._SetMacroValue(Macro, Value)
                     self._WipeOffArea.append(((DefineLine, DefineOffset), (self.CurrentLineNumber - 1, self.CurrentOffsetWithinLine - 1)))
-            elif self._Token == 'SET':
+            elif AtLineStart and self._Token == 'SET':
                 if not self._GetIfListCurrentItemStat(IfList):
                     continue
                 SetLine = self.CurrentLineNumber - 1
@@ -760,7 +1007,7 @@ class FdfParser:
                 self.Profile.PcdFileLineDict[PcdPair] = FileLineTuple
 
                 self._WipeOffArea.append(((SetLine, SetOffset), (self.CurrentLineNumber - 1, self.CurrentOffsetWithinLine - 1)))
-            elif self._Token in {TAB_IF_DEF, TAB_IF_N_DEF, TAB_IF}:
+            elif AtLineStart and self._Token in {TAB_IF_DEF, TAB_IF_N_DEF, TAB_IF}:
                 IfStartPos = (self.CurrentLineNumber - 1, self.CurrentOffsetWithinLine - len(self._Token))
                 IfList.append([IfStartPos, None, None])
 
@@ -778,7 +1025,7 @@ class FdfParser:
                 IfList[-1] = [IfList[-1][0], ConditionSatisfied, BranchDetermined]
                 if ConditionSatisfied:
                     self._WipeOffArea.append((IfList[-1][0], (self.CurrentLineNumber - 1, self.CurrentOffsetWithinLine - 1)))
-            elif self._Token in {TAB_ELSE_IF, TAB_ELSE}:
+            elif AtLineStart and self._Token in {TAB_ELSE_IF, TAB_ELSE}:
                 ElseStartPos = (self.CurrentLineNumber - 1, self.CurrentOffsetWithinLine - len(self._Token))
                 if len(IfList) <= 0:
                     raise Warning("Missing !if statement", self.FileName, self.CurrentLineNumber)
@@ -800,7 +1047,7 @@ class FdfParser:
                         else:
                             IfList[-1][2] = True
                             self._WipeOffArea.append((IfList[-1][0], (self.CurrentLineNumber - 1, self.CurrentOffsetWithinLine - 1)))
-            elif self._Token == '!endif':
+            elif AtLineStart and self._Token == TAB_END_IF:
                 if len(IfList) <= 0:
                     raise Warning("Missing !if statement", self.FileName, self.CurrentLineNumber)
                 if IfList[-1][1]:
@@ -810,52 +1057,43 @@ class FdfParser:
 
                 IfList.pop()
             elif not IfList:    # Don't use PCDs inside conditional directive
-                if self.CurrentLineNumber <= RegionLayoutLine:
-                    # Don't try the same line twice
-                    continue
-                SetPcd = ShortcutPcdPattern.match(self.Profile.FileLinesList[self.CurrentLineNumber - 1])
-                if SetPcd:
-                    self._PcdDict[SetPcd.group('name')] = SetPcd.group('value')
-                    RegionLayoutLine = self.CurrentLineNumber
-                    continue
-                RegionSize = RegionSizePattern.match(self.Profile.FileLinesList[self.CurrentLineNumber - 1])
-                if not RegionSize:
-                    RegionLayoutLine = self.CurrentLineNumber
-                    continue
-                RegionSizeGuid = RegionSizeGuidPattern.match(self.Profile.FileLinesList[self.CurrentLineNumber])
-                if not RegionSizeGuid:
-                    RegionLayoutLine = self.CurrentLineNumber + 1
-                    continue
-                self._PcdDict[RegionSizeGuid.group('base')] = RegionSize.group('base')
-                self._PcdDict[RegionSizeGuid.group('size')] = RegionSize.group('size')
-                RegionLayoutLine = self.CurrentLineNumber + 1
+                RegionLayoutLine = self._CollectRegionPcd(self._PcdDict, RegionLayoutLine)
 
         if IfList:
             raise Warning("Missing !endif", self.FileName, self.CurrentLineNumber)
         self.Rewind()
 
-    def _CollectMacroPcd(self):
+    def _CollectMacroPcd(self, LocalMacroDict = None, LocalPcdDict = None):
         MacroDict = {}
 
         # PCD macro
         MacroDict.update(GlobalData.gPlatformPcds)
-        MacroDict.update(self._PcdDict)
+        if LocalPcdDict is None:
+            MacroDict.update(self._PcdDict)
+        else:
+            MacroDict.update(LocalPcdDict)
 
         # Lowest priority
         MacroDict.update(GlobalData.gPlatformDefines)
 
         if self._CurSection:
             # Defines macro
-            ScopeMacro = self._MacroDict[TAB_COMMON, TAB_COMMON, TAB_COMMON]
+            if LocalMacroDict is None:
+                ScopeMacro = self._MacroDict[TAB_COMMON, TAB_COMMON, TAB_COMMON]
+            else:
+                ScopeMacro = LocalMacroDict.get((TAB_COMMON, TAB_COMMON, TAB_COMMON))
             if ScopeMacro:
                 MacroDict.update(ScopeMacro)
 
             # Section macro
-            ScopeMacro = self._MacroDict[
-                        self._CurSection[0],
-                        self._CurSection[1],
-                        self._CurSection[2]
-            ]
+            if LocalMacroDict is None:
+                ScopeMacro = self._MacroDict[
+                            self._CurSection[0],
+                            self._CurSection[1],
+                            self._CurSection[2]
+                ]
+            else:
+                ScopeMacro = LocalMacroDict.get(tuple(self._CurSection))
             if ScopeMacro:
                 MacroDict.update(ScopeMacro)
 
@@ -871,8 +1109,16 @@ class FdfParser:
 
         return MacroDict
 
-    def _EvaluateConditional(self, Expression, Line, Op = None, Value = None):
-        MacroPcdDict = self._CollectMacroPcd()
+    def _EvaluateConditional(
+        self,
+        Expression,
+        Line,
+        Op = None,
+        Value = None,
+        LocalMacroDict = None,
+        LocalPcdDict = None,
+    ):
+        MacroPcdDict = self._CollectMacroPcd(LocalMacroDict, LocalPcdDict)
         if Op == 'eval':
             try:
                 if Value:

--- a/BaseTools/Tests/FdfParserTests.py
+++ b/BaseTools/Tests/FdfParserTests.py
@@ -1,0 +1,632 @@
+## @file
+# Unit tests for FDF parser macro scope handling.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+import os
+import tempfile
+import unittest
+
+from Common import GlobalData
+from Common.MultipleWorkspace import MultipleWorkspace
+import GenFds.FdfParser as FdfParserModule
+from GenFds.FdfParser import FdfParser, Warning
+from GenFds.GenFdsGlobalVariable import GenFdsGlobalVariable
+
+
+class FdfParserMacroScopeTests(unittest.TestCase):
+    def setUp(self):
+        self._saved_global_defines = GlobalData.gGlobalDefines
+        self._saved_platform_defines = GlobalData.gPlatformDefines
+        self._saved_command_line_defines = GlobalData.gCommandLineDefines
+        self._saved_platform_pcds = GlobalData.gPlatformPcds
+        self._saved_active_platform = GlobalData.gActivePlatform
+        self._saved_fdf_parser = GlobalData.gFdfParser
+        self._saved_global_workspace = GlobalData.gWorkspace
+        self._saved_workspace = MultipleWorkspace.WORKSPACE
+        self._saved_packages_path = MultipleWorkspace.PACKAGES_PATH
+        self._saved_workspace_dir = GenFdsGlobalVariable.WorkSpaceDir
+        self._saved_genfds_active_platform = GenFdsGlobalVariable.ActivePlatform
+        self._saved_include_file_list = FdfParserModule.AllIncludeFileList[:]
+
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        GlobalData.gGlobalDefines = {}
+        GlobalData.gPlatformDefines = {}
+        GlobalData.gCommandLineDefines = {}
+        GlobalData.gPlatformPcds = {}
+        GlobalData.gActivePlatform = None
+        GlobalData.gWorkspace = self._temporary_directory.name
+        MultipleWorkspace.setWs(self._temporary_directory.name)
+        GenFdsGlobalVariable.WorkSpaceDir = self._temporary_directory.name
+        GenFdsGlobalVariable.ActivePlatform = None
+        FdfParserModule.AllIncludeFileList.clear()
+
+    def tearDown(self):
+        GlobalData.gGlobalDefines = self._saved_global_defines
+        GlobalData.gPlatformDefines = self._saved_platform_defines
+        GlobalData.gCommandLineDefines = self._saved_command_line_defines
+        GlobalData.gPlatformPcds = self._saved_platform_pcds
+        GlobalData.gActivePlatform = self._saved_active_platform
+        GlobalData.gFdfParser = self._saved_fdf_parser
+        GlobalData.gWorkspace = self._saved_global_workspace
+        MultipleWorkspace.WORKSPACE = self._saved_workspace
+        MultipleWorkspace.PACKAGES_PATH = self._saved_packages_path
+        GenFdsGlobalVariable.WorkSpaceDir = self._saved_workspace_dir
+        GenFdsGlobalVariable.ActivePlatform = self._saved_genfds_active_platform
+        FdfParserModule.AllIncludeFileList[:] = self._saved_include_file_list
+        self._temporary_directory.cleanup()
+
+    def _write_file(self, relative_path, content):
+        path = os.path.join(self._temporary_directory.name, relative_path)
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        with open(path, "w", newline="\n") as output_file:
+            output_file.write(content)
+        return path
+
+    def _preprocess(self, fdf_content, included_files):
+        for relative_path, content in included_files.items():
+            self._write_file(relative_path, content)
+
+        fdf_path = self._write_file("Test.fdf", fdf_content)
+        parser = FdfParser(fdf_path)
+        parser.Preprocess()
+        return "".join(parser.Profile.FileLinesList)
+
+    def test_local_macro_expands_include_in_same_section(self):
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "DEFINE LOCAL = SameSection\n"
+            "!include $(LOCAL).inc\n",
+            {"SameSection.inc": "SAME_SECTION_MARKER\n"},
+        )
+
+        self.assertIn("SAME_SECTION_MARKER", result)
+
+    def test_local_macro_is_undefined_in_later_section(self):
+        with self.assertRaisesRegex(Warning, "The Macro LOCAL is not defined"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "DEFINE LOCAL = Leaked\n"
+                "\n"
+                "[FV.SECOND]\n"
+                "!include $(LOCAL).inc\n",
+                {"Leaked.inc": "LEAKED_INCLUDE_MARKER\n"},
+            )
+
+    def test_defines_macro_expands_in_multiple_sections(self):
+        result = self._preprocess(
+            "[Defines]\n"
+            "DEFINE SHARED = Shared\n"
+            "\n"
+            "[FV.FIRST]\n"
+            "!include $(SHARED).inc\n"
+            "\n"
+            "[FV.SECOND]\n"
+            "!include $(SHARED).inc\n",
+            {"Shared.inc": "SHARED_MARKER\n"},
+        )
+
+        self.assertEqual(2, result.count("SHARED_MARKER"))
+
+    def test_local_macros_resolve_independently_by_section(self):
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "DEFINE LOCAL = First\n"
+            "!include $(LOCAL).inc\n"
+            "\n"
+            "[FV.SECOND]\n"
+            "DEFINE LOCAL = Second\n"
+            "!include $(LOCAL).inc\n",
+            {
+                "First.inc": "FIRST_MARKER\n",
+                "Second.inc": "SECOND_MARKER\n",
+            },
+        )
+
+        self.assertEqual(1, result.count("FIRST_MARKER"))
+        self.assertEqual(1, result.count("SECOND_MARKER"))
+
+    def test_nested_include_uses_active_section_macro(self):
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "DEFINE LOCAL = Nested\n"
+            "!include Outer.inc\n",
+            {
+                "Outer.inc": "!include $(LOCAL).inc\n",
+                "Nested.inc": "NESTED_MARKER\n",
+            },
+        )
+
+        self.assertIn("NESTED_MARKER", result)
+
+    def test_command_line_macro_overrides_local_macro(self):
+        GlobalData.gCommandLineDefines = {"LOCAL": "CommandLine"}
+
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "DEFINE LOCAL = Local\n"
+            "!include $(LOCAL).inc\n",
+            {
+                "CommandLine.inc": "COMMAND_LINE_MARKER\n",
+                "Local.inc": "LOCAL_MARKER\n",
+            },
+        )
+
+        self.assertIn("COMMAND_LINE_MARKER", result)
+        self.assertNotIn("LOCAL_MARKER", result)
+
+    def test_define_before_first_section_remains_invalid(self):
+        with self.assertRaisesRegex(
+            Warning,
+            "macro cannot be defined in Rule section or out of section",
+        ):
+            self._preprocess(
+                "DEFINE OUTSIDE = Value\n"
+                "[FV.FIRST]\n",
+                {},
+            )
+
+    def test_quoted_defines_header_does_not_change_macro_scope(self):
+        with self.assertRaisesRegex(Warning, "The Macro LOCAL is not defined"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "UI = \"label [Defines] text\"\n"
+                "DEFINE LOCAL = Leaked\n"
+                "[FV.SECOND]\n"
+                "!include $(LOCAL).inc\n",
+                {"Leaked.inc": "LEAKED_MARKER\n"},
+            )
+
+    def test_quoted_fv_header_does_not_change_macro_scope(self):
+        with self.assertRaisesRegex(Warning, "The Macro LOCAL is not defined"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "UI = \"label [FV.SECOND] text\"\n"
+                "DEFINE LOCAL = Leaked\n"
+                "[FV.SECOND]\n"
+                "!include $(LOCAL).inc\n",
+                {"Leaked.inc": "LEAKED_MARKER\n"},
+            )
+
+    def test_section_header_must_close_on_same_line(self):
+        with self.assertRaisesRegex(Warning, r"expected '\]'"):
+            self._preprocess(
+                "[FV.FIRST\n"
+                "[FV.SECOND]\n",
+                {},
+            )
+
+    def test_inactive_malformed_section_header_does_not_change_macro_scope(self):
+        GlobalData.gCommandLineDefines = {"FEATURE": "FALSE"}
+
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "DEFINE LOCAL = Active\n"
+            "!if $(FEATURE) == TRUE\n"
+            "[FV.INACTIVE\n"
+            "!endif\n"
+            "!include $(LOCAL).inc\n",
+            {"Active.inc": "ACTIVE_MARKER\n"},
+        )
+
+        self.assertIn("ACTIVE_MARKER", result)
+
+    def test_quoted_conditional_does_not_change_active_state(self):
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "UI = \"label !if FALSE text\"\n"
+            "DEFINE LOCAL = Active\n"
+            "!include $(LOCAL).inc\n",
+            {"Active.inc": "ACTIVE_MARKER\n"},
+        )
+
+        self.assertIn("ACTIVE_MARKER", result)
+
+    def test_nested_include_comments_do_not_change_macro_scope(self):
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "DEFINE LOCAL = Active\n"
+            "!include ScopeComment.inc\n"
+            "!include $(LOCAL).inc\n",
+            {
+                "ScopeComment.inc": (
+                    "/*\n"
+                    "[Defines]\n"
+                    "DEFINE LOCAL = Comment\n"
+                    "*/\n"
+                ),
+                "Active.inc": "ACTIVE_MARKER\n",
+                "Comment.inc": "COMMENT_MARKER\n",
+            },
+        )
+
+        self.assertIn("ACTIVE_MARKER", result)
+        self.assertNotIn("COMMENT_MARKER", result)
+
+    def test_included_file_ending_with_define_preserves_parser_cursor(self):
+        result = self._preprocess(
+            "[Defines]\n"
+            "!include Defines.inc\n"
+            "\n"
+            "[FV.FIRST]\n"
+            "!include $(INCLUDED).inc\n",
+            {
+                "Defines.inc": "DEFINE INCLUDED = Included\n",
+                "Included.inc": "INCLUDED_MARKER\n",
+            },
+        )
+
+        self.assertIn("INCLUDED_MARKER", result)
+
+    def test_nested_include_ending_with_define_preserves_parser_cursor(self):
+        result = self._preprocess(
+            "[Defines]\n"
+            "!include Outer.inc\n"
+            "\n"
+            "[FV.FIRST]\n"
+            "!include $(NESTED).inc\n",
+            {
+                "Outer.inc": "!include Inner.inc\n",
+                "Inner.inc": "DEFINE NESTED = Nested\n",
+                "Nested.inc": "NESTED_MARKER\n",
+            },
+        )
+
+        self.assertIn("NESTED_MARKER", result)
+
+
+    def test_inactive_include_is_still_expanded(self):
+        GlobalData.gCommandLineDefines = {"FEATURE": "FALSE"}
+
+        with self.assertRaisesRegex(Warning, "include file does not exist"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "!if $(FEATURE) == TRUE\n"
+                "!include Missing.inc\n"
+                "!endif\n",
+                {},
+            )
+
+    def test_elseif_selects_local_macro(self):
+        GlobalData.gCommandLineDefines = {
+            "FIRST_ENABLED": "FALSE",
+            "SECOND_ENABLED": "TRUE",
+        }
+
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "!if $(FIRST_ENABLED) == TRUE\n"
+            "DEFINE LOCAL = First\n"
+            "!elseif $(SECOND_ENABLED) == TRUE\n"
+            "DEFINE LOCAL = Second\n"
+            "!else\n"
+            "DEFINE LOCAL = Else\n"
+            "!endif\n"
+            "!include $(LOCAL).inc\n",
+            {
+                "First.inc": "FIRST_MARKER\n",
+                "Second.inc": "SECOND_MARKER\n",
+                "Else.inc": "ELSE_MARKER\n",
+            },
+        )
+
+        self.assertIn("SECOND_MARKER", result)
+        self.assertNotIn("FIRST_MARKER", result)
+        self.assertNotIn("ELSE_MARKER", result)
+
+    def test_else_selects_local_macro(self):
+        GlobalData.gCommandLineDefines = {
+            "FIRST_ENABLED": "FALSE",
+            "SECOND_ENABLED": "FALSE",
+        }
+
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "!if $(FIRST_ENABLED) == TRUE\n"
+            "DEFINE LOCAL = First\n"
+            "!elseif $(SECOND_ENABLED) == TRUE\n"
+            "DEFINE LOCAL = Second\n"
+            "!else\n"
+            "DEFINE LOCAL = Else\n"
+            "!endif\n"
+            "!include $(LOCAL).inc\n",
+            {
+                "First.inc": "FIRST_MARKER\n",
+                "Second.inc": "SECOND_MARKER\n",
+                "Else.inc": "ELSE_MARKER\n",
+            },
+        )
+
+        self.assertIn("ELSE_MARKER", result)
+        self.assertNotIn("FIRST_MARKER", result)
+        self.assertNotIn("SECOND_MARKER", result)
+
+    def test_ifdef_and_ifndef_select_local_macros(self):
+        result = self._preprocess(
+            "[Defines]\n"
+            "DEFINE PRESENT = Defined\n"
+            "[FV.FIRST]\n"
+            "!ifdef PRESENT\n"
+            "DEFINE IFDEF_LOCAL = Ifdef\n"
+            "!endif\n"
+            "!ifndef MISSING\n"
+            "DEFINE IFNDEF_LOCAL = Ifndef\n"
+            "!endif\n"
+            "!include $(IFDEF_LOCAL).inc\n"
+            "!include $(IFNDEF_LOCAL).inc\n",
+            {
+                "Ifdef.inc": "IFDEF_MARKER\n",
+                "Ifndef.inc": "IFNDEF_MARKER\n",
+            },
+        )
+
+        self.assertIn("IFDEF_MARKER", result)
+        self.assertIn("IFNDEF_MARKER", result)
+
+    def test_macro_cannot_generate_conditional_directive(self):
+        GlobalData.gCommandLineDefines = {
+            "FEATURE": "TRUE",
+            "SWITCH": "!else",
+        }
+
+        with self.assertRaisesRegex(
+            Warning,
+            "macro expansion cannot generate a section header or preprocessing directive",
+        ):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "!if $(FEATURE) == TRUE\n"
+                "$(SWITCH)\n"
+                "DEFINE PICK = Evil\n"
+                "!endif\n"
+                "!include $(PICK).inc\n",
+                {"Evil.inc": "EVIL_MARKER\n"},
+            )
+
+    def test_empty_macro_line_does_not_raise_index_error(self):
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "DEFINE EMPTY =\n"
+            "$(EMPTY)\n",
+            {},
+        )
+
+        self.assertNotIn("$(EMPTY)", result)
+
+
+    def test_inactive_define_resolves_include_without_leaking(self):
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "!if FALSE\n"
+            "DEFINE INC = Inactive\n"
+            "!include $(INC).inc\n"
+            "!endif\n",
+            {"Inactive.inc": "INACTIVE_MARKER\n"},
+        )
+
+        self.assertNotIn("INACTIVE_MARKER", result)
+        self.assertNotIn("INC", result)
+
+
+    def test_inactive_define_does_not_escape_branch(self):
+        with self.assertRaisesRegex(Warning, "The Macro INC is not defined"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "!if FALSE\n"
+                "DEFINE INC = Inactive\n"
+                "!include $(INC).inc\n"
+                "!endif\n"
+                "!include $(INC).inc\n",
+                {"Inactive.inc": "INACTIVE_MARKER\n"},
+            )
+
+    def test_set_updates_condition_before_include_expansion(self):
+        GlobalData.gPlatformPcds = {"gTest.PcdGate": "TRUE"}
+
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "SET gTest.PcdGate = FALSE\n"
+            "!if $(gTest.PcdGate) == TRUE\n"
+            "DEFINE INC = First\n"
+            "!else\n"
+            "DEFINE INC = Second\n"
+            "!endif\n"
+            "!include $(INC).inc\n",
+            {
+                "First.inc": "FIRST_MARKER\n",
+                "Second.inc": "SECOND_MARKER\n",
+            },
+        )
+
+        self.assertIn("SECOND_MARKER", result)
+        self.assertNotIn("FIRST_MARKER", result)
+
+    def test_set_uses_preceding_region_pcd_before_include_expansion(self):
+        result = self._preprocess(
+            "[FD.TEST]\n"
+            "BaseAddress = 0x0\n"
+            "Size = 0x100\n"
+            "0x0|0x20\n"
+            "gTest.PcdBase|gTest.PcdSize\n"
+            "SET gTest.PcdGate = gTest.PcdBase\n"
+            "!if $(gTest.PcdGate) == 0x0\n"
+            "DEFINE INC = Included\n"
+            "!else\n"
+            "DEFINE INC = Other\n"
+            "!endif\n"
+            "!include $(INC).inc\n",
+            {
+                "Included.inc": "INCLUDED_MARKER\n",
+                "Other.inc": "OTHER_MARKER\n",
+            },
+        )
+
+        self.assertIn("INCLUDED_MARKER", result)
+        self.assertNotIn("OTHER_MARKER", result)
+
+    def test_set_uses_macro_valued_region_pcd_before_include_expansion(self):
+        result = self._preprocess(
+            "[FD.TEST]\n"
+            "DEFINE REGION_BASE = 0x0\n"
+            "DEFINE REGION_SIZE = 0x20\n"
+            "BaseAddress = 0x0\n"
+            "Size = 0x100\n"
+            "$(REGION_BASE)|$(REGION_SIZE)\n"
+            "gTest.PcdBase|gTest.PcdSize\n"
+            "SET gTest.PcdGate = gTest.PcdSize\n"
+            "!if $(gTest.PcdGate) == 0x20\n"
+            "DEFINE INC = Included\n"
+            "!else\n"
+            "DEFINE INC = Other\n"
+            "!endif\n"
+            "!include $(INC).inc\n",
+            {
+                "Included.inc": "INCLUDED_MARKER\n",
+                "Other.inc": "OTHER_MARKER\n",
+            },
+        )
+
+        self.assertIn("INCLUDED_MARKER", result)
+        self.assertNotIn("OTHER_MARKER", result)
+
+    def test_set_uses_macro_valued_shortcut_pcd_before_include_expansion(self):
+        result = self._preprocess(
+            "[Defines]\n"
+            "DEFINE REGION_BASE = 0x0\n"
+            "[FD.TEST]\n"
+            "BaseAddress = $(REGION_BASE)|gTest.PcdBase\n"
+            "Size = 0x100\n"
+            "SET gTest.PcdGate = gTest.PcdBase\n"
+            "!if $(gTest.PcdGate) == 0x0\n"
+            "DEFINE INC = Included\n"
+            "!else\n"
+            "DEFINE INC = Other\n"
+            "!endif\n"
+            "!include $(INC).inc\n",
+            {
+                "Included.inc": "INCLUDED_MARKER\n",
+                "Other.inc": "OTHER_MARKER\n",
+            },
+        )
+
+        self.assertIn("INCLUDED_MARKER", result)
+        self.assertNotIn("OTHER_MARKER", result)
+
+    def test_region_size_at_end_of_file_does_not_raise_index_error(self):
+        self._preprocess(
+            "[FD.TEST]\n"
+            "0x0|0x20",
+            {},
+        )
+
+    def test_cyclic_macro_in_section_header_is_rejected(self):
+        with self.assertRaisesRegex(Warning, "macro cannot be used in section header"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "DEFINE LOOP = $(LOOP)\n"
+                "[$(LOOP)]\n",
+                {},
+            )
+
+    def test_cyclic_macro_in_include_path_is_rejected(self):
+        with self.assertRaisesRegex(Warning, "Cyclic macro expansion"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "DEFINE LOOP = $(LOOP)\n"
+                "!include $(LOOP).inc\n",
+                {},
+            )
+
+    def test_growing_cyclic_macro_in_include_path_is_rejected(self):
+        with self.assertRaisesRegex(Warning, "Cyclic macro expansion"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "DEFINE LOOP = $(LOOP)x\n"
+                "!include $(LOOP).inc\n",
+                {},
+            )
+
+    def test_growing_cyclic_macro_on_line_is_rejected(self):
+        with self.assertRaisesRegex(Warning, "Cyclic macro expansion"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "DEFINE LOOP = $(LOOP)x\n"
+                "$(LOOP)\n",
+                {},
+            )
+
+    def test_growing_cyclic_macro_after_prefix_is_rejected(self):
+        with self.assertRaisesRegex(Warning, "Cyclic macro expansion"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "DEFINE LOOP = $(LOOP)x\n"
+                "VALUE = $(LOOP)\n",
+                {},
+            )
+    def test_mutually_cyclic_macros_in_include_path_are_rejected(self):
+        with self.assertRaisesRegex(Warning, "Cyclic macro expansion"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "DEFINE FIRST = $(SECOND)x\n"
+                "DEFINE SECOND = $(FIRST)y\n"
+                "!include $(FIRST).inc\n",
+                {},
+            )
+    def test_repeated_and_nested_macros_expand_without_cycle(self):
+        result = self._preprocess(
+            "[FV.FIRST]\n"
+            "DEFINE LEAF = Part\n"
+            "DEFINE NAME = $(LEAF)$(LEAF)\n"
+            "!include $(NAME).inc\n",
+            {"PartPart.inc": "REPEATED_NESTED_MARKER\n"},
+        )
+
+        self.assertIn("REPEATED_NESTED_MARKER", result)
+    def test_deep_acyclic_macro_chain_expands_without_recursion_error(self):
+        chain_length = 1100
+        lines = ["[FV.FIRST]\n"]
+        for index in range(chain_length):
+            value = "$(M%d)" % (index + 1) if index < chain_length - 1 else "Final"
+            lines.append("DEFINE M%d = %s\n" % (index, value))
+        lines.append("!include $(M0).inc\n")
+
+        result = self._preprocess(
+            "".join(lines),
+            {"Final.inc": "DEEP_CHAIN_MARKER\n"},
+        )
+
+        self.assertIn("DEEP_CHAIN_MARKER", result)
+    def test_nested_selected_macros_remain_in_inactive_parent_branch(self):
+        self._preprocess(
+            "[FV.FIRST]\n"
+            "!if FALSE\n"
+            "!if TRUE\n"
+            "DEFINE INC = Nested\n"
+            "!endif\n"
+            "!include $(INC).inc\n"
+            "!endif\n",
+            {"Nested.inc": "NESTED_MARKER\n"},
+        )
+
+    def test_macro_generated_error_directive_is_rejected(self):
+        with self.assertRaisesRegex(Warning, "macro expansion cannot generate"):
+            self._preprocess(
+                "[FV.FIRST]\n"
+                "DEFINE DIRECTIVE = !error\n"
+                "$(DIRECTIVE) generated message\n",
+                {},
+            )
+def TheTestSuite():
+    return unittest.defaultTestLoader.loadTestsFromTestCase(
+        FdfParserMacroScopeTests
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/BaseTools/Tests/PythonToolsTests.py
+++ b/BaseTools/Tests/PythonToolsTests.py
@@ -20,6 +20,8 @@ def TheTestSuite():
     suites.append(CheckPythonSyntax.TheTestSuite())
     import CheckUnicodeSourceFiles
     suites.append(CheckUnicodeSourceFiles.TheTestSuite())
+    import FdfParserTests
+    suites.append(FdfParserTests.TheTestSuite())
     import MetaFileParserTests
     suites.append(MetaFileParserTests.TheTestSuite())
     return unittest.TestSuite(suites)


### PR DESCRIPTION
# Description

Fixes #13079.

`PreprocessIncludeFile()` collects FDF `DEFINE` statements in a flat macro map, allowing a section-local macro to expand an `!include` path in a later section.

This change:

- Tracks FDF macros by exact section and resolves include paths against the active section.
- Preserves `[Defines]` file scope and existing platform, global, and command-line precedence.
- Keeps conditional branch, active `SET`, and preceding FD region PCD state consistent during include preprocessing.
- Rejects cyclic and directive-generating macro expansions without recursive Python expansion.
- Adds regression coverage for section scope, precedence, conditionals, nested includes, comments, malformed headers, `SET` handling, FD region PCDs, and macro cycles.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [x] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Focused FDF parser regression suite on Windows with Python 3.12.10: 38/38 passed.
- Full BaseTools Python suite under WSL Ubuntu with Python 3.12.3: 350/350 passed.
- Re-ran the failing OVMF CLANGPDB RELEASE configuration through metadata and GenFds; the prior region-PCD errors no longer reproduce. Local C compilation then stopped because `clang` is not installed.
- Direct `py_compile` validation of all three changed Python files passed.
- `BaseTools/Scripts/PatchCheck.py -1` passed without warnings.
- CRLF-aware `git diff --check` passed.

## Integration Instructions

N/A