### PR TITLE
NetworkPkg/Ip4Dxe: Handle NULL buffer failures

### DIFF
--- a/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Config2Nv.c
@@ -909,8 +909,13 @@ Ip4FormExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gIp4Config2NvDataGuid, mIp4Config2StorageName, Private->ChildHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
+    if (ConfigRequestHdr == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Failure;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
       goto Failure;
@@ -1336,24 +1341,27 @@ Ip4Config2FormInit (
                       STRING_TOKEN (STR_IP4_CONFIG2_FORM_HELP),
                       NULL
                       );
-    UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_IP4_CONFIG2_FORM_HELP),
-      MenuString,
-      NULL
-      );
+    if (OldMenuString != NULL) {
+      UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_IP4_CONFIG2_FORM_HELP),
+        MenuString,
+        NULL
+        );
 
-    UnicodeSPrint (PortString, 128, L"MAC:%s", MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_IP4_DEVICE_FORM_HELP),
-      PortString,
-      NULL
-      );
+      UnicodeSPrint (PortString, 128, L"MAC:%s", MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_IP4_DEVICE_FORM_HELP),
+        PortString,
+        NULL
+        );
+
+      FreePool (OldMenuString);
+    }
 
     FreePool (MacString);
-    FreePool (OldMenuString);
 
     return EFI_SUCCESS;
   }

--- a/NetworkPkg/Ip4Dxe/Ip4Icmp.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Icmp.c
@@ -230,7 +230,12 @@ Ip4IcmpReplyEcho (
   // update is omitted.
   //
   Icmp = (IP4_ICMP_QUERY_HEAD *)NetbufGetByte (Data, 0, NULL);
-  ASSERT (Icmp != NULL);
+  if (Icmp == NULL) {
+    ASSERT (Icmp != NULL);
+    Status = EFI_INVALID_PARAMETER;
+    goto ON_EXIT;
+  }
+
   Icmp->Head.Type     = ICMP_ECHO_REPLY;
   Icmp->Head.Checksum = 0;
   Icmp->Head.Checksum = (UINT16)(~NetblockChecksum ((UINT8 *)Icmp, Data->TotalSize));

--- a/NetworkPkg/Ip4Dxe/Ip4If.c
+++ b/NetworkPkg/Ip4Dxe/Ip4If.c
@@ -1130,6 +1130,12 @@ Ip4SendFrame (
   // Found a pending ARP request, enqueue the frame then return
   //
   if (Entry != &Interface->ArpQues) {
+    if (ArpQue == NULL) {
+      ASSERT (ArpQue != NULL);
+      Status = EFI_DEVICE_ERROR;
+      goto ON_ERROR;
+    }
+
     InsertTailList (&ArpQue->Frames, &Token->Link);
     return EFI_SUCCESS;
   }

--- a/NetworkPkg/Ip4Dxe/Ip4Impl.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Impl.c
@@ -1582,6 +1582,7 @@ EfiIp4Transmit (
   UINT8                  RawHdrLen;
   UINT32                 OptionsLength;
   UINT8                  *OptionsBuffer;
+  UINT8                  NoOptions;
   VOID                   *FirstFragment;
 
   if (This == NULL) {
@@ -1596,9 +1597,10 @@ EfiIp4Transmit (
 
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
-  IpSb   = IpInstance->Service;
-  IpIf   = IpInstance->Interface;
-  Config = &IpInstance->ConfigData;
+  IpSb      = IpInstance->Service;
+  IpIf      = IpInstance->Interface;
+  Config    = &IpInstance->ConfigData;
+  NoOptions = 0;
 
   if (Config->UseDefaultAddress && IP4_NO_MAPPING (IpInstance)) {
     Status = EFI_NO_MAPPING;
@@ -1705,6 +1707,16 @@ EfiIp4Transmit (
 
     OptionsLength = TxData->OptionsLength;
     OptionsBuffer = (UINT8 *)(TxData->OptionsBuffer);
+  }
+
+  if ((OptionsLength != 0) && (OptionsBuffer == NULL)) {
+    ASSERT (OptionsBuffer != NULL);
+    Status = EFI_INVALID_PARAMETER;
+    goto ON_EXIT;
+  }
+
+  if (OptionsBuffer == NULL) {
+    OptionsBuffer = &NoOptions;
   }
 
   //

--- a/NetworkPkg/Ip4Dxe/Ip4Input.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Input.c
@@ -259,7 +259,10 @@ Ip4Reassemble (
   //
   // Assemble shouldn't be NULL here
   //
-  ASSERT (Assemble != NULL);
+  if (Assemble == NULL) {
+    ASSERT (Assemble != NULL);
+    goto DROP;
+  }
 
   //
   // Find the point to insert the packet: before the first
@@ -849,9 +852,11 @@ Ip4AccpetFrame (
   IP4_HEAD     ZeroHead;
   UINT8        *Option;
   UINT32       OptionLen;
+  UINT8        NoOption;
 
-  IpSb   = (IP4_SERVICE *)Context;
-  Option = NULL;
+  IpSb     = (IP4_SERVICE *)Context;
+  Option   = NULL;
+  NoOption = 0;
 
   if (EFI_ERROR (IoStatus) || (IpSb->State == IP4_SERVICE_DESTROY)) {
     goto DROP;
@@ -862,10 +867,16 @@ Ip4AccpetFrame (
   }
 
   Head = (IP4_HEAD *)NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Head != NULL);
+  if (Head == NULL) {
+    ASSERT (Head != NULL);
+    goto RESTART;
+  }
+
   OptionLen = (Head->HeadLen << 2) - IP4_MIN_HEADLEN;
   if (OptionLen > 0) {
     Option = (UINT8 *)(Head + 1);
+  } else {
+    Option = &NoOption;
   }
 
   //
@@ -916,7 +927,11 @@ Ip4AccpetFrame (
     }
 
     Head = (IP4_HEAD *)NetbufGetByte (Packet, 0, NULL);
-    ASSERT (Head != NULL);
+    if (Head == NULL) {
+      ASSERT (Head != NULL);
+      goto RESTART;
+    }
+
     Status = Ip4PreProcessPacket (
                IpSb,
                &Packet,
@@ -1306,7 +1321,10 @@ Ip4InstanceDeliverPacket (
         // may be not continuous before the data.
         //
         Head = NetbufAllocSpace (Dup, IP4_MAX_HEADLEN, NET_BUF_HEAD);
-        ASSERT (Head != NULL);
+        if (Head == NULL) {
+          ASSERT (Head != NULL);
+          return EFI_OUT_OF_RESOURCES;
+        }
 
         Dup->Ip.Ip4 = (IP4_HEAD *)Head;
 

--- a/NetworkPkg/Ip4Dxe/Ip4Route.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Route.c
@@ -522,6 +522,8 @@ Ip4Route (
       return NULL;
     } else if (!AlwaysTryDestAddr) {
       return NULL;
+    } else {
+      return NULL;
     }
   }
 


### PR DESCRIPTION
# Description
CodeQL static analysis reports potential NULL pointer dereferences in the IPv4 driver. Several configuration, packet processing, and transmit paths rely on ASSERT() or implicit assumptions to validate allocations and buffer accesses. These assumptions do not provide runtime protection when assertions are disabled or external input is malformed.

Add explicit NULL checks for HII configuration headers, ICMP and ARP buffers, reassembly state, packet headers, and receive header allocations. Validate transmit option buffers before use and provide a valid sentinel buffer for zero-length options. Route failures through the existing cleanup paths and return an appropriate error where the caller can handle it.

This prevents NULL pointer dereferences and invalid buffer accesses, preserves resource cleanup on failure, and resolves the related CodeQL static scanning failures.

- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No integration necessary