### PR TITLE
BaseTools/PatchCheck.py: Allow more room for subject descriptions

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -278,17 +278,12 @@ class CommitMessageCheck:
             # subject line to 92 characters
             #
             maxlength = 92
-        elif lines[0].find(':') > 55:
-            #
-            # If we need to enumerate lots of packages, ensure to leave room for
-            # a very short description at the end (after the ':').
-            #
-            maxlength = lines[0].find(':') + 20
         else:
             #
-            # Otherwise, limit the length of subject line to 75 characters
+            # Keep the usual 75-character limit, but allow at least 40
+            # description characters after the package/component prefix.
             #
-            maxlength = 75
+            maxlength = max(75, lines[0].find(':') + 2 + 40)
 
         if len(lines[0].rstrip()) > maxlength:
             self.error(


### PR DESCRIPTION
# Description

Allow at least 40 description characters after long package or component prefixes, while keeping the default total subject limit at 75 characters. This extends the allowance introduced by #11241; the CVE-specific limit and package checks are unchanged.

Only `BaseTools/Scripts/PatchCheck.py` is changed.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

Local checks outside the patch cover default and expanded length boundaries, two- and three-package subjects, and unchanged CVE, package and trailing-period rules. All 7 tests passed. The existing BaseTools Python suite also passed.

No firmware build was run; this only changes Python commit-message validation.

## Integration Instructions

No special integration steps are required.
