### PR TITLE
MdeModulePkg/NvmExpressDxe: Harden register reads against all-ones data

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -52,6 +52,14 @@ ReadNvmeControllerCapabilities (
     return Status;
   }
 
+  if (Data == MAX_UINT64) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ReadNvmeControllerCapabilities: device returned all-ones -- not responding\n"
+      ));
+    return EFI_DEVICE_ERROR;
+  }
+
   WriteUnaligned64 ((UINT64 *)Cap, Data);
   return EFI_SUCCESS;
 }
@@ -88,6 +96,14 @@ ReadNvmeControllerConfiguration (
 
   if (EFI_ERROR (Status)) {
     return Status;
+  }
+
+  if (Data == MAX_UINT32) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ReadNvmeControllerConfiguration: device returned all-ones -- not responding\n"
+      ));
+    return EFI_DEVICE_ERROR;
   }
 
   WriteUnaligned32 ((UINT32 *)Cc, Data);
@@ -172,6 +188,11 @@ ReadNvmeControllerStatus (
 
   if (EFI_ERROR (Status)) {
     return Status;
+  }
+
+  if (Data == MAX_UINT32) {
+    DEBUG ((DEBUG_ERROR, "ReadNvmeControllerStatus: device returned all-ones -- not responding\n"));
+    return EFI_DEVICE_ERROR;
   }
 
   WriteUnaligned32 ((UINT32 *)Csts, Data);
@@ -775,7 +796,15 @@ NvmeControllerInit (
   //
   // Currently the driver only supports 4k page size.
   //
-  ASSERT ((Private->Cap.Mpsmin + 12) <= EFI_PAGE_SHIFT);
+  if ((Private->Cap.Mpsmin + 12) > EFI_PAGE_SHIFT) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "NvmeControllerInit: controller requires minimum page size 2^%d, driver supports 2^%d\n",
+      Private->Cap.Mpsmin + 12,
+      EFI_PAGE_SHIFT
+      ));
+    return EFI_UNSUPPORTED;
+  }
 
   Private->Cid[0]        = 0;
   Private->Cid[1]        = 0;


### PR DESCRIPTION
When an NVMe device is non-responsive over PCIe (e.g. after a BMC-only power cycle where the device retains auxiliary power but never receives a PCIe Fundamental Reset), MMIO reads to the device BAR return all-ones (0xFFFFFFFF_FFFFFFFF for 64-bit, 0xFFFFFFFF for 32-bit). This is a PCIe Root Complex fabricated completion (Completion Timeout or Unsupported Request) and is not a valid NVMe register value under any circumstance.

Two missing/invalid check cause a fatal ASSERT in this scenario:

1. ReadNvmeControllerCapabilities() did not detect the all-ones pattern and returned EFI_SUCCESS with garbage data to its caller.

2. NvmeControllerInit() used ASSERT to validate the Mpsmin field of the CAP register. When Mpsmin decoded to 0xF (15) from all-ones data, the check (15 + 12) <= EFI_PAGE_SHIFT evaluated to 27 <= 12 -- FALSE -- halting the entire system even though only one NVMe device was faulty. ASSERT is inappropriate here: Mpsmin is external hardware input, not an internal programmer invariant, and ASSERTs are stripped in RELEASE builds regardless.

Fix both checks:

- In ReadNvmeControllerCapabilities(), add a MAX_UINT64 check after a successful PciIo->Mem.Read. An all-ones 64-bit value is returned as EFI_DEVICE_ERROR so the caller can propagate the failure cleanly.

- In NvmeControllerInit(), replace the ASSERT with a runtime conditional that logs a DEBUG_ERROR message and returns EFI_UNSUPPORTED. The UEFI Driver Binding protocol model expects DriverBindingStart() to return an error for unsupported or unavailable devices; the platform continues booting with the affected device skipped.

- For consistency, apply the same all-ones guard (MAX_UINT32) to the 32-bit register readers ReadNvmeControllerConfiguration() and ReadNvmeControllerStatus().

The NVMe Base Specification defines all reserved bits in CAP as returning 0h when read; all-ones is therefore never a valid CAP value and always indicates a PCIe-layer failure outside the NVMe spec's scope.

# Description

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Boot test on AMD platform.

## Integration Instructions

N/A