### PR TITLE
EmulatorPkg: Fix markdownlint violations and enable the check

### DIFF
--- a/EmulatorPkg/EmulatorPkg.ci.yaml
+++ b/EmulatorPkg/EmulatorPkg.ci.yaml
@@ -111,7 +111,7 @@
 
     ## options defined .pytool/Plugin/MarkdownLintCheck
     "MarkdownLintCheck": {
-        "AuditOnly": True,           # If True, log all errors and then mark as skipped
+        "AuditOnly": False,          # If True, log all errors and then mark as skipped
         "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/EmulatorPkg/PlatformCI/ReadMe.md
+++ b/EmulatorPkg/PlatformCI/ReadMe.md
@@ -1,20 +1,19 @@
 # EmulatorPkg - Platform CI
 
-This ReadMe.md describes the Azure DevOps based Platform CI for EmulatorPkg and how
-to use the same Pytools based build infrastructure locally.
+This ReadMe.md describes the Azure DevOps based Platform CI for EmulatorPkg and how to use the same Pytools based build
+infrastructure locally.
 
 ## Supported Configuration Details
 
-This solution for building and running EmulatorPkg has only been validated with Windows 10
-with VS2026 and Ubuntu 18.04 with GCC toolchain. Four different firmware builds are
-supported and are described below.
+This solution for building and running EmulatorPkg has only been validated with Windows 10 with VS2026 and Ubuntu 18.04
+with GCC toolchain. Four different firmware builds are supported and are described below.
 
-| Configuration name      | Architectures      | DSC File         |Additional Flags |
-| :----                   | :-----             | :----            | :----           |
-| IA32                    | IA32               | EmulatorPkg.dsc  | None            |
-| X64                     | X64                | EmulatorPkg.dsc  | None            |
-| IA32 Full               | IA32               | EmulatorPkg.dsc  | SECURE_BOOT_ENABLE=TRUE |
-| X64 Full                | X64                | EmulatorPkg.dsc  | SECURE_BOOT_ENABLE=TRUE |
+| Configuration name | Architectures | DSC File        | Additional Flags        |
+| :----------------- | :------------ | :-------------- | :---------------------- |
+| IA32               | IA32          | EmulatorPkg.dsc | None                    |
+| X64                | X64           | EmulatorPkg.dsc | None                    |
+| IA32 Full          | IA32          | EmulatorPkg.dsc | SECURE_BOOT_ENABLE=TRUE |
+| X64 Full           | X64           | EmulatorPkg.dsc | SECURE_BOOT_ENABLE=TRUE |
 
 ## EDK2 Developer environment
 
@@ -24,107 +23,104 @@ supported and are described below.
 - [Edk2 Source](https://github.com/tianocore/edk2)
 - For building Basetools and other host applications
 
-  ``` bash
+  ```bash
   sudo apt-get update
   sudo apt-get install gcc g++ make uuid-dev
   ```
 
 - For building ARCH IA32 on X64 Ubuntu 18.04 LTS these steps where needed.
 
-  ``` bash
+  ```bash
   sudo dpkg --add-architecture i386
   sudo apt-get update
   sudo apt-get install libc6-dev:i386 libx11-dev:i386 libxext-dev:i386 lib32gcc-7-dev
   ```
 
-Note: edksetup, Submodule initialization and manual installation of NASM, iASL, or
-the required cross-compiler toolchains are **not** required, this is handled by the
-Pytools build system.
+Note: edksetup, Submodule initialization and manual installation of NASM, iASL, or the required cross-compiler
+toolchains are **not** required, this is handled by the Pytools build system.
 
 ## Building with Pytools for EmulatorPkg
 
-If you are unfamiliar with Pytools, it is recommended to first read through
-the generic set of edk2 [Build Instructions](https://github.com/tianocore/tianocore.github.io/wiki/Build-Instructions).
+If you are unfamiliar with Pytools, it is recommended to first read through the generic set of edk2
+[Build Instructions](https://github.com/tianocore/tianocore.github.io/wiki/Build-Instructions).
 
 1. [Optional] Create a Python Virtual Environment - generally once per workspace
 
-    ``` bash
-    python -m venv <name of virtual environment>
-    ```
+   ```bash
+   python -m venv <name of virtual environment>
+   ```
 
 2. [Optional] Activate Virtual Environment - each time new shell opened
-    - Linux
+   - Linux
 
-      ```bash
-      source <name of virtual environment>/bin/activate
-      ```
+     ```bash
+     source <name of virtual environment>/bin/activate
+     ```
 
-    - Windows
+   - Windows
 
-      ``` bash
-      <name of virtual environment>/Scripts/activate.bat
-      ```
+     ```bash
+     <name of virtual environment>/Scripts/activate.bat
+     ```
 
 3. Install Pytools - generally once per virtual env or whenever pip-requirements.txt changes
 
-    ``` bash
-    pip install --upgrade -r pip-requirements.txt
-    ```
+   ```bash
+   pip install --upgrade -r pip-requirements.txt
+   ```
 
 4. Initialize & Update Submodules - only when submodules updated
 
-    ``` bash
-    stuart_setup -c EmulatorPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=<TOOL_CHAIN_TAG> -a <TARGET_ARCH>
-    ```
+   ```bash
+   stuart_setup -c EmulatorPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=<TOOL_CHAIN_TAG> -a <TARGET_ARCH>
+   ```
 
 5. Initialize & Update Dependencies - only as needed when ext_deps change
 
-    ``` bash
-    stuart_update -c EmulatorPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=<TOOL_CHAIN_TAG> -a <TARGET_ARCH>
-    ```
+   ```bash
+   stuart_update -c EmulatorPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=<TOOL_CHAIN_TAG> -a <TARGET_ARCH>
+   ```
 
 6. Compile the basetools if necessary - only when basetools C source files change
 
-    ``` bash
-    python BaseTools/Edk2ToolsBuild.py -t <ToolChainTag>
-    ```
+   ```bash
+   python BaseTools/Edk2ToolsBuild.py -t <ToolChainTag>
+   ```
 
 7. Compile Firmware
 
-    ``` bash
-    stuart_build -c EmulatorPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=<TOOL_CHAIN_TAG> -a <TARGET_ARCH>
-    ```
+   ```bash
+   stuart_build -c EmulatorPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=<TOOL_CHAIN_TAG> -a <TARGET_ARCH>
+   ```
 
-    - use `stuart_build -c EmulatorPkg/PlatformCI/PlatformBuild.py -h` option to see additional
-    options like `--clean`
+   - use `stuart_build -c EmulatorPkg/PlatformCI/PlatformBuild.py -h` option to see additional options like `--clean`
 
 8. Running Emulator
-    - You can add `--FlashRom` to the end of your build command and the emulator will run after the
-    build is complete.
-    - or use the `--FlashOnly` feature to just run the emulator.
+   - You can add `--FlashRom` to the end of your build command and the emulator will run after the build is complete.
+   - or use the `--FlashOnly` feature to just run the emulator.
 
-      ``` bash
-      stuart_build -c EmulatorPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=<TOOL_CHAIN_TAG> -a <TARGET_ARCH> --FlashOnly
-      ```
+     ```bash
+     stuart_build -c EmulatorPkg/PlatformCI/PlatformBuild.py TOOL_CHAIN_TAG=<TOOL_CHAIN_TAG> -a <TARGET_ARCH> --FlashOnly
+     ```
 
 ### Notes
 
-1. Configuring *ACTIVE_PLATFORM* and *TARGET_ARCH* in Conf/target.txt is **not** required. This
-   environment is set by PlatformBuild.py based upon the `[-a <TARGET_ARCH>]` parameter.
+1. Configuring _ACTIVE_PLATFORM_ and _TARGET_ARCH_ in Conf/target.txt is **not** required. This environment is set by
+   PlatformBuild.py based upon the `[-a <TARGET_ARCH>]` parameter.
 
 **NOTE:** Logging the execution output will be in the normal stuart log as well as to your console.
 
 ### Custom Build Options
 
-**MAKE_STARTUP_NSH=TRUE** will output a *startup.nsh* file to the location mapped as fs0. This is
-used in CI in combination with the `--FlashOnly` feature to run the Emulator to the UEFI shell and then execute
-the contents of *startup.nsh*.
+**MAKE_STARTUP_NSH=TRUE** will output a _startup.nsh_ file to the location mapped as fs0. This is used in CI in
+combination with the `--FlashOnly` feature to run the Emulator to the UEFI shell and then execute the contents of
+_startup.nsh_.
 
 ### Passing Build Defines
 
-To pass build defines through _stuart_build_, prepend `BLD_*_`to the define name and pass it on the
-command-line. _stuart_build_ currently requires values to be assigned, so add an`=1` suffix for bare defines.
-For example, to enable the IP6 Network Stack, the stuart_build command-line would be:
+To pass build defines through _stuart_build_, prepend `BLD_*_`to the define name and pass it on the command-line.
+_stuart_build_ currently requires values to be assigned, so add an`=1` suffix for bare defines. For example, to enable
+the IP6 Network Stack, the stuart_build command-line would be:
 
 `stuart_build -c EmulatorPkg/PlatformCI/PlatformBuild.py BLD_*_NETWORK_IP6_ENABLE=1`
 

--- a/EmulatorPkg/Readme.md
+++ b/EmulatorPkg/Readme.md
@@ -1,56 +1,60 @@
+# EmulatorPkg Readme
+
 ## Overview
 
-EmulatorPkg provides an environment where a UEFI environment can be
-emulated under an environment where a full UEFI compatible
-environment is not possible.  (For example, running under an OS
-where an OS process hosts the UEFI emulation environment.)
+EmulatorPkg provides an environment where a UEFI environment can be emulated under an environment where a full UEFI
+compatible environment is not possible. (For example, running under an OS where an OS process hosts the UEFI emulation
+environment.)
 
-https://github.com/tianocore/tianocore.github.io/wiki/EmulatorPkg
+<https://github.com/tianocore/tianocore.github.io/wiki/EmulatorPkg>
 
 ## Status
 
-* Builds and runs under
-  *  a posix-like environment with X windows
-      - Linux
-      - OS X
-  *  Windows environment
-      - Win10 (verified)
-      - Win8 (not verified)
+- Builds and runs under
+  - a posix-like environment with X windows
+    - Linux
+    - OS X
+  - Windows environment
+    - Win10 (verified)
+    - Win8 (not verified)
 
 ## How to Build & Run
+
 **You can use the following command to build.**
-  * 32bit emulator in Windows:
 
-    `build -p EmulatorPkg\EmulatorPkg.dsc -t VS2026 -a IA32`
+- 32bit emulator in Windows:
 
-  * 64bit emulator in Windows:
+  `build -p EmulatorPkg\EmulatorPkg.dsc -t VS2026 -a IA32`
 
-    `build -p EmulatorPkg\EmulatorPkg.dsc -t VS2026 -a X64`
+- 64bit emulator in Windows:
 
-  * 32bit emulator in Linux:
+  `build -p EmulatorPkg\EmulatorPkg.dsc -t VS2026 -a X64`
 
-    `build -p EmulatorPkg\EmulatorPkg.dsc -t GCC -a IA32`
+- 32bit emulator in Linux:
 
-  * 64bit emulator in Linux:
+  `build -p EmulatorPkg\EmulatorPkg.dsc -t GCC -a IA32`
 
-    `build -p EmulatorPkg\EmulatorPkg.dsc -t GCC -a X64`
+- 64bit emulator in Linux:
+
+  `build -p EmulatorPkg\EmulatorPkg.dsc -t GCC -a X64`
 
 **You can start/run the emulator using the following command:**
-  * 32bit emulator in Windows:
 
-    `cd Build\EmulatorIA32\DEBUG_VS2026\IA32\ && WinHost.exe`
+- 32bit emulator in Windows:
 
-  * 64bit emulator in Windows:
+  `cd Build\EmulatorIA32\DEBUG_VS2026\IA32\ && WinHost.exe`
 
-    `cd Build\EmulatorX64\DEBUG_VS2026\X64\ && WinHost.exe`
+- 64bit emulator in Windows:
 
-  * 32bit emulator in Linux:
+  `cd Build\EmulatorX64\DEBUG_VS2026\X64\ && WinHost.exe`
 
-    `cd Build/EmulatorIA32/DEBUG_GCC/IA32/ && ./Host`
+- 32bit emulator in Linux:
 
-  * 64bit emulator in Linux:
+  `cd Build/EmulatorIA32/DEBUG_GCC/IA32/ && ./Host`
 
-    `cd Build/EmulatorX64/DEBUG_GCC/X64/ && ./Host`
+- 64bit emulator in Linux:
+
+  `cd Build/EmulatorX64/DEBUG_GCC/X64/ && ./Host`
 
 **On posix-like environment with the bash shell you can use EmulatorPkg/build.sh to simplify building and running
 emulator.**
@@ -58,6 +62,7 @@ emulator.**
 For example, to build + run:
 
 `$ EmulatorPkg/build.sh`
+
 `$ EmulatorPkg/build.sh run`
 
 The build architecture will match your host machine's architecture.
@@ -65,4 +70,5 @@ The build architecture will match your host machine's architecture.
 On X64 host machines, you can build + run IA32 mode as well:
 
 `$ EmulatorPkg/build.sh -a IA32`
+
 `$ EmulatorPkg/build.sh -a IA32 run`


### PR DESCRIPTION
# Description

Fixes markdown formatting issues reported by the markdownlint plugin and enables the check in EmulatorPkg.ci.yaml.

No substantial content changes are made other than modifying text where necessary to fix the markdownlint violations.

The markdown files currently contain quite a bit of stale information. That will be updated in a future comit.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

- `stuart_ci_build -c .pytool/CISettings.py -p EmulatorPkg -t NO-TARGET` (runs the markdownlint plugin)

## Integration Instructions

- N/A