### PR TITLE
EmulatorPkg: missing UEFI_APPLICATION in LIBRARY_CLASSES

### DIFF
--- a/EmulatorPkg/Library/DxeEmuLib/DxeEmuLib.inf
+++ b/EmulatorPkg/Library/DxeEmuLib/DxeEmuLib.inf
@@ -17,7 +17,7 @@
   FILE_GUID                      = 31479AFD-B06F-4E4A-863B-A8F7E7710778
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = EmuThunkLib|DXE_CORE DXE_RUNTIME_DRIVER DXE_DRIVER UEFI_DRIVER
+  LIBRARY_CLASS                  = EmuThunkLib|DXE_CORE DXE_RUNTIME_DRIVER DXE_DRIVER UEFI_DRIVER UEFI_APPLICATION
   CONSTRUCTOR                    = DxeEmuLibConstructor
 
 

--- a/EmulatorPkg/Library/DxeEmuPeCoffExtraActionLib/DxeEmuPeCoffExtraActionLib.inf
+++ b/EmulatorPkg/Library/DxeEmuPeCoffExtraActionLib/DxeEmuPeCoffExtraActionLib.inf
@@ -15,7 +15,7 @@
   FILE_GUID                      = 68FCD487-D230-6846-95B1-5E1F2EF942C4
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = PeCoffExtraActionLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_DRIVER
+  LIBRARY_CLASS                  = PeCoffExtraActionLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_DRIVER UEFI_APPLICATION
 
   CONSTRUCTOR                    = DxeEmuPeCoffLibExtraActionConstructor
 


### PR DESCRIPTION
# Description

`DxeEmuLib` and `DxeEmuPeCoffExtraActionLib` declare a `LIBRARY_CLASS` module type list that
omits `UEFI_APPLICATION`, even though `EmulatorPkg.dsc` maps both of them in a
`[LibraryClasses]` section that explicitly includes `UEFI_APPLICATION`. Any `UEFI_APPLICATION` that consumes one of these libraries therefore fails to build.

Fixes:

- Add `UEFI_APPLICATION` to `LIBRARY_CLASS` in `DxeEmuLib.inf`.
- Add `UEFI_APPLICATION` to `LIBRARY_CLASS` in `DxeEmuPeCoffExtraActionLib.inf`.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- Built a UEFI_APPLICATION that consumes EmuThunkLib against current master; observed the build failure.
- Applied DxeEmuLib fix; observed the same build succeed.
- Reverted DxeEmuLib fix and confirmed the failure reproduces
- Applied both fixes; built an EmulatorPkg-based platform (VS2026, X64, DEBUG); build succeeds.

## Integration Instructions

N/A
