### PR TITLE
OvmfPkg/BaseMemEncryptSevLib: Fix read-only pagetable support

### DIFF
--- a/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
+++ b/OvmfPkg/Library/BaseMemEncryptSevLib/X64/PeiDxeVirtualMemory.c
@@ -730,11 +730,6 @@ SetMemoryEncDec (
   UINTN                           OrigLength;
   RETURN_STATUS                   Status;
 
-  //
-  // Set PageMapLevel4Entry to suppress incorrect compiler/analyzer warnings.
-  //
-  PageMapLevel4Entry = NULL;
-
   DEBUG ((
     DEBUG_PAGING,
     "%a:%a: Cr3Base=0x%Lx Physical=0x%Lx Length=0x%Lx Mode=%a CacheFlush=%u Mmio=%u\n",
@@ -809,14 +804,14 @@ SetMemoryEncDec (
   OrigLength          = Length;
   OrigPhysicalAddress = PhysicalAddress;
 
-  while (Length != 0) {
-    //
-    // If Cr3BaseAddress is not specified then read the current CR3
-    //
-    if (Cr3BaseAddress == 0) {
-      Cr3BaseAddress = AsmReadCr3 ();
-    }
+  //
+  // If Cr3BaseAddress is not specified then read the current CR3
+  //
+  if (Cr3BaseAddress == 0) {
+    Cr3BaseAddress = AsmReadCr3 ();
+  }
 
+  while (Length != 0) {
     PageMapLevel4Entry  = (VOID *)(Cr3BaseAddress & ~PgTableMask);
     PageMapLevel4Entry += PML4_OFFSET (PhysicalAddress);
     if (!PageMapLevel4Entry->Bits.Present) {
@@ -974,7 +969,7 @@ SetMemoryEncDec (
   // read-only.
   //
   if (IsWpEnabled) {
-    EnablePageTableProtection ((UINTN)PageMapLevel4Entry, TRUE);
+    EnablePageTableProtection ((UINTN)(Cr3BaseAddress & ~PgTableMask), TRUE);
   }
 
   //


### PR DESCRIPTION
# Description

SetMemoryEncDec() ensures that any newly created pagetable pages are marked read-only upon completion of the pagetable changes. This is done by calling EnablePageTableProtection(). EnablePageTableProtection() invokes SetPageTablePoolReadOnly() which expects the input PageTableBase parameter to point to the beginning of the level 4 pagetable as it calculates the offset/index into the pagetable based on the input address.

However, there is a bug that is seen when the input address is above 512GB. SetMemoryEncDec() uses the PageMapLevel4Entry variable when it invokes EnablePageTableProtection(), which points to the start of the level 4 pagetable if the address is below 512GB. Once above that range, PageMapLevel4Entry points past the start of the pagetable. This causes SetPageTablePoolReadOnly() to improperly address pagetable entries.

This was recently exposed when 7735ed4f8eb3 ("OvmfPkg/PlatformInitLib: Set dynamic MMIO window size to 1/4") pushed the MMIO range above 512GB.

Fix the issue by always using the Cr3BaseAddress value when calling EnablePageTableProtection().

Since PageMapLevel4Entry is never used outside of the loop anymore, remove the initialization to NULL. Also, the check for Cr3BaseAddress being NULL does not need to be done inside the loop, so move it to outside the loop (which will suppress incorrect compiler/analyzer warnings).

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
  - If checked, follow the [Breaking Change and Release Process](https://raw.githubusercontent.com/tianocore/tianocore-wiki.github.io/refs/heads/main/rfc/text/0003-edk2-breaking-change-and-release-process.md).
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

Booted with a specific failing configuration before and after applying the fix. Before applying the fix, the boot failed. After applying the fix the boot succeeded.

## Integration Instructions

N/A
