### PR TITLE
OvmfPkg/RiscVVirt/PlatformPei: Initialize TpmBase

### DIFF
--- a/OvmfPkg/RiscVVirt/PlatformPei/PlatformPeim.c
+++ b/OvmfPkg/RiscVVirt/PlatformPei/PlatformPeim.c
@@ -122,6 +122,7 @@ SetupTPMResources (
   //
   // Empty TpmBaseSize indicates no TPM found.
   //
+  TpmBase     = 0;
   TpmBaseSize = 0;
 
   //


### PR DESCRIPTION
# Description

Building RiscVVirtQemu with GCC fails with -Werror=maybe-uninitialized.
SetupTPMResources() only assigns TpmBase inside the "Len == 8" and
"Len == 16" branches that decode the TPM 'reg' property, and the preceding
ASSERT() is not a control flow guarantee for the compiler:
```
PlatformPeim.c:192:23: error: 'TpmBase' may be used uninitialized
[-Werror=maybe-uninitialized]
  192 |   TpmBase -= Fdt64ToCpu (ReadUnaligned64 ((UINT64 *)RangesProp));
      |           ^~
```
Initialize TpmBase to 0 next to the existing TpmBaseSize initialization,
matching ArmVirtPkg/Library/PlatformPeiLib/PlatformPeiLib.c, from which
this code was derived and where the initialization is already present.


- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested
- git submodule update --init
- export GCC_RISCV64_PREFIX=riscv64-suse-linux-
- make -C BaseTools
- . edksetup.sh
- build  -D TPM2_ENABLE -D TPM2_CONFIG_ENABLE  -D RISCVVIRT_PEI_BOOTING -D NETWORK_IP6_ENABLE -D NETWORK_HTTP_BOOT_ENABLE  -a RISCV64 -p OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc -b DEBUG -t GCC 

## Integration Instructions

- N/A
