### PR TITLE
NetworkPkg: Validate network library operation results

### DIFF
--- a/NetworkPkg/Library/DxeHttpIoLib/DxeHttpIoLib.c
+++ b/NetworkPkg/Library/DxeHttpIoLib/DxeHttpIoLib.c
@@ -535,12 +535,20 @@ HttpIoSendChunkedTransfer (
       }
 
       NewHeaders = AllocateZeroPool ((RequestMessage->HeaderCount + AddNewHeader) * sizeof (EFI_HTTP_HEADER));
+      if (NewHeaders == NULL) {
+        return EFI_OUT_OF_RESOURCES;
+      }
+
       CopyMem ((VOID *)NewHeaders, (VOID *)RequestMessage->Headers, RequestMessage->HeaderCount * sizeof (EFI_HTTP_HEADER));
       if (AddNewHeader == 0) {
         //
         // Override content-length to Transfer-Encoding.
         //
-        ContentLengthHeader             = HttpFindHeader (RequestMessage->HeaderCount, NewHeaders, HTTP_HEADER_CONTENT_LENGTH);
+        ContentLengthHeader = HttpFindHeader (RequestMessage->HeaderCount, NewHeaders, HTTP_HEADER_CONTENT_LENGTH);
+        if (ContentLengthHeader == NULL) {
+          return EFI_INVALID_PARAMETER;
+        }
+
         ContentLengthHeader->FieldName  = NULL;
         ContentLengthHeader->FieldValue = NULL;
       } else {

--- a/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
+++ b/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
@@ -752,8 +752,11 @@ HttpUrlGetPort (
   }
 
   Status =  AsciiStrDecimalToUintnS (Url + Parser->FieldData[HTTP_URI_FIELD_PORT].Offset, (CHAR8 **)NULL, &Data);
+  if (EFI_ERROR (Status)) {
+    goto ON_EXIT;
+  }
 
-  if (EFI_ERROR (Status) || (Data > HTTP_URI_PORT_MAX_NUM)) {
+  if (Data > HTTP_URI_PORT_MAX_NUM) {
     Status = EFI_INVALID_PARAMETER;
     goto ON_EXIT;
   }

--- a/NetworkPkg/Library/DxeNetLib/NetBuffer.c
+++ b/NetworkPkg/Library/DxeNetLib/NetBuffer.c
@@ -303,6 +303,11 @@ NetbufDuplicate (
   NetbufReserve (Duplicate, HeadSpace);
 
   Dst = NetbufAllocSpace (Duplicate, Nbuf->TotalSize, NET_BUF_TAIL);
+  if (Dst == NULL) {
+    ASSERT (Dst != NULL);
+    return NULL;
+  }
+
   NetbufCopy (Nbuf, 0, Nbuf->TotalSize, Dst);
 
   return Duplicate;

--- a/NetworkPkg/Library/DxeTcpIoLib/DxeTcpIoLib.c
+++ b/NetworkPkg/Library/DxeTcpIoLib/DxeTcpIoLib.c
@@ -188,14 +188,29 @@ TcpIoCreateSocket (
                   Controller,
                   EFI_OPEN_PROTOCOL_BY_DRIVER
                   );
-  if (EFI_ERROR (Status) || (*Interface == NULL)) {
+  if (EFI_ERROR (Status)) {
+    goto ON_ERROR;
+  }
+
+  if (*Interface == NULL) {
+    Status = EFI_DEVICE_ERROR;
     goto ON_ERROR;
   }
 
   if (TcpVersion == TCP_VERSION_4) {
     Tcp4 = TcpIo->Tcp.Tcp4;
+    if (Tcp4 == NULL) {
+      ASSERT (Tcp4 != NULL);
+      Status = EFI_DEVICE_ERROR;
+      goto ON_ERROR;
+    }
   } else {
     Tcp6 = TcpIo->Tcp.Tcp6;
+    if (Tcp6 == NULL) {
+      ASSERT (Tcp6 != NULL);
+      Status = EFI_DEVICE_ERROR;
+      goto ON_ERROR;
+    }
   }
 
   TcpIo->Image      = Image;
@@ -248,8 +263,6 @@ TcpIoCreateSocket (
       sizeof (EFI_IPv4_ADDRESS)
       );
 
-    ASSERT (Tcp4 != NULL);
-
     //
     // Configure the TCP4 protocol.
     //
@@ -287,7 +300,6 @@ TcpIoCreateSocket (
 
     IP6_COPY_ADDRESS (&AccessPoint6->RemoteAddress, &ConfigData->Tcp6IoConfigData.RemoteIp);
 
-    ASSERT (Tcp6 != NULL);
     //
     // Configure the TCP6 protocol.
     //
@@ -550,10 +562,18 @@ TcpIoConnect (
   Tcp6 = NULL;
 
   if (TcpIo->TcpVersion == TCP_VERSION_4) {
-    Tcp4   = TcpIo->Tcp.Tcp4;
+    Tcp4 = TcpIo->Tcp.Tcp4;
+    if (Tcp4 == NULL) {
+      return EFI_INVALID_PARAMETER;
+    }
+
     Status = Tcp4->Connect (Tcp4, &TcpIo->ConnToken.Tcp4Token);
   } else if (TcpIo->TcpVersion == TCP_VERSION_6) {
-    Tcp6   = TcpIo->Tcp.Tcp6;
+    Tcp6 = TcpIo->Tcp.Tcp6;
+    if (Tcp6 == NULL) {
+      return EFI_INVALID_PARAMETER;
+    }
+
     Status = Tcp6->Connect (Tcp6, &TcpIo->ConnToken.Tcp6Token);
   } else {
     return EFI_UNSUPPORTED;
@@ -626,10 +646,18 @@ TcpIoAccept (
   Tcp6 = NULL;
 
   if (TcpIo->TcpVersion == TCP_VERSION_4) {
-    Tcp4   = TcpIo->Tcp.Tcp4;
+    Tcp4 = TcpIo->Tcp.Tcp4;
+    if (Tcp4 == NULL) {
+      return EFI_INVALID_PARAMETER;
+    }
+
     Status = Tcp4->Accept (Tcp4, &TcpIo->ListenToken.Tcp4Token);
   } else if (TcpIo->TcpVersion == TCP_VERSION_6) {
-    Tcp6   = TcpIo->Tcp.Tcp6;
+    Tcp6 = TcpIo->Tcp.Tcp6;
+    if (Tcp6 == NULL) {
+      return EFI_INVALID_PARAMETER;
+    }
+
     Status = Tcp6->Accept (Tcp6, &TcpIo->ListenToken.Tcp6Token);
   } else {
     return EFI_UNSUPPORTED;
@@ -678,6 +706,9 @@ TcpIoAccept (
                     TcpIo->Controller,
                     EFI_OPEN_PROTOCOL_BY_DRIVER
                     );
+    if (!EFI_ERROR (Status) && (TcpIo->NewTcp.Tcp4 == NULL)) {
+      Status = EFI_DEVICE_ERROR;
+    }
   }
 
   return Status;
@@ -710,11 +741,19 @@ TcpIoReset (
   if (TcpIo->TcpVersion == TCP_VERSION_4) {
     TcpIo->CloseToken.Tcp4Token.AbortOnClose = TRUE;
     Tcp4                                     = TcpIo->Tcp.Tcp4;
-    Status                                   = Tcp4->Close (Tcp4, &TcpIo->CloseToken.Tcp4Token);
+    if (Tcp4 == NULL) {
+      return;
+    }
+
+    Status = Tcp4->Close (Tcp4, &TcpIo->CloseToken.Tcp4Token);
   } else if (TcpIo->TcpVersion == TCP_VERSION_6) {
     TcpIo->CloseToken.Tcp6Token.AbortOnClose = TRUE;
     Tcp6                                     = TcpIo->Tcp.Tcp6;
-    Status                                   = Tcp6->Close (Tcp6, &TcpIo->CloseToken.Tcp6Token);
+    if (Tcp6 == NULL) {
+      return;
+    }
+
+    Status = Tcp6->Close (Tcp6, &TcpIo->CloseToken.Tcp6Token);
   } else {
     return;
   }


### PR DESCRIPTION
# Description
CodeQL static analysis reports potential NULL pointer dereferences and unchecked return values in shared networking libraries. HTTP, network buffer, and TCP I/O paths may continue after allocation, parsing, protocol lookup, or interface initialization fails, resulting in invalid memory accesses or operations on incomplete objects.

Validate HTTP chunk header allocation and require Content-Length before transforming the request. Propagate URL port parsing failures before checking the parsed value, and stop network buffer duplication when destination allocation fails. Verify TCP4 and TCP6 interfaces and protocol instances before invoking socket operations. Return an appropriate error or stop when required objects are unavailable.

These checks prevent NULL pointer dereferences, invalid buffer copies, and use of partially initialized protocol state, and resolve the related CodeQL static scanning failures.

- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No integration necessary 