### PR TITLE
CryptoPkg/IntrinsicLib: fix memcpy alias param type for Clang 23

### DIFF
--- a/CryptoPkg/Library/IntrinsicLib/CopyMem.c
+++ b/CryptoPkg/Library/IntrinsicLib/CopyMem.c
@@ -29,9 +29,9 @@ __memcpy (
 __attribute__ ((__alias__ ("__memcpy")))
 void *
 memcpy (
-  void          *dest,
-  const void    *src,
-  unsigned int  count
+  void        *dest,
+  const void  *src,
+  size_t      count
   );
 
 #else


### PR DESCRIPTION
# Description

Clang 23 adds -Wattribute-alias to check alias declaration matches target in https://github.com/llvm/llvm-project/commit/40da6920a0d71d49dfa2392b09153600b0759f5e. The memcpy alias uses unsigned int while __memcpy uses size_t, causing a build failure. Change to size_t to match.

## How This Was Tested

Build X64 OVMF firmware with clang 32.1: `build -a X64 -t CLANGDWARF -D DEBUG -p OvmfPkg/OvmfPkgX64.dsc`, error log is occurred:
```
edk2-dev/CryptoPkg/Library/IntrinsicLib/CopyMem.c:29:17: error: alias and aliasee have different types 'void *(void *, const void *, unsigned int)' and 'void *(void *, const void *, size_t)' (aka 'void *(void *, const void *, unsigned long long)') [-Werror,-Wattribute-alias]
   29 | __attribute__ ((__alias__ ("__memcpy")))
      |                 ^
/data/gaoqihang/edk2-dev/CryptoPkg/Library/IntrinsicLib/CopyMem.c:20:1: note: aliasee is declared here
   20 | __memcpy (
      | ^
1 error generated.

```
After applying this patch, no error is occurred.

## Integration Instructions

N/A