### PR TITLE
NetworkPkg: Address CodeQL Failures

### DIFF
--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -440,8 +440,8 @@ Dns4CopyConfigure (
   IN  EFI_DNS4_CONFIG_DATA  *Src
   )
 {
-  UINTN   Len;
-  UINT32  Index;
+  UINTN  Len;
+  UINTN  Index;
 
   CopyMem (Dst, Src, sizeof (*Dst));
   Dst->DnsServerList = NULL;

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -388,7 +388,7 @@ TlsConfigCertificate (
   EFI_STATUS          Status;
   UINT8               *CACert;
   UINTN               CACertSize;
-  UINT32              Index;
+  UINTN               Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_DATA  *Cert;
   UINTN               CertArraySizeInBytes;

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -1259,6 +1259,7 @@ TlsConnectSession (
   DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
   if (DataOut == NULL) {
     FreePool (BufferOut);
+    NetbufFree (PacketOut);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1351,6 +1352,7 @@ TlsConnectSession (
       DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
       if (DataOut == NULL) {
         FreePool (BufferOut);
+        NetbufFree (PacketOut);
         return EFI_OUT_OF_RESOURCES;
       }
 
@@ -1513,6 +1515,7 @@ TlsCloseSession (
   DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
   if (DataOut == NULL) {
     FreePool (BufferOut);
+    NetbufFree (PacketOut);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1805,6 +1808,7 @@ HttpsReceive (
           DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
           if (DataOut == NULL) {
             FreePool (BufferOut);
+            NetbufFree (PacketOut);
             return EFI_OUT_OF_RESOURCES;
           }
 
@@ -1903,6 +1907,7 @@ HttpsReceive (
       DataOut = NetbufAllocSpace (PacketOut, (UINT32)BufferOutSize, NET_BUF_TAIL);
       if (DataOut == NULL) {
         FreePool (BufferOut);
+        NetbufFree (PacketOut);
         return EFI_OUT_OF_RESOURCES;
       }
 

--- a/NetworkPkg/HttpUtilitiesDxe/HttpUtilitiesDxe.c
+++ b/NetworkPkg/HttpUtilitiesDxe/HttpUtilitiesDxe.c
@@ -27,7 +27,7 @@ HttpUtilitiesDxeUnload (
   EFI_STATUS                   Status;
   UINTN                        HandleNum;
   EFI_HANDLE                   *HandleBuffer;
-  UINT32                       Index;
+  UINTN                        Index;
   EFI_HTTP_UTILITIES_PROTOCOL  *HttpUtilitiesProtocol;
 
   HandleBuffer = NULL;

--- a/NetworkPkg/IScsiDxe/IScsiDhcp.c
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp.c
@@ -77,7 +77,7 @@ IScsiDhcpExtractRootPath (
       Fields[FieldIndex].Str = &TmpStr[Index];
     }
 
-    while ((TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER) && (Index < Length)) {
+    while ((Index < Length) && (TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER)) {
       Index++;
     }
 

--- a/NetworkPkg/IScsiDxe/IScsiDhcp6.c
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp6.c
@@ -37,7 +37,7 @@ IScsiDhcp6ExtractRootPath (
   ISCSI_ROOT_PATH_FIELD        Fields[RP_FIELD_IDX_MAX];
   ISCSI_ROOT_PATH_FIELD        *Field;
   UINT32                       FieldIndex;
-  UINT8                        Index;
+  UINT16                       Index;
   ISCSI_SESSION_CONFIG_NVDATA  *ConfigNvData;
   EFI_IP_ADDRESS               Ip;
   UINT8                        IpMode;

--- a/NetworkPkg/IScsiDxe/IScsiDhcp6.c
+++ b/NetworkPkg/IScsiDxe/IScsiDhcp6.c
@@ -88,7 +88,7 @@ IScsiDhcp6ExtractRootPath (
   Fields[RP_FIELD_IDX_SERVERNAME].Str = &TmpStr[Index];
 
   if (!ConfigNvData->DnsMode) {
-    while ((TmpStr[Index] != ISCSI_ROOT_PATH_ADDR_END_DELIMITER) && (Index < Length)) {
+    while ((Index < Length) && (TmpStr[Index] != ISCSI_ROOT_PATH_ADDR_END_DELIMITER)) {
       Index++;
     }
 
@@ -98,7 +98,7 @@ IScsiDhcp6ExtractRootPath (
     TmpStr[Index] = '\0';
     Index        += 2;
   } else {
-    while ((TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER) && (Index < Length)) {
+    while ((Index < Length) && (TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER)) {
       Index++;
     }
 
@@ -119,7 +119,7 @@ IScsiDhcp6ExtractRootPath (
       Fields[FieldIndex].Str = &TmpStr[Index];
     }
 
-    while ((TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER) && (Index < Length)) {
+    while ((Index < Length) && (TmpStr[Index] != ISCSI_ROOT_PATH_FIELD_DELIMITER)) {
       Index++;
     }
 

--- a/NetworkPkg/IScsiDxe/IScsiDriver.c
+++ b/NetworkPkg/IScsiDxe/IScsiDriver.c
@@ -361,7 +361,7 @@ IScsiStart (
   LIST_ENTRY                       *NextEntry;
   ISCSI_ATTEMPT_CONFIG_NVDATA      *AttemptConfigData;
   ISCSI_SESSION                    *Session;
-  UINT8                            Index;
+  UINTN                            Index;
   EFI_EXT_SCSI_PASS_THRU_PROTOCOL  *ExistIScsiExtScsiPassThru;
   ISCSI_DRIVER_DATA                *ExistPrivate;
   UINT8                            *AttemptConfigOrder;

--- a/NetworkPkg/IScsiDxe/IScsiMisc.c
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.c
@@ -810,7 +810,7 @@ IScsiRemoveNic (
 **/
 EFI_STATUS
 IScsiCreateAttempts (
-  IN UINTN  AttemptNum
+  IN UINT8  AttemptNum
   )
 {
   ISCSI_ATTEMPT_CONFIG_NVDATA  *AttemptConfigData;

--- a/NetworkPkg/IScsiDxe/IScsiMisc.h
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.h
@@ -255,7 +255,7 @@ IScsiRemoveNic (
 **/
 EFI_STATUS
 IScsiCreateAttempts (
-  IN UINTN  AttemptNum
+  IN UINT8  AttemptNum
   );
 
 /**

--- a/NetworkPkg/MnpDxe/MnpConfig.c
+++ b/NetworkPkg/MnpDxe/MnpConfig.c
@@ -214,7 +214,7 @@ MnpFreeNbuf (
 EFI_STATUS
 MnpAddFreeTxBuf (
   IN OUT MNP_DEVICE_DATA  *MnpDeviceData,
-  IN     UINTN            Count
+  IN     UINT32           Count
   )
 {
   EFI_STATUS       Status;

--- a/NetworkPkg/TcpDxe/TcpInput.c
+++ b/NetworkPkg/TcpDxe/TcpInput.c
@@ -1625,7 +1625,7 @@ TcpIcmpInput (
                     &IcmpErrNotify
                     );
 
-  if (IcmpErrNotify) {
+  if (EFI_ERROR (IcmpErrStatus) && IcmpErrNotify) {
     SOCK_ERROR (Tcb->Sk, IcmpErrStatus);
   }
 

--- a/NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigImpl.c
+++ b/NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigImpl.c
@@ -127,7 +127,7 @@ UpdateDeletePage (
   )
 {
   EFI_STATUS          Status;
-  UINT32              Index;
+  UINTN               Index;
   UINTN               CertCount;
   UINTN               GuidIndex;
   VOID                *StartOpCodeHandle;
@@ -318,7 +318,7 @@ DeleteCert (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINT32              Index;
+  UINTN               Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;

--- a/NetworkPkg/TlsDxe/TlsDriver.c
+++ b/NetworkPkg/TlsDxe/TlsDriver.c
@@ -156,7 +156,7 @@ TlsUnload (
   EFI_STATUS                    Status;
   UINTN                         HandleNum;
   EFI_HANDLE                    *HandleBuffer;
-  UINT32                        Index;
+  UINTN                         Index;
   EFI_SERVICE_BINDING_PROTOCOL  *ServiceBinding;
   TLS_SERVICE                   *TlsService;
 

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -1368,7 +1368,7 @@ PxeBcDhcp4Discover (
   EFI_DHCP4_TRANSMIT_RECEIVE_TOKEN  Token;
   BOOLEAN                           IsBCast;
   EFI_STATUS                        Status;
-  UINT16                            RepIndex;
+  UINT32                            RepIndex;
   UINT16                            SrvIndex;
   UINT16                            TryIndex;
   EFI_DHCP4_LISTEN_POINT            ListenPoint;

--- a/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
+++ b/NetworkPkg/WifiConnectionManagerDxe/WifiConnectionMgrHiiConfigAccess.c
@@ -268,7 +268,7 @@ WifiMgrGetStrAKMList (
   IN  WIFI_MGR_NETWORK_PROFILE  *Profile
   )
 {
-  UINT8   Index;
+  UINT16  Index;
   UINT16  AKMSuiteCount;
   CHAR16  *AKMListDisplay;
   UINTN   Length;
@@ -327,7 +327,7 @@ WifiMgrGetStrCipherList (
   IN  WIFI_MGR_NETWORK_PROFILE  *Profile
   )
 {
-  UINT8   Index;
+  UINT16  Index;
   UINT16  CipherSuiteCount;
   CHAR16  *CipherListDisplay;
 


### PR DESCRIPTION
# Description

This PR contains 5 commits to address CodeQL failures in NetworkPkg. Per general request, each commit deals with one type of change. 

In an attempt to make reviewing this easier, the changes are limited in scope.

The failures being addresses 
- access beyond boundary, where code could access beyond the valid memory range of a buffer
- loop comparison with a wider width (using UINT8 as index and UINT16/UINT32/UINT64 as loop termination condition)
- memory leak where memory was not freed
- 
- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No integration necessary.