### PR TITLE
NetworkPkg: Validate DHCP packet processing state

### DIFF
--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
@@ -1360,7 +1360,10 @@ PxeDhcpInput (
   }
 
   Packet = (EFI_DHCP4_PACKET *)NetbufAllocSpace (Wrap, Len, NET_BUF_TAIL);
-  ASSERT (Packet != NULL);
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    goto RESTART;
+  }
 
   Packet->Size   = Len;
   Head           = &Packet->Dhcp4.Header;

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -1135,6 +1135,21 @@ DhcpSendMessage (
   UINT32                 Len;
   UINT32                 Index;
 
+  if (((Type == DHCP_MSG_DECLINE) || (Type == DHCP_MSG_RELEASE) ||
+       ((Type == DHCP_MSG_REQUEST) && (DhcpSb->DhcpState == Dhcp4Requesting))) &&
+      ((Para == NULL) || (Para->ServerId == 0)))
+  {
+    ASSERT ((Para != NULL) && (Para->ServerId != 0));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((((Type == DHCP_MSG_REQUEST) && (DhcpSb->DhcpState == Dhcp4Requesting)) ||
+       (Type == DHCP_MSG_DECLINE)) && (Seed == NULL))
+  {
+    ASSERT (Seed != NULL);
+    return EFI_INVALID_PARAMETER;
+  }
+
   //
   // Allocate a big enough memory block to hold the DHCP packet
   //
@@ -1203,8 +1218,6 @@ DhcpSendMessage (
       ((Type == DHCP_MSG_REQUEST) && (DhcpSb->DhcpState == Dhcp4Requesting))
       )
   {
-    ASSERT ((Para != NULL) && (Para->ServerId != 0));
-
     IpAddr = HTONL (Para->ServerId);
     Buf    = DhcpAppendOption (Buf, DHCP4_TAG_SERVER_ID, 4, (UINT8 *)&IpAddr);
   }
@@ -1221,11 +1234,21 @@ DhcpSendMessage (
     if (DhcpSb->DhcpState == Dhcp4Rebooting) {
       IpAddr = EFI_IP4 (Config->ClientAddress);
     } else if (DhcpSb->DhcpState == Dhcp4Requesting) {
-      ASSERT (SeedHead != NULL);
+      if (SeedHead == NULL) {
+        ASSERT (SeedHead != NULL);
+        FreePool (Packet);
+        return EFI_INVALID_PARAMETER;
+      }
+
       IpAddr = EFI_IP4 (SeedHead->YourAddr);
     }
   } else if (Type == DHCP_MSG_DECLINE) {
-    ASSERT (SeedHead != NULL);
+    if (SeedHead == NULL) {
+      ASSERT (SeedHead != NULL);
+      FreePool (Packet);
+      return EFI_INVALID_PARAMETER;
+    }
+
     IpAddr = EFI_IP4 (SeedHead->YourAddr);
   }
 

--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Io.c
@@ -2948,6 +2948,16 @@ Dhcp6HandleStateless (
     goto ON_EXIT;
   }
 
+  if (InfCb == NULL) {
+    ASSERT (InfCb != NULL);
+    goto ON_EXIT;
+  }
+
+  if (InfCb->ReplyCallback == NULL) {
+    ASSERT (InfCb->ReplyCallback != NULL);
+    goto ON_EXIT;
+  }
+
   //
   // Check whether include server Id or not.
   //
@@ -3084,6 +3094,11 @@ Dhcp6ReceivePacket (
       TxCb = NET_LIST_USER_STRUCT (Entry2, DHCP6_TX_CB, Link);
 
       if (Packet->Dhcp6.Header.TransactionId == TxCb->Xid) {
+        if (TxCb->TxPacket == NULL) {
+          ASSERT (TxCb->TxPacket != NULL);
+          continue;
+        }
+
         //
         // Find the corresponding packet in tx list, and check it whether belongs
         // to stateful exchange process.
@@ -3106,6 +3121,11 @@ Dhcp6ReceivePacket (
   // Skip this packet if not dispatched to any instance.
   //
   if (!IsDispatched) {
+    goto ON_CONTINUE;
+  }
+
+  if (Instance == NULL) {
+    ASSERT (Instance != NULL);
     goto ON_CONTINUE;
   }
 


### PR DESCRIPTION
# Description
CodeQL static analysis reports potential NULL pointer dereferences in the DHCPv4 and DHCPv6 drivers. Packet allocation, message construction, callback dispatch, and transaction processing paths rely on ASSERT() or implicit state assumptions before using returned pointers. ASSERT() does not provide runtime protection in release builds.

Restart DHCPv4 PXE processing when packet allocation fails. Validate server identifiers, request parameters, and packet seed data before constructing DHCPv4 messages, returning EFI_INVALID_PARAMETER and freeing allocated packet memory on invalid input. In DHCPv6, verify callback, transmitted packet, and instance pointers before dispatching through the existing exit or continue paths.

These checks prevent NULL pointer dereferences, reject inconsistent DHCP state, preserve cleanup on failure, and resolve the related CodeQL static scanning failures.


- [ ] Breaking change?
- [X] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No integration necessary