### PR TITLE
NetworkPkg: Handle NULL results in network components

### DIFF
--- a/NetworkPkg/Application/VConfig/VConfig.c
+++ b/NetworkPkg/Application/VConfig/VConfig.c
@@ -651,18 +651,34 @@ VlanConfigMain (
 
   if (ShellCommandLineGetFlag (List, L"-l")) {
     Str = ShellCommandLineGetValue (List, L"-l");
+    if (Str == NULL) {
+      ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_VCONFIG_NO_IF), mHiiHandle);
+      goto Exit;
+    }
+
     DisplayVlan ((CHAR16 *)Str);
     goto Exit;
   }
 
   if (ShellCommandLineGetFlag (List, L"-a")) {
     Str = ShellCommandLineGetValue (List, L"-a");
+    if (Str == NULL) {
+      ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_VCONFIG_NO_IF), mHiiHandle);
+      goto Exit;
+    }
+
     AddVlan ((CHAR16 *)Str);
+
     goto Exit;
   }
 
   if (ShellCommandLineGetFlag (List, L"-d")) {
     Str = ShellCommandLineGetValue (List, L"-d");
+    if (Str == NULL) {
+      ShellPrintHiiEx (-1, -1, NULL, STRING_TOKEN (STR_VCONFIG_NO_IF), mHiiHandle);
+      goto Exit;
+    }
+
     DeleteVlan ((CHAR16 *)Str);
     goto Exit;
   }

--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -1089,7 +1089,11 @@ IsValidDnsResponse (
       continue;
     } else {
       TxString = NetbufGetByte (Packet, 0, NULL);
-      ASSERT (TxString != NULL);
+      if (TxString == NULL) {
+        ASSERT (TxString != NULL);
+        continue;
+      }
+
       DnsHeader    = (DNS_HEADER *)TxString;
       QueryName    = (CHAR8 *)(TxString + sizeof (*DnsHeader));
       QuerySection = (DNS_QUERY_SECTION *)(QueryName + AsciiStrLen (QueryName) + 1);
@@ -1256,7 +1260,13 @@ ParseDnsResponse (
       goto ON_EXIT;
     }
 
-    ASSERT (Item != NULL);
+    if ((Item == NULL) || (Item->Key == NULL)) {
+      ASSERT ((Item != NULL) && (Item->Key != NULL));
+      *Completed = FALSE;
+      Status     = EFI_ABORTED;
+      goto ON_EXIT;
+    }
+
     Dns4TokenEntry = (DNS4_TOKEN_ENTRY *)(Item->Key);
   } else {
     if (!IsValidDnsResponse (
@@ -1272,7 +1282,13 @@ ParseDnsResponse (
       goto ON_EXIT;
     }
 
-    ASSERT (Item != NULL);
+    if ((Item == NULL) || (Item->Key == NULL)) {
+      ASSERT ((Item != NULL) && (Item->Key != NULL));
+      *Completed = FALSE;
+      Status     = EFI_ABORTED;
+      goto ON_EXIT;
+    }
+
     Dns6TokenEntry = (DNS6_TOKEN_ENTRY *)(Item->Key);
   }
 
@@ -1298,7 +1314,11 @@ ParseDnsResponse (
   // Do some buffer allocations.
   //
   if (Instance->Service->IpVersion == IP_VERSION_4) {
-    ASSERT (Dns4TokenEntry != NULL);
+    if (Dns4TokenEntry == NULL) {
+      ASSERT (Dns4TokenEntry != NULL);
+      Status = EFI_ABORTED;
+      goto ON_EXIT;
+    }
 
     if (Dns4TokenEntry->GeneralLookUp) {
       //
@@ -1337,7 +1357,11 @@ ParseDnsResponse (
       }
     }
   } else {
-    ASSERT (Dns6TokenEntry != NULL);
+    if (Dns6TokenEntry == NULL) {
+      ASSERT (Dns6TokenEntry != NULL);
+      Status = EFI_ABORTED;
+      goto ON_EXIT;
+    }
 
     if (Dns6TokenEntry->GeneralLookUp) {
       //
@@ -1432,7 +1456,19 @@ ParseDnsResponse (
     //
     // Check whether it's the GeneralLookUp querying.
     //
-    if ((Instance->Service->IpVersion == IP_VERSION_4) && Dns4TokenEntry->GeneralLookUp) {
+    if (Instance->Service->IpVersion == IP_VERSION_4) {
+      if (Dns4TokenEntry == NULL) {
+        ASSERT (Dns4TokenEntry != NULL);
+        Status = EFI_ABORTED;
+        goto ON_EXIT;
+      }
+    } else if (Dns6TokenEntry == NULL) {
+      ASSERT (Dns6TokenEntry != NULL);
+      Status = EFI_ABORTED;
+      goto ON_EXIT;
+    }
+
+    if ((Instance->Service->IpVersion == IP_VERSION_4) && (Dns4TokenEntry != NULL) && Dns4TokenEntry->GeneralLookUp) {
       Dns4RR     = Dns4TokenEntry->Token->RspData.GLookupData->RRList;
       AnswerData = (UINT8 *)AnswerSection + sizeof (*AnswerSection);
 
@@ -1460,7 +1496,7 @@ ParseDnsResponse (
 
       RRCount++;
       Status = EFI_SUCCESS;
-    } else if ((Instance->Service->IpVersion == IP_VERSION_6) && Dns6TokenEntry->GeneralLookUp) {
+    } else if ((Instance->Service->IpVersion == IP_VERSION_6) && (Dns6TokenEntry != NULL) && Dns6TokenEntry->GeneralLookUp) {
       Dns6RR     = Dns6TokenEntry->Token->RspData.GLookupData->RRList;
       AnswerData = (UINT8 *)AnswerSection + sizeof (*AnswerSection);
 
@@ -1498,7 +1534,11 @@ ParseDnsResponse (
           //
           // This is address entry, get Data.
           //
-          ASSERT (Dns4TokenEntry != NULL);
+          if (Dns4TokenEntry == NULL) {
+            ASSERT (Dns4TokenEntry != NULL);
+            Status = EFI_ABORTED;
+            goto ON_EXIT;
+          }
 
           if (AnswerSection->DataLength != 4) {
             Status = EFI_ABORTED;
@@ -1560,7 +1600,11 @@ ParseDnsResponse (
           //
           // This is address entry, get Data.
           //
-          ASSERT (Dns6TokenEntry != NULL);
+          if (Dns6TokenEntry == NULL) {
+            ASSERT (Dns6TokenEntry != NULL);
+            Status = EFI_ABORTED;
+            goto ON_EXIT;
+          }
 
           if (AnswerSection->DataLength != 16) {
             Status = EFI_ABORTED;
@@ -1639,7 +1683,11 @@ ParseDnsResponse (
   }
 
   if (Instance->Service->IpVersion == IP_VERSION_4) {
-    ASSERT (Dns4TokenEntry != NULL);
+    if (Dns4TokenEntry == NULL) {
+      ASSERT (Dns4TokenEntry != NULL);
+      Status = EFI_ABORTED;
+      goto ON_EXIT;
+    }
 
     if (Dns4TokenEntry->GeneralLookUp) {
       Dns4TokenEntry->Token->RspData.GLookupData->RRCount = RRCount;
@@ -1652,7 +1700,11 @@ ParseDnsResponse (
       }
     }
   } else {
-    ASSERT (Dns6TokenEntry != NULL);
+    if (Dns6TokenEntry == NULL) {
+      ASSERT (Dns6TokenEntry != NULL);
+      Status = EFI_ABORTED;
+      goto ON_EXIT;
+    }
 
     if (Dns6TokenEntry->GeneralLookUp) {
       Dns6TokenEntry->Token->RspData.GLookupData->RRCount = RRCount;
@@ -1675,7 +1727,12 @@ ON_COMPLETE:
   }
 
   if (Instance->Service->IpVersion == IP_VERSION_4) {
-    ASSERT (Dns4TokenEntry != NULL);
+    if (Dns4TokenEntry == NULL) {
+      ASSERT (Dns4TokenEntry != NULL);
+      Status = EFI_ABORTED;
+      goto ON_EXIT;
+    }
+
     Dns4RemoveTokenEntry (&Instance->Dns4TxTokens, Dns4TokenEntry);
     Dns4TokenEntry->Token->Status = Status;
     if (Dns4TokenEntry->Token->Event != NULL) {
@@ -1683,7 +1740,12 @@ ON_COMPLETE:
       DispatchDpc ();
     }
   } else {
-    ASSERT (Dns6TokenEntry != NULL);
+    if (Dns6TokenEntry == NULL) {
+      ASSERT (Dns6TokenEntry != NULL);
+      Status = EFI_ABORTED;
+      goto ON_EXIT;
+    }
+
     Dns6RemoveTokenEntry (&Instance->Dns6TxTokens, Dns6TokenEntry);
     Dns6TokenEntry->Token->Status = Status;
     if (Dns6TokenEntry->Token->Event != NULL) {

--- a/NetworkPkg/MnpDxe/MnpIo.c
+++ b/NetworkPkg/MnpDxe/MnpIo.c
@@ -621,7 +621,10 @@ MnpAnalysePacket (
   // Get the packet buffer.
   //
   BufPtr = NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (BufPtr != NULL);
+  if (BufPtr == NULL) {
+    ASSERT (BufPtr != NULL);
+    return;
+  }
 
   //
   // Set the initial values.
@@ -873,7 +876,10 @@ MnpReceivePacket (
   Nbuf   = MnpDeviceData->RxNbufCache;
   BufLen = Nbuf->TotalSize;
   BufPtr = NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (BufPtr != NULL);
+  if (BufPtr == NULL) {
+    ASSERT (BufPtr != NULL);
+    return EFI_DEVICE_ERROR;
+  }
 
   //
   // Receive packet through Snp.

--- a/NetworkPkg/MnpDxe/MnpVlan.c
+++ b/NetworkPkg/MnpDxe/MnpVlan.c
@@ -131,7 +131,10 @@ MnpRemoveVlanTag (
   // Get the packet buffer.
   //
   Packet = NetbufGetByte (Nbuf, 0, NULL);
-  ASSERT (Packet != NULL);
+  if (Packet == NULL) {
+    ASSERT (Packet != NULL);
+    return FALSE;
+  }
 
   //
   // Check whether this is VLAN tagged frame by Ether Type

--- a/NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigImpl.c
+++ b/NetworkPkg/TlsAuthConfigDxe/TlsAuthConfigImpl.c
@@ -614,7 +614,11 @@ ExtractFileNameFromDevicePath (
 
   ASSERT (DevicePath != NULL);
 
-  String      = DevicePathToStr (DevicePath);
+  String = DevicePathToStr (DevicePath);
+  if (String == NULL) {
+    return NULL;
+  }
+
   MatchString = String;
   LastMatch   = String;
   FileName    = NULL;
@@ -1225,9 +1229,18 @@ TlsAuthConfigAccessExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gTlsAuthConfigGuid, mTlsAuthConfigStorageName, Private->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequestHdr == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);

--- a/NetworkPkg/Udp4Dxe/Udp4Impl.c
+++ b/NetworkPkg/Udp4Dxe/Udp4Impl.c
@@ -1599,7 +1599,11 @@ Udp4Demultiplex (
   // Get the datagram header from the packet buffer.
   //
   Udp4Header = (EFI_UDP_HEADER *)NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Udp4Header != NULL);
+  if (Udp4Header == NULL) {
+    ASSERT (Udp4Header != NULL);
+    NetbufFree (Packet);
+    return;
+  }
 
   if (Udp4Header->Checksum != 0) {
     //
@@ -1714,7 +1718,11 @@ Udp4SendPortUnreach (
   // Allocate space for the IP4_ICMP_ERROR_HEAD.
   //
   IcmpErrHdr = (IP4_ICMP_ERROR_HEAD *)NetbufAllocSpace (Packet, Len, FALSE);
-  ASSERT (IcmpErrHdr != NULL);
+  if (IcmpErrHdr == NULL) {
+    ASSERT (IcmpErrHdr != NULL);
+    NetbufFree (Packet);
+    return;
+  }
 
   //
   // Set the required fields for the icmp port unreachable message.
@@ -1789,7 +1797,11 @@ Udp4IcmpHandler (
   }
 
   Udp4Header = (EFI_UDP_HEADER *)NetbufGetByte (Packet, 0, NULL);
-  ASSERT (Udp4Header != NULL);
+  if (Udp4Header == NULL) {
+    ASSERT (Udp4Header != NULL);
+    NetbufFree (Packet);
+    return;
+  }
 
   CopyMem (&Udp4Session.SourceAddress, &NetSession->Source, sizeof (EFI_IPv4_ADDRESS));
   CopyMem (&Udp4Session.DestinationAddress, &NetSession->Dest, sizeof (EFI_IPv4_ADDRESS));

--- a/NetworkPkg/Udp4Dxe/Udp4Main.c
+++ b/NetworkPkg/Udp4Dxe/Udp4Main.c
@@ -563,7 +563,11 @@ Udp4Transmit (
   *((UINTN *)&Packet->ProtoData[0]) = (UINTN)(Udp4Service->IpIo);
 
   Udp4Header = (EFI_UDP_HEADER *)NetbufAllocSpace (Packet, UDP4_HEADER_SIZE, TRUE);
-  ASSERT (Udp4Header != NULL);
+  if (Udp4Header == NULL) {
+    ASSERT (Udp4Header != NULL);
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ON_EXIT;
+  }
 
   ConfigData = &Instance->ConfigData;
 


### PR DESCRIPTION
# Description
CodeQL static analysis reports potential NULL pointer dereferences and unchecked return values across several network components. DNS, MNP, UDP, VLAN, TLS authentication, and configuration paths rely on ASSERT() or implicit assumptions before using packet data, transaction state, or allocated objects. These assumptions do not protect release builds.

Validate VConfig option arguments and abort DNS response processing when required transaction entries are unavailable. Check MNP and UDP packet buffers and headers before use, return appropriate errors, and free UDP packets on failure paths. Handle TLS authentication and VLAN HII allocation failures, including cleanup of partially allocated request data, and skip form entries when string creation fails.

These checks prevent NULL pointer dereferences and invalid buffer accesses, preserve cleanup on failure, and resolve the related CodeQL static scanning failures.


- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
Local CI and Shipping in platforms for a few years.

## Integration Instructions
No integration necessary