### PR TITLE
MdePkg/CompilerIntrinsicsLib: Fix IA32 with VS202x

### DIFF
--- a/MdePkg/Library/CompilerIntrinsicsLib/memcmp_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memcmp_ms.c
@@ -7,7 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-typedef unsigned __int64 size_t;
+typedef UINTN size_t;
 
 int
 memcmp (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memcpy_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memcpy_ms.c
@@ -7,7 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-typedef unsigned __int64 size_t;
+typedef UINTN size_t;
 
 void *
 memcpy (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memmove_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memmove_ms.c
@@ -7,7 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-typedef unsigned __int64 size_t;
+typedef UINTN size_t;
 
 void *
 memmove (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memset_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memset_ms.c
@@ -7,7 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-typedef unsigned __int64 size_t;
+typedef UINTN size_t;
 
 void *
 memset (

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -63,7 +63,8 @@
             "8002", "aligned (",
             "4002", "_ReturnAddress",
             "8005", "__security_cookie",
-            "8006", "__stack_chk_fail"
+            "8006", "__stack_chk_fail",
+            "8002", "size_t"
         ],
         ## Both file path and directory path are accepted.
         "IgnoreFiles": [

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -163,6 +163,7 @@
   MdePkg/Library/BaseRngLib/BaseRngLib.inf
 
 [Components.IA32, Components.X64]
+  MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
   MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   MdePkg/Library/BaseMemoryLibMmx/BaseMemoryLibMmx.inf


### PR DESCRIPTION


# Description
CompilerIntrinsicsLib is causing a #UD when used in IA32 mode.

This was tracked back to memcpy using size_t, which locally defined in the file as __int64. When compiling for IA32 target, this results in the memcpy interpreting 64 bits from the calling convention instead of the 32 bits that were passed.

Update the local size_t defines to use UINTN. This matches the functionality from CryptoPkg's Intrinsic functions.

Add CompilerIntrinsics to IA32/X64 component so it is complied as part of CI.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested
IA32 compiled binary which consumed CompilerIntrinsicsLib, was resulitng in #UD when executing a memcpy
intrinsic function. This was tracked back to the memcpy interpreting 64 bits from the stack as the size, instead 
of the 32 bits that were passed. The very large memory copy overwrote existing code in memory.

Once this fix was applied, the binary was able to execute successfully, and manual examination of the code was correct. 

## Integration Instructions
No integration necessary. 