### PR TITLE
NetworkPkg/IScsiDxe: Validate pointers before use

### DIFF
--- a/NetworkPkg/IScsiDxe/IScsiConfig.c
+++ b/NetworkPkg/IScsiDxe/IScsiConfig.c
@@ -1765,7 +1765,11 @@ IScsiConvertlfrNvDataToAttemptConfigDataByKeyword (
   //
   // Record the user configuration information in NVR.
   //
-  ASSERT (Attempt != NULL);
+  if (Attempt == NULL) {
+    ASSERT (Attempt != NULL);
+    return EFI_NOT_FOUND;
+  }
+
   UnicodeSPrint (mPrivate->PortString, (UINTN)ISCSI_NAME_IFR_MAX_SIZE, L"Attempt %d", Attempt->AttemptConfigIndex);
   return gRT->SetVariable (
                 mPrivate->PortString,
@@ -2825,6 +2829,11 @@ IScsiConfigProcessDefault (
       FreePool (AttemptConfigOrder);
     }
 
+    if (AttemptConfigData == NULL) {
+      ASSERT (AttemptConfigData != NULL);
+      return EFI_NOT_FOUND;
+    }
+
     //
     // Record the MAC info in Config Data.
     //
@@ -2835,7 +2844,6 @@ IScsiConfigProcessDefault (
       MacString
       );
 
-    ASSERT (AttemptConfigData != NULL);
     UnicodeStrToAsciiStrS (MacString, AttemptConfigData->MacString, sizeof (AttemptConfigData->MacString));
     AttemptConfigData->NicIndex = NicIndex;
     AttemptConfigData->Actived  = ISCSI_ACTIVE_ENABLED;
@@ -3053,8 +3061,14 @@ IScsiFormExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gIScsiConfigGuid, mVendorStorageName, Private->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
+    if (ConfigRequestHdr == NULL) {
+      FreePool (IfrNvData);
+      FreePool (InitiatorName);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
       FreePool (IfrNvData);
       FreePool (InitiatorName);

--- a/NetworkPkg/IScsiDxe/IScsiDriver.c
+++ b/NetworkPkg/IScsiDxe/IScsiDriver.c
@@ -858,12 +858,23 @@ IScsiStart (
       goto ON_ERROR;
     }
 
+    if (ExistPrivate == NULL) {
+      ASSERT (ExistPrivate != NULL);
+      Status = EFI_NOT_FOUND;
+      goto ON_ERROR;
+    }
+
     for (Index = 0; Index < AttemptConfigOrderSize / sizeof (UINT8); Index++) {
       if ((AttemptConfigOrder[Index] == mPrivate->BootSelectedIndex) ||
           (AttemptConfigOrder[Index] == BootSelected))
       {
         break;
       }
+    }
+
+    if (Index == AttemptConfigOrderSize / sizeof (UINT8)) {
+      Status = EFI_NOT_FOUND;
+      goto ON_ERROR;
     }
 
     if (mPrivate->EnableMpio) {

--- a/NetworkPkg/IScsiDxe/IScsiIbft.c
+++ b/NetworkPkg/IScsiDxe/IScsiIbft.c
@@ -318,7 +318,10 @@ IScsiFillNICAndTargetSections (
     // Get Nic Info: VLAN tag, Mac address, PCI location.
     //
     NicInfo = IScsiGetNicInfoByIndex (Attempt->NicIndex);
-    ASSERT (NicInfo != NULL);
+    if (NicInfo == NULL) {
+      ASSERT (NicInfo != NULL);
+      break;
+    }
 
     Nic->VLanTag = NicInfo->VlanId;
     CopyMem (Nic->Mac, &NicInfo->PermanentAddress, sizeof (Nic->Mac));
@@ -506,9 +509,15 @@ IScsiPublishIbft (
   //
   // Fill in the various section of the iSCSI Boot Firmware Table.
   //
-  if (Rsdp->Revision >= EFI_ACPI_2_0_ROOT_SYSTEM_DESCRIPTION_POINTER_REVISION) {
+  if (Xsdt != NULL) {
     IScsiInitIbfTableHeader (Table, Xsdt->OemId, &Xsdt->OemTableId);
   } else {
+    if (Rsdt == NULL) {
+      ASSERT (Rsdt != NULL);
+      FreePool (Table);
+      return;
+    }
+
     IScsiInitIbfTableHeader (Table, Rsdt->OemId, &Rsdt->OemTableId);
   }
 

--- a/NetworkPkg/IScsiDxe/IScsiMisc.c
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.c
@@ -2219,7 +2219,11 @@ IScsiGetConfigData (
     //
 
     NicInfo = IScsiGetNicInfoByIndex (mPrivate->CurrentNic);
-    ASSERT (NicInfo != NULL);
+    if (NicInfo == NULL) {
+      ASSERT (NicInfo != NULL);
+      break;
+    }
+
     IScsiMacAddrToStr (&NicInfo->PermanentAddress, NicInfo->HwAddressSize, NicInfo->VlanId, MacString);
     UnicodeSPrint (
       mPrivate->PortString,


### PR DESCRIPTION
# Description
CodeQL static analysis reports potential NULL pointer dereferences in the iSCSI driver. Configuration, boot attempt, NIC lookup, and iBFT construction paths rely on ASSERT() or unchecked API results before using returned pointers. ASSERT() does not provide runtime protection in release builds, so missing data or allocation failures may lead to invalid memory accesses.

Add runtime checks for missing attempt configuration and NIC data, and return or stop processing when required entries are unavailable. Handle HII configuration header allocation failure through the existing cleanup path. During iBFT publication, use an available XSDT or RSDT and free the allocated table when neither ACPI root table is available.

These checks prevent NULL pointer dereferences, preserve cleanup on failure, and resolve the related CodeQL static scanning failures.

- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No integration necessary