### PR TITLE
OvmfPkg: Fix MemDebugLobLib and StandaloneMm integration

### DIFF
--- a/OvmfPkg/OvmfPkgX64.dsc
+++ b/OvmfPkg/OvmfPkgX64.dsc
@@ -528,6 +528,7 @@
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
   StandaloneMmDriverEntryPoint|MdePkg/Library/DynamicStackCookieEntryPointLib/StandaloneMmDriverEntryPoint.inf
   TimerLib|OvmfPkg/Library/AcpiTimerLib/DxeAcpiTimerLib.inf
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
@@ -546,6 +547,7 @@
 !else
   DebugLib|OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf
 !endif
+  MemDebugLogLib|OvmfPkg/Library/MemDebugLogLib/MemDebugLogLibNull.inf
   ExtractGuidedSectionLib|StandaloneMmPkg/Library/StandaloneMmExtractGuidedSectionLib/StandaloneMmExtractGuidedSectionLib.inf
   HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.inf


### PR DESCRIPTION
# Description
When DEBUG_TO_MEM==TRUE the build tool integrates MemDebugLogLib instance OvmfPkg/Library/MemDebugLogLib/MemDebugLogDxeLib.inf. That library in turn uses SynchronizationLib instance
MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf which again uses TimerLib instance
OvmfPkg/Library/AcpiTimerLib/BaseRomAcpiTimerLib.inf. 

The issue is none of those library instances support StandaloneMm module types which make OVMF build fail when DEBUG_ON_MEM enabled with STANDALONE_ENABLED:

```build.py...
/home/khaalid/Documents/edk2/OvmfPkg/OvmfPkgX64.dsc(...): error 1001: Module type [MM_CORE_STANDALONE] is not supported by library instance [/home/khaalid/Documents/edk2/OvmfPkg/Library/M]
        consumed by library instance [/home/khaalid/Documents/edk2/OvmfPkg/Library/PlatformDebugLibIoPort/PlatformDebugLibIoPort.inf] which is consumed by module [/home/khaalid/Documents/]

build.py...
/home/khaalid/Documents/edk2/OvmfPkg/OvmfPkgX64.dsc(...): error 1001: Module type [MM_CORE_STANDALONE] is not supported by library instance [/home/khaalid/Documents/edk2/OvmfPkg/Library/A]
        consumed by library instance [/home/khaalid/Documents/edk2/MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf] which is consumed by module [/home/khaalid/Documents/e]
```

This PR adds those two library instances to support module type MM_CORE_STANDALONE MM_STANDALONE so build could able to successfully integrate.

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

build -a X64 -p OvmfPkg/OvmfPkgX64.dsc -t GCC5 -b DEBUG -DDEBUG_TO_MEM=TRUE -DSMM_REQUIRE=TRUE -DSTANDALONE_MM_ENABLE=TRUE


## Integration Instructions
N/A