### PR TITLE
NetworkPkg: Handle HTTP buffer and allocation failures

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootConfig.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootConfig.c
@@ -324,8 +324,12 @@ HttpBootFormExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gHttpBootConfigGuid, mHttpBootConfigStorageName, CallbackInfo->ChildHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
+    if (ConfigRequestHdr == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }
@@ -683,16 +687,19 @@ HttpBootConfigFormInit (
                       STRING_TOKEN (STR_HTTP_BOOT_CONFIG_FORM_HELP),
                       NULL
                       );
-    UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
-    HiiSetString (
-      CallbackInfo->RegisteredHandle,
-      STRING_TOKEN (STR_HTTP_BOOT_CONFIG_FORM_HELP),
-      MenuString,
-      NULL
-      );
+    if (OldMenuString != NULL) {
+      UnicodeSPrint (MenuString, 128, L"%s (MAC:%s)", OldMenuString, MacString);
+      HiiSetString (
+        CallbackInfo->RegisteredHandle,
+        STRING_TOKEN (STR_HTTP_BOOT_CONFIG_FORM_HELP),
+        MenuString,
+        NULL
+        );
+
+      FreePool (OldMenuString);
+    }
 
     FreePool (MacString);
-    FreePool (OldMenuString);
 
     CallbackInfo->Initialized = TRUE;
     return EFI_SUCCESS;

--- a/NetworkPkg/HttpDxe/HttpImpl.c
+++ b/NetworkPkg/HttpDxe/HttpImpl.c
@@ -291,6 +291,10 @@ EfiHttpRequest (
   // Only support GET, HEAD, DELETE, CONNECT, PATCH, PUT and POST method in current implementation.
   //
   if (Request != NULL) {
+    if (Request->Url == NULL) {
+      return EFI_INVALID_PARAMETER;
+    }
+
     switch (Request->Method) {
       case HttpMethodGet:
       case HttpMethodHead:
@@ -381,12 +385,21 @@ EfiHttpRequest (
       HttpInstance->UrlLen = UrlLen;
     }
 
+    if (Url == NULL) {
+      return EFI_DEVICE_ERROR;
+    }
+
     UnicodeStrToAsciiStrS (Request->Url, Url, UrlLen);
 
     //
     // In case of HTTP Connect, parse proxy URI from Request.
     //
     if (Request->Method == HttpMethodConnect) {
+      if ((ConnRequest == NULL) || (ConnRequest->ProxyUrl == NULL)) {
+        ASSERT ((ConnRequest != NULL) && (ConnRequest->ProxyUrl != NULL));
+        return EFI_INVALID_PARAMETER;
+      }
+
       ProxyUrl    = HttpInstance->ProxyUrl;
       ProxyUrlLen = StrLen (ConnRequest->ProxyUrl) + 1;
       if (ProxyUrlLen > HttpInstance->ProxyUrlLen) {
@@ -403,6 +416,11 @@ EfiHttpRequest (
         HttpInstance->ProxyUrlLen = ProxyUrlLen;
       }
 
+      if (ProxyUrl == NULL) {
+        ASSERT (ProxyUrl != NULL);
+        return EFI_DEVICE_ERROR;
+      }
+
       UnicodeStrToAsciiStrS (ConnRequest->ProxyUrl, ProxyUrl, ProxyUrlLen);
     }
 
@@ -411,6 +429,11 @@ EfiHttpRequest (
     // be able to determine whether to use http or https.
     //
     if (Request->Method == HttpMethodConnect) {
+      if (ProxyUrl == NULL) {
+        ASSERT (ProxyUrl != NULL);
+        return EFI_DEVICE_ERROR;
+      }
+
       HttpInstance->UseHttps = IsHttpsUrl (ProxyUrl);
     } else {
       HttpInstance->UseHttps = IsHttpsUrl (Url);
@@ -688,8 +711,20 @@ EfiHttpRequest (
       goto Error3;
     }
 
+    if (HttpInstance->EndPointHostName == NULL) {
+      ASSERT (HttpInstance->EndPointHostName != NULL);
+      Status = EFI_DEVICE_ERROR;
+      goto Error3;
+    }
+
     Status = HttpUrlGetPort (Url, EndPointUrlParser, &EndPointRemotePort);
     if (EFI_ERROR (Status)) {
+      if (Url == NULL) {
+        ASSERT (Url != NULL);
+        Status = EFI_DEVICE_ERROR;
+        goto Error3;
+      }
+
       if (IsHttpsUrl (Url)) {
         EndPointRemotePort = HTTPS_DEFAULT_PORT;
       } else {
@@ -717,7 +752,7 @@ EfiHttpRequest (
     HttpUrlFreeParser (EndPointUrlParser);
   } else {
     FileUrl = Url;
-    if ((Url != NULL) && (*FileUrl != '/')) {
+    if ((FileUrl != NULL) && (*FileUrl != '/')) {
       //
       // Convert the absolute-URI to the absolute-path
       //
@@ -1201,7 +1236,12 @@ HttpResponseWorker (
       goto Error;
     }
 
-    ASSERT (HttpHeaders != NULL);
+    if ((HttpHeaders == NULL) || (EndofHeader == NULL)) {
+      ASSERT (HttpHeaders != NULL);
+      ASSERT (EndofHeader != NULL);
+      Status = EFI_DEVICE_ERROR;
+      goto Error;
+    }
 
     //
     // Cache the part of body.

--- a/NetworkPkg/HttpDxe/HttpProto.c
+++ b/NetworkPkg/HttpDxe/HttpProto.c
@@ -1857,7 +1857,10 @@ HttpTcpReceiveHeader (
   CHAR8              *Buffer;
   NET_FRAGMENT       Fragment;
 
-  ASSERT (HttpInstance != NULL);
+  if (HttpInstance == NULL) {
+    ASSERT (HttpInstance != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
 
   EndofHeader   = HttpInstance->EndofHeader;
   HttpHeaders   = HttpInstance->HttpHeaders;
@@ -1869,10 +1872,22 @@ HttpTcpReceiveHeader (
   Fragment.Len  = 0;
   Fragment.Bulk = NULL;
 
+  if ((EndofHeader == NULL) || (HttpHeaders == NULL)) {
+    ASSERT (EndofHeader != NULL);
+    ASSERT (HttpHeaders != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
   if (HttpInstance->LocalAddressIsIPv6) {
-    ASSERT (Tcp6 != NULL);
+    if (Tcp6 == NULL) {
+      ASSERT (Tcp6 != NULL);
+      return EFI_INVALID_PARAMETER;
+    }
   } else {
-    ASSERT (Tcp4 != NULL);
+    if (Tcp4 == NULL) {
+      ASSERT (Tcp4 != NULL);
+      return EFI_INVALID_PARAMETER;
+    }
   }
 
   if (!HttpInstance->UseHttps) {
@@ -1884,12 +1899,21 @@ HttpTcpReceiveHeader (
 
   if (!HttpInstance->LocalAddressIsIPv6) {
     if (!HttpInstance->UseHttps) {
-      Rx4Token                                                 = &HttpInstance->Rx4Token;
+      Rx4Token = &HttpInstance->Rx4Token;
+      if (Rx4Token == NULL) {
+        ASSERT (Rx4Token != NULL);
+        return EFI_DEVICE_ERROR;
+      }
+
       Rx4Token->Packet.RxData->FragmentTable[0].FragmentBuffer = AllocateZeroPool (DEF_BUF_LEN);
       if (Rx4Token->Packet.RxData->FragmentTable[0].FragmentBuffer == NULL) {
         Status = EFI_OUT_OF_RESOURCES;
         return Status;
       }
+    }
+
+    if (Rx4Token  == NULL) {
+      return EFI_INVALID_PARAMETER;
     }
 
     //
@@ -1984,7 +2008,12 @@ HttpTcpReceiveHeader (
     }
   } else {
     if (!HttpInstance->UseHttps) {
-      Rx6Token                                                 = &HttpInstance->Rx6Token;
+      Rx6Token = &HttpInstance->Rx6Token;
+      if (Rx6Token == NULL) {
+        ASSERT (Rx6Token != NULL);
+        return EFI_DEVICE_ERROR;
+      }
+
       Rx6Token->Packet.RxData->FragmentTable[0].FragmentBuffer = AllocateZeroPool (DEF_BUF_LEN);
       if (Rx6Token->Packet.RxData->FragmentTable[0].FragmentBuffer == NULL) {
         Status = EFI_OUT_OF_RESOURCES;

--- a/NetworkPkg/HttpDxe/HttpsSupport.c
+++ b/NetworkPkg/HttpDxe/HttpsSupport.c
@@ -908,6 +908,16 @@ TlsCommonReceive (
     return EFI_INVALID_PARAMETER;
   }
 
+  if (!HttpInstance->LocalAddressIsIPv6 && (HttpInstance->Tcp4 == NULL)) {
+    ASSERT (HttpInstance->Tcp4 != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (HttpInstance->LocalAddressIsIPv6 && (HttpInstance->Tcp6 == NULL)) {
+    ASSERT (HttpInstance->Tcp6 != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
   FragmentCount = Packet->BlockOpNum;
   Fragment      = AllocatePool (FragmentCount * sizeof (NET_FRAGMENT));
   if (Fragment == NULL) {
@@ -923,14 +933,18 @@ TlsCommonReceive (
   if (!HttpInstance->LocalAddressIsIPv6) {
     Tcp4RxData = HttpInstance->Tcp4TlsRxToken.Packet.RxData;
     if (Tcp4RxData == NULL) {
-      return EFI_INVALID_PARAMETER;
+      ASSERT (Tcp4RxData != NULL);
+      Status = EFI_INVALID_PARAMETER;
+      goto ON_EXIT;
     }
 
     Tcp4RxData->FragmentCount = 1;
   } else {
     Tcp6RxData = HttpInstance->Tcp6TlsRxToken.Packet.RxData;
     if (Tcp6RxData == NULL) {
-      return EFI_INVALID_PARAMETER;
+      ASSERT (Tcp6RxData != NULL);
+      Status = EFI_INVALID_PARAMETER;
+      goto ON_EXIT;
     }
 
     Tcp6RxData->FragmentCount = 1;
@@ -941,11 +955,23 @@ TlsCommonReceive (
 
   while (CurrentFragment < FragmentCount) {
     if (!HttpInstance->LocalAddressIsIPv6) {
+      if (Tcp4RxData == NULL) {
+        ASSERT (Tcp4RxData != NULL);
+        Status = EFI_DEVICE_ERROR;
+        goto ON_EXIT;
+      }
+
       Tcp4RxData->DataLength                      = Fragment[CurrentFragment].Len;
       Tcp4RxData->FragmentTable[0].FragmentLength = Fragment[CurrentFragment].Len;
       Tcp4RxData->FragmentTable[0].FragmentBuffer = Fragment[CurrentFragment].Bulk;
       Status                                      = HttpInstance->Tcp4->Receive (HttpInstance->Tcp4, &HttpInstance->Tcp4TlsRxToken);
     } else {
+      if (Tcp6RxData == NULL) {
+        ASSERT (Tcp6RxData != NULL);
+        Status = EFI_DEVICE_ERROR;
+        goto ON_EXIT;
+      }
+
       Tcp6RxData->DataLength                      = Fragment[CurrentFragment].Len;
       Tcp6RxData->FragmentTable[0].FragmentLength = Fragment[CurrentFragment].Len;
       Tcp6RxData->FragmentTable[0].FragmentBuffer = Fragment[CurrentFragment].Bulk;
@@ -989,6 +1015,12 @@ TlsCommonReceive (
         goto ON_EXIT;
       }
 
+      if (Tcp4RxData == NULL) {
+        ASSERT (Tcp4RxData != NULL);
+        Status = EFI_DEVICE_ERROR;
+        goto ON_EXIT;
+      }
+
       Fragment[CurrentFragment].Len -= Tcp4RxData->FragmentTable[0].FragmentLength;
       if (Fragment[CurrentFragment].Len == 0) {
         CurrentFragment++;
@@ -998,6 +1030,12 @@ TlsCommonReceive (
     } else {
       Status = HttpInstance->Tcp6TlsRxToken.CompletionToken.Status;
       if (EFI_ERROR (Status)) {
+        goto ON_EXIT;
+      }
+
+      if (Tcp6RxData == NULL) {
+        ASSERT (Tcp6RxData != NULL);
+        Status = EFI_DEVICE_ERROR;
         goto ON_EXIT;
       }
 

--- a/NetworkPkg/HttpUtilitiesDxe/HttpUtilitiesProtocol.c
+++ b/NetworkPkg/HttpUtilitiesDxe/HttpUtilitiesProtocol.c
@@ -85,7 +85,10 @@ HttpUtilitiesBuild (
   *NewMessageSize = 0;
   Status          = EFI_SUCCESS;
 
-  if (This == NULL) {
+  if ((This == NULL) || (NewMessageSize == NULL) || (NewMessage == NULL) ||
+      ((DeleteCount != 0) && (DeleteList == NULL)) ||
+      ((AppendCount != 0) && (AppendList == NULL)))
+  {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -100,12 +103,24 @@ HttpUtilitiesBuild (
     if (EFI_ERROR (Status)) {
       goto ON_EXIT;
     }
+
+    if ((SeedFieldCount != 0) && (SeedHeaderFields == NULL)) {
+      ASSERT (SeedHeaderFields != NULL);
+      Status = EFI_DEVICE_ERROR;
+      goto ON_EXIT;
+    }
   }
 
   //
   // Handle DeleteList
   //
   if ((SeedFieldCount != 0) && (DeleteCount != 0)) {
+    if (SeedHeaderFields == NULL) {
+      ASSERT (SeedHeaderFields != NULL);
+      Status = EFI_DEVICE_ERROR;
+      goto ON_EXIT;
+    }
+
     TempHeaderFields = AllocateZeroPool (SeedFieldCount * sizeof (EFI_HTTP_HEADER));
     if (TempHeaderFields == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
@@ -144,6 +159,12 @@ HttpUtilitiesBuild (
   }
 
   for (Index = 0; Index < TempFieldCount; Index++) {
+    if (TempHeaderFields == NULL) {
+      ASSERT (TempHeaderFields != NULL);
+      Status = EFI_DEVICE_ERROR;
+      goto ON_EXIT;
+    }
+
     Status = HttpSetFieldNameAndValue (
                &NewHeaderFields[Index],
                TempHeaderFields[Index].FieldName,
@@ -157,6 +178,12 @@ HttpUtilitiesBuild (
   NewFieldCount = TempFieldCount;
 
   for (Index = 0; Index < AppendCount; Index++) {
+    if (AppendList[Index] == NULL) {
+      ASSERT (AppendList[Index] != NULL);
+      Status = EFI_INVALID_PARAMETER;
+      goto ON_EXIT;
+    }
+
     HttpHeader = HttpFindHeader (NewFieldCount, NewHeaderFields, AppendList[Index]->FieldName);
     if (HttpHeader != NULL) {
       Status = HttpSetFieldNameAndValue (


### PR DESCRIPTION
# Description
CodeQL static analysis reports potential NULL pointer dereferences and unchecked allocation results in the HTTP stack. HTTP Boot configuration, HTTP request and response processing, HTTPS receive handling, and HTTP Utilities may continue with missing or partially initialized data after an allocation or protocol operation fails.

Add runtime validation for configuration headers, request and response data, received headers, TLS buffers, and utility output structures. Propagate allocation and lower-level protocol failures to callers, and release partially constructed state on error paths.

These checks prevent NULL pointer dereferences, invalid buffer accesses, and resource leaks, and resolve the related CodeQL static scanning failures.

- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No integration necessary 