### PR TITLE
NetworkPkg/Ip6Dxe: Handle NULL buffer failures

### DIFF
--- a/NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c
+++ b/NetworkPkg/Ip6Dxe/Ip6ConfigImpl.c
@@ -865,19 +865,23 @@ Ip6ManualAddrDadCallback (
         // data with those passed.
         //
         PassedAddr = (EFI_IP6_CONFIG_MANUAL_ADDRESS *)AllocatePool (Item->DataSize);
-        ASSERT (PassedAddr != NULL);
+        if (PassedAddr == NULL) {
+          ASSERT (PassedAddr != NULL);
+          Item->Data.Ptr = NULL;
+          Item->Status   = EFI_OUT_OF_RESOURCES;
+        } else {
+          Item->Data.Ptr = PassedAddr;
+          Item->Status   = EFI_SUCCESS;
 
-        Item->Data.Ptr = PassedAddr;
-        Item->Status   = EFI_SUCCESS;
+          while (!NetMapIsEmpty (&Instance->DadPassedMap)) {
+            ManualAddr = (EFI_IP6_CONFIG_MANUAL_ADDRESS *)NetMapRemoveHead (&Instance->DadPassedMap, NULL);
+            CopyMem (PassedAddr, ManualAddr, sizeof (EFI_IP6_CONFIG_MANUAL_ADDRESS));
 
-        while (!NetMapIsEmpty (&Instance->DadPassedMap)) {
-          ManualAddr = (EFI_IP6_CONFIG_MANUAL_ADDRESS *)NetMapRemoveHead (&Instance->DadPassedMap, NULL);
-          CopyMem (PassedAddr, ManualAddr, sizeof (EFI_IP6_CONFIG_MANUAL_ADDRESS));
+            PassedAddr++;
+          }
 
-          PassedAddr++;
+          ASSERT ((UINTN)PassedAddr - (UINTN)Item->Data.Ptr == Item->DataSize);
         }
-
-        ASSERT ((UINTN)PassedAddr - (UINTN)Item->Data.Ptr == Item->DataSize);
       }
     } else {
       //

--- a/NetworkPkg/Ip6Dxe/Ip6ConfigNv.c
+++ b/NetworkPkg/Ip6Dxe/Ip6ConfigNv.c
@@ -1407,9 +1407,19 @@ Ip6FormExtractConfig (
                          mIp6ConfigStorageName,
                          Private->ChildHandle
                          );
+    if (ConfigRequestHdr == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Exit;
+    }
+
     Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
     ConfigRequest = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Exit;
+    }
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (
       ConfigRequest,
@@ -1994,25 +2004,27 @@ Ip6ConfigFormInit (
                       CallbackInfo->RegisteredHandle,
                       STRING_TOKEN (STR_IP6_CONFIG_FORM_HELP),
                       NULL
-                      )
-    ;
-    UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_IP6_CONFIG_FORM_HELP),
-      MenuString,
-      NULL
-      );
-    UnicodeSPrint (PortString, 128, L"MAC:%s", MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_IP6_DEVICE_FORM_HELP),
-      PortString,
-      NULL
-      );
+                      );
+    if (OldMenuString != NULL) {
+      UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_IP6_CONFIG_FORM_HELP),
+        MenuString,
+        NULL
+        );
+      UnicodeSPrint (PortString, 128, L"MAC:%s", MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_IP6_DEVICE_FORM_HELP),
+        PortString,
+        NULL
+        );
+
+      FreePool (OldMenuString);
+    }
 
     FreePool (MacString);
-    FreePool (OldMenuString);
 
     InitializeListHead (&Instance->Ip6NvData.ManualAddress);
     InitializeListHead (&Instance->Ip6NvData.GatewayAddress);

--- a/NetworkPkg/Ip6Dxe/Ip6If.c
+++ b/NetworkPkg/Ip6Dxe/Ip6If.c
@@ -705,7 +705,11 @@ Ip6SendFrame (
   //
 
   NeighborCache = Ip6FindNeighborEntry (IpSb, NextHop);
-  ASSERT (NeighborCache != NULL);
+  if (NeighborCache == NULL) {
+    ASSERT (NeighborCache != NULL);
+    Status = EFI_NOT_FOUND;
+    goto Error;
+  }
 
   if (NeighborCache->Interface == NULL) {
     NeighborCache->Interface = Interface;

--- a/NetworkPkg/Ip6Dxe/Ip6Input.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Input.c
@@ -331,7 +331,11 @@ Ip6Reassemble (
     // Revert IP head to network order.
     //
     DupHead = NetbufGetByte (Duplicate, 0, NULL);
-    ASSERT (DupHead != NULL);
+    if (DupHead == NULL) {
+      ASSERT (DupHead != NULL);
+      goto Error;
+    }
+
     Duplicate->Ip.Ip6 = Ip6NtohHead ((EFI_IP6_HEADER *)DupHead);
     Assemble->Packet  = Duplicate;
 
@@ -399,7 +403,11 @@ Ip6Reassemble (
     // the Fragment Header is excluded.
     //
     TmpPacket = NetbufGetFragment (Fragment, 0, This->HeadLen, 0);
-    ASSERT (TmpPacket != NULL);
+    if (TmpPacket == NULL) {
+      ASSERT (TmpPacket != NULL);
+      Ip6FreeAssembleEntry (Assemble);
+      goto Error;
+    }
 
     NET_LIST_FOR_EACH (Cur, ListHead) {
       //
@@ -1302,19 +1310,19 @@ Ip6InstanceFrameAcceptable (
   //
   ExtHdrs = NetbufGetByte (Packet, 0, NULL);
 
-  if (!Ip6IsExtsValid (
-         IpInstance->Service,
-         Packet,
-         &Head->NextHeader,
-         ExtHdrs,
-         (UINT32)Head->PayloadLength,
-         TRUE,
-         NULL,
-         &Proto,
-         NULL,
-         NULL,
-         NULL
-         ))
+  if ((ExtHdrs == NULL) || !Ip6IsExtsValid (
+                              IpInstance->Service,
+                              Packet,
+                              &Head->NextHeader,
+                              ExtHdrs,
+                              (UINT32)Head->PayloadLength,
+                              TRUE,
+                              NULL,
+                              &Proto,
+                              NULL,
+                              NULL,
+                              NULL
+                              ))
   {
     return FALSE;
   }
@@ -1336,20 +1344,19 @@ Ip6InstanceFrameAcceptable (
       //
       ErrMsgPayloadLen = NTOHS (Icmp.IpHead.PayloadLength);
       ErrMsgPayload    = NetbufGetByte (Packet, sizeof (Icmp), NULL);
-
-      if (!Ip6IsExtsValid (
-             NULL,
-             NULL,
-             &Icmp.IpHead.NextHeader,
-             ErrMsgPayload,
-             ErrMsgPayloadLen,
-             TRUE,
-             NULL,
-             &Proto,
-             NULL,
-             NULL,
-             NULL
-             ))
+      if ((ErrMsgPayload == NULL) || !Ip6IsExtsValid (
+                                        NULL,
+                                        NULL,
+                                        &Icmp.IpHead.NextHeader,
+                                        ErrMsgPayload,
+                                        ErrMsgPayloadLen,
+                                        TRUE,
+                                        NULL,
+                                        &Proto,
+                                        NULL,
+                                        NULL,
+                                        NULL
+                                        ))
       {
         return FALSE;
       }
@@ -1506,7 +1513,11 @@ Ip6InstanceDeliverPacket (
       // may be not continuous before the data.
       //
       Head = NetbufAllocSpace (Dup, sizeof (EFI_IP6_HEADER), NET_BUF_HEAD);
-      ASSERT (Head != NULL);
+      if (Head == NULL) {
+        ASSERT (Head != NULL);
+        return EFI_OUT_OF_RESOURCES;
+      }
+
       Dup->Ip.Ip6 = (EFI_IP6_HEADER *)Head;
 
       CopyMem (Head, Packet->Ip.Ip6, sizeof (EFI_IP6_HEADER));

--- a/NetworkPkg/Ip6Dxe/Ip6Mld.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Mld.c
@@ -181,7 +181,12 @@ Ip6SendMldReport (
   // Fill a IPv6 Router Alert option in a Hop-by-Hop Options Header
   //
   Options = NetbufAllocSpace (Packet, (UINT32)OptionLen, FALSE);
-  ASSERT (Options != NULL);
+  if (Options == NULL) {
+    ASSERT (Options != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   Status = Ip6FillHopByHop (Options, &OptionLen, IP6_ICMP);
   if (EFI_ERROR (Status)) {
     NetbufFree (Packet);
@@ -193,7 +198,12 @@ Ip6SendMldReport (
   // Fill in MLD message - Report
   //
   MldHead = (IP6_MLD_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_MLD_HEAD), FALSE);
-  ASSERT (MldHead != NULL);
+  if (MldHead == NULL) {
+    ASSERT (MldHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (MldHead, sizeof (IP6_MLD_HEAD));
   MldHead->Head.Type = ICMP_V6_LISTENER_REPORT;
   MldHead->Head.Code = 0;
@@ -285,7 +295,13 @@ Ip6SendMldDone (
   // Fill a IPv6 Router Alert option in a Hop-by-Hop Options Header
   //
   Options = NetbufAllocSpace (Packet, (UINT32)OptionLen, FALSE);
-  ASSERT (Options != NULL);
+  if (Options == NULL) {
+    ASSERT (Options != NULL);
+    NetbufFree (Packet);
+    Packet = NULL;
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   Status = Ip6FillHopByHop (Options, &OptionLen, IP6_ICMP);
   if (EFI_ERROR (Status)) {
     NetbufFree (Packet);
@@ -297,7 +313,12 @@ Ip6SendMldDone (
   // Fill in MLD message - Done
   //
   MldHead = (IP6_MLD_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_MLD_HEAD), FALSE);
-  ASSERT (MldHead != NULL);
+  if (MldHead == NULL) {
+    ASSERT (MldHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (MldHead, sizeof (IP6_MLD_HEAD));
   MldHead->Head.Type = ICMP_V6_LISTENER_DONE;
   MldHead->Head.Code = 0;

--- a/NetworkPkg/Ip6Dxe/Ip6Nd.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.c
@@ -1174,7 +1174,12 @@ Ip6SendRouterSolicit (
   //
 
   IcmpHead = (IP6_ICMP_INFORMATION_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_ICMP_INFORMATION_HEAD), FALSE);
-  ASSERT (IcmpHead != NULL);
+  if (IcmpHead == NULL) {
+    ASSERT (IcmpHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (IcmpHead, sizeof (IP6_ICMP_INFORMATION_HEAD));
   IcmpHead->Head.Type = ICMP_V6_ROUTER_SOLICIT;
   IcmpHead->Head.Code = 0;
@@ -1186,7 +1191,12 @@ Ip6SendRouterSolicit (
                                                  sizeof (IP6_ETHER_ADDR_OPTION),
                                                  FALSE
                                                  );
-    ASSERT (LinkLayerOption != NULL);
+    if (LinkLayerOption == NULL) {
+      ASSERT (LinkLayerOption != NULL);
+      NetbufFree (Packet);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     LinkLayerOption->Type   = Ip6OptionEtherSource;
     LinkLayerOption->Length = (UINT8)sizeof (IP6_ETHER_ADDR_OPTION);
     CopyMem (LinkLayerOption->EtherAddr, SourceLinkAddress, 6);
@@ -1280,7 +1290,12 @@ Ip6SendNeighborAdvertise (
   //
 
   IcmpHead = (IP6_ICMP_INFORMATION_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_ICMP_INFORMATION_HEAD), FALSE);
-  ASSERT (IcmpHead != NULL);
+  if (IcmpHead == NULL) {
+    ASSERT (IcmpHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (IcmpHead, sizeof (IP6_ICMP_INFORMATION_HEAD));
   IcmpHead->Head.Type = ICMP_V6_NEIGHBOR_ADVERTISE;
   IcmpHead->Head.Code = 0;
@@ -1298,7 +1313,12 @@ Ip6SendNeighborAdvertise (
   }
 
   Target = (EFI_IPv6_ADDRESS *)NetbufAllocSpace (Packet, sizeof (EFI_IPv6_ADDRESS), FALSE);
-  ASSERT (Target != NULL);
+  if (Target == NULL) {
+    ASSERT (Target != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   IP6_COPY_ADDRESS (Target, TargetIp6Address);
 
   LinkLayerOption = (IP6_ETHER_ADDR_OPTION *)NetbufAllocSpace (
@@ -1306,7 +1326,12 @@ Ip6SendNeighborAdvertise (
                                                sizeof (IP6_ETHER_ADDR_OPTION),
                                                FALSE
                                                );
-  ASSERT (LinkLayerOption != NULL);
+  if (LinkLayerOption == NULL) {
+    ASSERT (LinkLayerOption != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   LinkLayerOption->Type   = Ip6OptionEtherTarget;
   LinkLayerOption->Length = 1;
   CopyMem (LinkLayerOption->EtherAddr, TargetLinkAddress, 6);
@@ -1414,13 +1439,22 @@ Ip6SendNeighborSolicit (
   // Fill in the ICMP header, Target address, and Source link-layer address.
   //
   IcmpHead = (IP6_ICMP_INFORMATION_HEAD *)NetbufAllocSpace (Packet, sizeof (IP6_ICMP_INFORMATION_HEAD), FALSE);
-  ASSERT (IcmpHead != NULL);
+  if (IcmpHead == NULL) {
+    ASSERT (IcmpHead != NULL);
+    NetbufFree (Packet);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   ZeroMem (IcmpHead, sizeof (IP6_ICMP_INFORMATION_HEAD));
   IcmpHead->Head.Type = ICMP_V6_NEIGHBOR_SOLICIT;
   IcmpHead->Head.Code = 0;
 
   Target = (EFI_IPv6_ADDRESS *)NetbufAllocSpace (Packet, sizeof (EFI_IPv6_ADDRESS), FALSE);
-  ASSERT (Target != NULL);
+  if (Target == NULL) {
+    ASSERT (Target != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   IP6_COPY_ADDRESS (Target, TargetIp6Address);
 
   LinkLayerOption = NULL;
@@ -1433,7 +1467,12 @@ Ip6SendNeighborSolicit (
                                                  sizeof (IP6_ETHER_ADDR_OPTION),
                                                  FALSE
                                                  );
-    ASSERT (LinkLayerOption != NULL);
+    if (LinkLayerOption == NULL) {
+      ASSERT (LinkLayerOption != NULL);
+      NetbufFree (Packet);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     LinkLayerOption->Type   = Ip6OptionEtherSource;
     LinkLayerOption->Length = 1;
     CopyMem (LinkLayerOption->EtherAddr, SourceLinkAddress, 6);
@@ -1522,7 +1561,10 @@ Ip6ProcessNeighborSolicit (
     OptionLen = (UINT16)(Head->PayloadLength - IP6_ND_LENGTH);
     if (OptionLen != 0) {
       Option = NetbufGetByte (Packet, IP6_ND_LENGTH, NULL);
-      ASSERT (Option != NULL);
+      if (Option == NULL) {
+        ASSERT (Option != NULL);
+        goto Exit;
+      }
 
       //
       // All included options should have a length that is greater than zero.
@@ -1754,7 +1796,11 @@ Ip6ProcessNeighborAdvertise (
     OptionLen = (UINT16)(Head->PayloadLength - IP6_ND_LENGTH);
     if (OptionLen != 0) {
       Option = NetbufGetByte (Packet, IP6_ND_LENGTH, NULL);
-      ASSERT (Option != NULL);
+      if (Option == NULL) {
+        ASSERT (Option != NULL);
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Exit;
+      }
 
       //
       // All included options should have a length that is greater than zero.
@@ -2011,7 +2057,10 @@ Ip6ProcessRouterAdvertise (
   OptionLen = (UINT16)(Head->PayloadLength - IP6_RA_LENGTH);
   if (OptionLen != 0) {
     Option = NetbufGetByte (Packet, IP6_RA_LENGTH, NULL);
-    ASSERT (Option != NULL);
+    if (Option == NULL) {
+      ASSERT (Option != NULL);
+      goto Exit;
+    }
 
     if (!Ip6IsNDOptionValid (Option, OptionLen)) {
       goto Exit;
@@ -2479,7 +2528,11 @@ Ip6ProcessRedirect (
   OptionLen = (UINT16)(Head->PayloadLength - IP6_REDITECT_LENGTH);
   if (OptionLen != 0) {
     Option = NetbufGetByte (Packet, IP6_REDITECT_LENGTH, NULL);
-    ASSERT (Option != NULL);
+    if (Option == NULL) {
+      ASSERT (Option != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Exit;
+    }
 
     if (!Ip6IsNDOptionValid (Option, OptionLen)) {
       goto Exit;

--- a/NetworkPkg/Ip6Dxe/Ip6Output.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Output.c
@@ -609,7 +609,11 @@ Ip6Output (
       }
 
       IcmpHead = (IP6_ICMP_HEAD *)NetbufGetByte (Packet, 0, NULL);
-      ASSERT (IcmpHead != NULL);
+      if (IcmpHead == NULL) {
+        ASSERT (IcmpHead != NULL);
+        return EFI_INVALID_PARAMETER;
+      }
+
       if (IcmpHead->Checksum == 0) {
         Checksum = &IcmpHead->Checksum;
       }
@@ -843,13 +847,22 @@ Ip6Output (
       // be fragmented below.
       //
       TmpPacket = NetbufGetFragment (Packet, 0, Packet->TotalSize, FragmentHdrsLen);
-      ASSERT (TmpPacket != NULL);
+      if (TmpPacket == NULL) {
+        ASSERT (TmpPacket != NULL);
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Error;
+      }
 
       //
       // Allocate the space to contain the fragmentable hdrs and copy the data.
       //
       Buf = NetbufAllocSpace (TmpPacket, FragmentHdrsLen, TRUE);
-      ASSERT (Buf != NULL);
+      if (Buf == NULL) {
+        ASSERT (Buf != NULL);
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Error;
+      }
+
       CopyMem (Buf, ExtHdrs + UnFragmentHdrsLen, FragmentHdrsLen);
 
       //


### PR DESCRIPTION

# Description
CodeQL static analysis reports potential NULL pointer dereferences in the IPv6 driver. Several configuration, packet processing, and transmit paths rely on ASSERT() or implicit assumptions to validate allocations and packet data. These assumptions do not provide runtime protection when assertions are disabled or packet data is malformed.

Add explicit NULL checks to the IPv6 configuration, interface, input, MLD, neighbor discovery, and output paths. Handle allocation failures while preserving DAD state, reject packets with unavailable extension header or ICMP error data, and stop MLD and neighbor discovery packet construction when required headers or options are unavailable.

Return appropriate errors or use existing failure paths for missing resources, neighbor entries, and invalid packet data. This prevents NULL pointer dereferences and invalid buffer accesses and resolves the related CodeQL static scanning failures.


- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No Integration necessary