### PR TITLE
[edk2/master PATCH] Update .gitmodules url's .git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,22 +1,22 @@
 [submodule "CryptoPkg/Library/OpensslLib/openssl"]
 	path = CryptoPkg/Library/OpensslLib/openssl
-	url = https://github.com/openssl/openssl
+	url = https://github.com/openssl/openssl.git
 [submodule "UnitTestFrameworkPkg/Library/CmockaLib/cmocka"]
 	path = UnitTestFrameworkPkg/Library/CmockaLib/cmocka
 	url = https://github.com/tianocore/edk2-cmocka.git
 [submodule "MdeModulePkg/Universal/RegularExpressionDxe/oniguruma"]
 	path = MdeModulePkg/Universal/RegularExpressionDxe/oniguruma
-	url = https://github.com/kkos/oniguruma
+	url = https://github.com/kkos/oniguruma.git
 [submodule "MdeModulePkg/Library/BrotliCustomDecompressLib/brotli"]
 	path = MdeModulePkg/Library/BrotliCustomDecompressLib/brotli
-	url = https://github.com/google/brotli
+	url = https://github.com/google/brotli.git
 [submodule "BaseTools/Source/C/BrotliCompress/brotli"]
 	path = BaseTools/Source/C/BrotliCompress/brotli
-	url = https://github.com/google/brotli
+	url = https://github.com/google/brotli.git
 	ignore = untracked
 [submodule "RedfishPkg/Library/JsonLib/jansson"]
 	path = RedfishPkg/Library/JsonLib/jansson
-	url = https://github.com/akheron/jansson
+	url = https://github.com/akheron/jansson.git
 [submodule "UnitTestFrameworkPkg/Library/GoogleTestLib/googletest"]
 	path = UnitTestFrameworkPkg/Library/GoogleTestLib/googletest
 	url = https://github.com/google/googletest.git
@@ -31,10 +31,10 @@
 	url = https://github.com/MIPI-Alliance/public-mipi-sys-t.git
 [submodule "CryptoPkg/Library/MbedTlsLib/mbedtls"]
 	path = CryptoPkg/Library/MbedTlsLib/mbedtls
-	url = https://github.com/ARMmbed/mbedtls
+	url = https://github.com/ARMmbed/mbedtls.git
 [submodule "SecurityPkg/DeviceSecurity/SpdmLib/libspdm"]
 	path = SecurityPkg/DeviceSecurity/SpdmLib/libspdm
 	url = https://github.com/DMTF/libspdm.git
 [submodule "TcgTpmPkg/Library/TpmLib/TPM"]
 	path = TcgTpmPkg/Library/TpmLib/TPM
-	url = https://github.com/TrustedComputingGroup/TPM
+	url = https://github.com/TrustedComputingGroup/TPM.git


### PR DESCRIPTION
Update .gitmodules URLs with .git extension.
Github advertises URLs ending in .git only in their documentation and their
interface for the http-protocol.

Discussed in issue: #13084

# Description

No code changes, only updated the sub-modules `.gitsubmodules` to the valid Github URL including the `.git` at the end.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

```
$ git clone https://github.com/tianocore/edk2.git
$ git submodule update --init --checkout
```

Now after the change still checks out the sub-modules OK (as long as you don't hit GitHub rate limiting, see #13084)

## Integration Instructions

If changed in an existing repo you may need to run the following command to update the url's in the git cache.
```
$ git submodule sync --recursive
```
