### PR TITLE
Mdepkg printlib ucs-2 truncation

### DIFF
--- a/MdePkg/Include/Library/PrintLib.h
+++ b/MdePkg/Include/Library/PrintLib.h
@@ -70,7 +70,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
       - Print a %%.
     - c
       - The argument is a Unicode character.  ASCII characters can be printed
-        using this type too by making sure bits 8..15 of the argument are set to 0.
+        using this type too by making sure bits 7..15 of the argument are set to 0.
     - x
       - The argument is an unsigned hexadecimal number.  The characters used are 0..9 and
         A..F.  If the flag 'L' is not specified, then the argument is assumed


### PR DESCRIPTION
=========== RFC ============

~~OVMF receives input from the QEMU command line (via `-append`) which is injected into the loaded image protocol's load options field, which the Linux kernel interprets as UCS-2 and converts to UTF-8 for consumption by the kernel proper as the kernel command line.~~

~~BasePrintLib currently ignores any encodings of narrow strings entirely, and simply widens each character to a 16-bit value when constructing a wide string from a narrow input (using the `%a` conversion). This produces garbage for any character outside of the 7-bit ASCII range.~~

~~Add a `%la` variant of the narrow string conversion to support this use case. Tested with OVMF + QEMU + Linux, passing accented Latin characters via `-append`~~

Avoid creating garbage ASCII/Latin-1 from UCS-2 characters >= U+0100