### PR TITLE
NetworkPkg/TcpDxe: Handle network buffer failures

### DIFF
--- a/NetworkPkg/TcpDxe/SockImpl.c
+++ b/NetworkPkg/TcpDxe/SockImpl.c
@@ -110,7 +110,10 @@ SockTcpDataToRcv (
   // Get the first socket receive buffer
   //
   RcvBufEntry = SockBufFirst (SockBuffer);
-  ASSERT (RcvBufEntry != NULL);
+  if (RcvBufEntry == NULL) {
+    ASSERT (RcvBufEntry != NULL);
+    return 0;
+  }
 
   TcpRsvData = (TCP_RSV_DATA *)RcvBufEntry->ProtoData;
 

--- a/NetworkPkg/TcpDxe/TcpInput.c
+++ b/NetworkPkg/TcpDxe/TcpInput.c
@@ -735,7 +735,10 @@ TcpInput (
   Tcb    = NULL;
 
   Head = (TCP_HEAD *)NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (Head != NULL);
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    goto DISCARD;
+  }
 
   if (Nbuf->TotalSize < sizeof (TCP_HEAD)) {
     DEBUG ((DEBUG_NET, "TcpInput: received a malformed packet\n"));
@@ -794,6 +797,9 @@ TcpInput (
   }
 
   Seg = TcpFormatNetbuf (Tcb, Nbuf);
+  if (Seg == NULL) {
+    goto DISCARD;
+  }
 
   //
   // RFC1122 recommended reaction to illegal option
@@ -1596,7 +1602,10 @@ TcpIcmpInput (
   }
 
   Head = (TCP_HEAD *)NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (Head != NULL);
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    goto CLEAN_EXIT;
+  }
 
   Tcb = TcpLocateTcb (
           Head->DstPort,

--- a/NetworkPkg/TcpDxe/TcpMisc.c
+++ b/NetworkPkg/TcpDxe/TcpMisc.c
@@ -890,7 +890,10 @@ TcpFormatNetbuf (
 
   Seg  = TCPSEG_NETBUF (Nbuf);
   Head = (TCP_HEAD *)NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (Head != NULL);
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    return NULL;
+  }
 
   Nbuf->Tcp = Head;
 
@@ -1146,7 +1149,11 @@ TcpResetConnection (
                         NET_BUF_TAIL
                         );
 
-  ASSERT (Nhead != NULL);
+  if (Nhead == NULL) {
+    ASSERT (Nhead != NULL);
+    NetbufFree (Nbuf);
+    return;
+  }
 
   Nbuf->Tcp = Nhead;
 

--- a/NetworkPkg/TcpDxe/TcpOption.c
+++ b/NetworkPkg/TcpDxe/TcpOption.c
@@ -130,7 +130,11 @@ TcpSynBuildOption (
              NET_BUF_HEAD
              );
 
-    ASSERT (Data != NULL);
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      return 0;  // Returning Len of 0 if we fail allocating space
+    }
+
     Len += TCP_OPTION_TS_ALIGNED_LEN;
 
     TcpPutUint32 (Data, TCP_OPTION_TS_FAST);
@@ -154,7 +158,10 @@ TcpSynBuildOption (
              NET_BUF_HEAD
              );
 
-    ASSERT (Data != NULL);
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      return 0; // Returning Len of 0 if we fail allocating space
+    }
 
     Len += TCP_OPTION_WS_ALIGNED_LEN;
     TcpPutUint32 (Data, TCP_OPTION_WS_FAST | TcpComputeScale (Tcb));
@@ -164,7 +171,10 @@ TcpSynBuildOption (
   // Build the MSS option.
   //
   Data = NetbufAllocSpace (Nbuf, TCP_OPTION_MSS_LEN, 1);
-  ASSERT (Data != NULL);
+  if (Data == NULL) {
+    ASSERT (Data != NULL);
+    return 0; // Returning Len of 0 if we fail allocating space
+  }
 
   Len += TCP_OPTION_MSS_LEN;
   TcpPutUint32 (Data, TCP_OPTION_MSS_FAST | Tcb->RcvMss);
@@ -206,7 +216,11 @@ TcpBuildOption (
              NET_BUF_HEAD
              );
 
-    ASSERT (Data != NULL);
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      return 0;
+    }
+
     Len += TCP_OPTION_TS_ALIGNED_LEN;
 
     TcpPutUint32 (Data, TCP_OPTION_TS_FAST);

--- a/NetworkPkg/TcpDxe/TcpOutput.c
+++ b/NetworkPkg/TcpDxe/TcpOutput.c
@@ -306,7 +306,10 @@ TcpTransmitSegment (
                        NET_BUF_HEAD
                        );
 
-  ASSERT (Head != NULL);
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    return -1;
+  }
 
   Nbuf->Tcp = Head;
 
@@ -496,7 +499,10 @@ TcpGetSegmentSndQue (
   //
   if (CopyLen != 0) {
     Data = NetbufAllocSpace (Nbuf, CopyLen, NET_BUF_TAIL);
-    ASSERT (Data != NULL);
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      goto OnError;
+    }
 
     if ((INT32)NetbufCopy (Node, Offset, CopyLen, Data) != CopyLen) {
       goto OnError;
@@ -560,7 +566,11 @@ TcpGetSegmentSock (
     // copy data to the segment.
     //
     Data = NetbufAllocSpace (Nbuf, Len, NET_BUF_TAIL);
-    ASSERT (Data != NULL);
+    if (Data == NULL) {
+      ASSERT (Data != NULL);
+      NetbufFree (Nbuf);
+      return NULL;
+    }
 
     DataGet = SockGetDataToSend (Tcb->Sk, 0, Len, Data);
   }
@@ -608,6 +618,10 @@ TcpGetSegment (
     Nbuf = TcpGetSegmentSndQue (Tcb, Seq, Len);
   } else {
     Nbuf = TcpGetSegmentSock (Tcb, Seq, Len);
+  }
+
+  if (Nbuf == NULL) {
+    return NULL;
   }
 
   if (TcpVerifySegment (Nbuf) == 0) {
@@ -1124,7 +1138,11 @@ TcpSendReset (
                         NET_BUF_TAIL
                         );
 
-  ASSERT (Nhead != NULL);
+  if (Nhead == NULL) {
+    ASSERT (Nhead != NULL);
+    NetbufFree (Nbuf);
+    return -1;
+  }
 
   Nbuf->Tcp   = Nhead;
   Nhead->Flag = TCP_FLG_RST;


### PR DESCRIPTION
# Description

CodeQL static analysis reports potential NULL pointer dereferences in the TCP driver. Several packet parsing, construction, and option handling paths rely on ASSERT() to validate network buffer allocations and accesses. Because ASSERT() checks are removed from release builds, these paths may continue with a NULL pointer and access invalid memory.

Add runtime NULL checks to the TCP input, output, socket, option, and support paths. Discard malformed input packets, propagate packet construction failures to callers, and free partially constructed buffers where ownership has already been acquired.

This prevents NULL pointer dereferences and resource leaks when network buffer allocation or access fails and resolves the related CodeQL static scanning failures.


- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No integration necessary 