### PR TITLE
NetworkPkg: Handle MTFTP network buffer failures

### DIFF
--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
@@ -101,7 +101,11 @@ Mtftp4RrqSendAck (
                                sizeof (EFI_MTFTP4_ACK_HEADER),
                                FALSE
                                );
-  ASSERT (Ack != NULL);
+  if (Ack == NULL) {
+    ASSERT (Ack != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Ack->Ack.OpCode   = HTONS (EFI_MTFTP4_OPCODE_ACK);
   Ack->Ack.Block[0] = HTONS (BlkNo);
@@ -710,7 +714,11 @@ Mtftp4RrqInput (
     NetbufCopy (UdpPacket, 0, Len, (UINT8 *)Packet);
   } else {
     Packet = (EFI_MTFTP4_PACKET *)NetbufGetByte (UdpPacket, 0, NULL);
-    ASSERT (Packet != NULL);
+    if (Packet == NULL) {
+      ASSERT (Packet != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ON_EXIT;
+    }
   }
 
   Opcode = NTOHS (Packet->OpCode);

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Support.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Support.c
@@ -303,7 +303,11 @@ Mtftp4SendRequest (
   }
 
   Packet = (EFI_MTFTP4_PACKET *)NetbufAllocSpace (Nbuf, BufferLength, FALSE);
-  ASSERT (Packet != NULL);
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    NetbufFree (Nbuf);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Packet->OpCode = HTONS (Instance->Operation);
   BufferLength  -= sizeof (Packet->OpCode);
@@ -366,7 +370,11 @@ Mtftp4SendError (
   }
 
   TftpError = (EFI_MTFTP4_PACKET *)NetbufAllocSpace (Packet, Len, FALSE);
-  ASSERT (TftpError != NULL);
+  if (TftpError == NULL) {
+    ASSERT (TftpError != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   TftpError->OpCode          = HTONS (EFI_MTFTP4_OPCODE_ERROR);
   TftpError->Error.ErrorCode = HTONS (ErrCode);
@@ -462,7 +470,11 @@ Mtftp4SendPacket (
   // to the connected port
   //
   Buffer = NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Buffer != NULL);
+  if (Buffer == NULL) {
+    ASSERT (Buffer != NULL);
+    return EFI_DEVICE_ERROR;
+  }
+
   OpCode = NTOHS (*(UINT16 *)Buffer);
 
   if ((OpCode == EFI_MTFTP4_OPCODE_RRQ) ||
@@ -520,7 +532,11 @@ Mtftp4Retransmit (
   // Set the requests to the listening port, other packets to the connected port
   //
   Buffer = NetbufGetByte (Instance->LastPacket, 0, NULL);
-  ASSERT (Buffer != NULL);
+  if (Buffer == NULL) {
+    ASSERT (Buffer != NULL);
+    return EFI_DEVICE_ERROR;
+  }
+
   OpCode = NTOHS (*(UINT16 *)Buffer);
 
   if ((OpCode == EFI_MTFTP4_OPCODE_RRQ) || (OpCode == EFI_MTFTP4_OPCODE_DIR) ||

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Wrq.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Wrq.c
@@ -44,7 +44,11 @@ Mtftp4WrqSendBlock (
   }
 
   Packet = (EFI_MTFTP4_PACKET *)NetbufAllocSpace (UdpPacket, MTFTP4_DATA_HEAD_LEN, FALSE);
-  ASSERT (Packet != NULL);
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    NetbufFree (UdpPacket);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Packet->Data.OpCode = HTONS (EFI_MTFTP4_OPCODE_DATA);
   Packet->Data.Block  = HTONS (BlockNum);
@@ -387,7 +391,11 @@ Mtftp4WrqInput (
     NetbufCopy (UdpPacket, 0, Len, (UINT8 *)Packet);
   } else {
     Packet = (EFI_MTFTP4_PACKET *)NetbufGetByte (UdpPacket, 0, NULL);
-    ASSERT (Packet != NULL);
+    if (Packet == NULL) {
+      ASSERT (Packet != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ON_EXIT;
+    }
   }
 
   Opcode = NTOHS (Packet->OpCode);

--- a/NetworkPkg/Mtftp6Dxe/Mtftp6Rrq.c
+++ b/NetworkPkg/Mtftp6Dxe/Mtftp6Rrq.c
@@ -44,7 +44,11 @@ Mtftp6RrqSendAck (
                                sizeof (EFI_MTFTP6_ACK_HEADER),
                                FALSE
                                );
-  ASSERT (Ack != NULL);
+  if (Ack == NULL) {
+    NetbufFree (Packet);
+    ASSERT (Ack != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Ack->Ack.OpCode   = HTONS (EFI_MTFTP6_OPCODE_ACK);
   Ack->Ack.Block[0] = HTONS (BlockNum);
@@ -755,7 +759,11 @@ Mtftp6RrqInput (
     NetbufCopy (UdpPacket, 0, Len, (UINT8 *)Packet);
   } else {
     Packet = (EFI_MTFTP6_PACKET *)NetbufGetByte (UdpPacket, 0, NULL);
-    ASSERT (Packet != NULL);
+    if (Packet == NULL) {
+      ASSERT (Packet != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ON_EXIT;
+    }
   }
 
   Opcode = NTOHS (Packet->OpCode);

--- a/NetworkPkg/Mtftp6Dxe/Mtftp6Support.c
+++ b/NetworkPkg/Mtftp6Dxe/Mtftp6Support.c
@@ -515,7 +515,11 @@ Mtftp6SendRequest (
   // Copy the opcode, filename and mode into packet.
   //
   Packet = (EFI_MTFTP6_PACKET *)NetbufAllocSpace (Nbuf, BufferLength, FALSE);
-  ASSERT (Packet != NULL);
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    NetbufFree (Nbuf);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Packet->OpCode = HTONS (Operation);
   BufferLength  -= sizeof (Packet->OpCode);
@@ -673,7 +677,10 @@ Mtftp6TransmitPacket (
   Instance->PacketToLive = Instance->IsMaster ? Instance->Timeout : (Instance->Timeout * 2);
 
   Temp = (UINT16 *)NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Temp != NULL);
+  if (Temp == NULL) {
+    ASSERT (Temp != NULL);
+    return EFI_DEVICE_ERROR;
+  }
 
   Value  = *Temp;
   OpCode = NTOHS (Value);

--- a/NetworkPkg/Mtftp6Dxe/Mtftp6Wrq.c
+++ b/NetworkPkg/Mtftp6Dxe/Mtftp6Wrq.c
@@ -48,7 +48,11 @@ Mtftp6WrqSendBlock (
                                   MTFTP6_DATA_HEAD_LEN,
                                   FALSE
                                   );
-  ASSERT (Packet != NULL);
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    NetbufFree (UdpPacket);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Packet->Data.OpCode = HTONS (EFI_MTFTP6_OPCODE_DATA);
   Packet->Data.Block  = HTONS (BlockNum);
@@ -436,7 +440,11 @@ Mtftp6WrqInput (
     NetbufCopy (UdpPacket, 0, Len, (UINT8 *)Packet);
   } else {
     Packet = (EFI_MTFTP6_PACKET *)NetbufGetByte (UdpPacket, 0, NULL);
-    ASSERT (Packet != NULL);
+    if (Packet == NULL) {
+      ASSERT (Packet != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto ON_EXIT;
+    }
   }
 
   Opcode = NTOHS (Packet->OpCode);


### PR DESCRIPTION
# Description

CodeQL static analysis reports potential NULL pointer dereferences in the MTFTPv4 and MTFTPv6 drivers. NetbufAllocSpace() and NetbufGetByte() may return NULL, but several request, response, and retransmission paths only verify their return values with ASSERT(). Because ASSERT() checks are removed from release builds, these paths may continue and dereference a NULL pointer.

Add runtime NULL checks to the MTFTPv4 and MTFTPv6 read, write, and support paths. Free partially constructed packets after allocation failures and return EFI_OUT_OF_RESOURCES. For failures to access packet data in transmit and retransmit paths, return EFI_DEVICE_ERROR. Input paths use their existing exit handling to release resources and report the failure.

This prevents NULL pointer dereferences, avoids leaking partially constructed packets, and resolves the CodeQL static scanning failures.

- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No Integration necessary