### PR TITLE
ArmPlatformPkg: Remove DXE Core FV placement assumption in PeilessSec

### DIFF
--- a/ArmPlatformPkg/PeilessSec/PeilessSec.c
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.c
@@ -48,6 +48,31 @@ GetPlatformPpi (
 }
 
 /**
+  Decompress all discovered firmware volumes.
+
+**/
+STATIC
+VOID
+DecompressFvs (
+  VOID
+  )
+{
+  UINTN                Instance;
+  EFI_PEI_FV_HANDLE    VolumeHandle;
+  EFI_PEI_FILE_HANDLE  FileHandle;
+
+  //
+  // Decompress all firmware volume images found across all FVs.
+  //
+  for (Instance = 0; !EFI_ERROR (FfsFindNextVolume (Instance, &VolumeHandle)); Instance++) {
+    FileHandle = NULL;
+    while (!EFI_ERROR (FfsFindNextFile (EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE, VolumeHandle, &FileHandle))) {
+      FfsProcessFvFile (FileHandle, VolumeHandle);
+    }
+  }
+}
+
+/**
   SEC main routine.
 
   @param[in]  UefiMemoryBase  Start of the PI/UEFI memory region
@@ -176,15 +201,15 @@ SecMain (
   // SEC phase needs to run library constructors by hand.
   ProcessLibraryConstructorList ();
 
-  // Assume the FV that contains the SEC (our code) also contains a compressed FV.
-  Status = DecompressFirstFv ();
-  ASSERT_EFI_ERROR (Status);
+  // Decompress firmware volumes and load the DXE Core
+  DecompressFvs ();
 
   Status = MeasurePeilessSec ();
   ASSERT_EFI_ERROR (Status);
 
   // Load the DXE Core and transfer control to it
   Status = LoadDxeCoreFromFv (NULL, 0);
+  DEBUG ((DEBUG_ERROR, "Failed to load DXE Core from any FV\n"));
   ASSERT_EFI_ERROR (Status);
 }
 


### PR DESCRIPTION
# Description

Instead of failing to boot if the DXE Core is not placed in the first FV instance found, decompress and search all firmware volumes that have been installed.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

- Boot with DXE Core placed in a compressed FV in different orders to other FVs

## Integration Instructions

- N/A - Backward compatible
